### PR TITLE
clarify some setup needed to make npm install work

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,17 @@ Environment setup
 3) [Install NodeJS Package Manager (npm)](https://nodejs.org/en/download/package-manager/)
     * For example, on Debian-based systems, use `sudo apt-get install npm`
 
-3) [Install Bower using NPM](http://bower.io/#install-bower)
-    * For example, on Debian-based systems, use `sudo npm install -g bower`
+4) Update NPM to npm's version of NPM because the version you got through your package manager [may cause you problems](https://github.com/nodejs/nan/issues/414):
 
-4) Install the Javascript UI libraries, using `npm`
+    sudo npm install -g npm
+
+5) Install some installation dependencies using `npm`:
+
+    sudo npm install -g bower
+    sudo npm install -g typings
+    sudo npm install -g typescript
+
+6) Install the Javascript UI libraries, using `npm`:
 
     cd windup-web/ui
     npm install
@@ -31,8 +38,8 @@ Environment setup
     sudo npm install -g patternfly # JBoss PatternFly, a UI components library
     sudo npm install -g grunt-cli  # Grunt
     sudo npm install -g tsc        # TypeScript compiler
-    sudo npm install -g typescript # TypeScript
-    
-    This list is not complete, feel free to add the missing items.
-  
+   
+   This list is not complete, feel free to add the missing items.
+
+7) You'll know you have everything you need when you can build the parent project: `mvn clean install`
  


### PR DESCRIPTION
In particular:
-- `npm install -g npm` to be sure you have a good version of NPM before trying to install anything else with NPM
-- typings needs to be installed before windup-web/ui can be installed, and typescript also needs to be installed separately before you can build with mvn