### PR TITLE
Added a bridge to enable communication from the Furnace environment to the CDI environment in the webapp, without duplicated producer methods.

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/WebPathUtil.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/WebPathUtil.java
@@ -1,11 +1,6 @@
 package org.jboss.windup.web.addons.websupport;
 
-import org.apache.commons.lang.StringUtils;
-
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 /**
  * Gets global paths (for example a global shared data directory).

--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/WindupWebServiceFactory.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/WindupWebServiceFactory.java
@@ -6,7 +6,8 @@ import org.jboss.windup.web.addons.websupport.service.RegisteredApplicationServi
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
-public interface WindupWebServiceFactory {
+public interface WindupWebServiceFactory
+{
     RegisteredApplicationService getRegisteredApplicationService();
 
     GraphContext getGlobalGraphContext();

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/WindupWebServiceFactoryImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/WindupWebServiceFactoryImpl.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import org.jboss.windup.graph.GraphContext;
@@ -29,6 +30,7 @@ public class WindupWebServiceFactoryImpl implements WindupWebServiceFactory
 
     private GraphContext graphContext;
 
+    @Produces
     public RegisteredApplicationService getRegisteredApplicationService()
     {
         return new RegisteredApplicationServiceImpl(getGlobalGraphContext(), webPathUtil);

--- a/furnace-service-provider/pom.xml
+++ b/furnace-service-provider/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.windup.web</groupId>
+        <artifactId>windup-web-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>furnace-service-provider</artifactId>
+    <name>Windup Web - Bridge from Furnace to Web App CDI</name>
+
+    <dependencies>
+
+        <!-- Furnace Container -->
+        <dependency>
+            <groupId>org.jboss.forge.furnace</groupId>
+            <artifactId>furnace</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.forge.furnace</groupId>
+            <artifactId>furnace-se</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.forge.furnace.container</groupId>
+            <artifactId>cdi</artifactId>
+            <classifier>forge-addon</classifier>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Servlet -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <version>1.0.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FromFurnace.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FromFurnace.java
@@ -1,0 +1,17 @@
+package org.jboss.windup.web.furnaceserviceprovider;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})
+public @interface FromFurnace
+{
+}

--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FurnaceExtension.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FurnaceExtension.java
@@ -1,0 +1,392 @@
+package org.jboss.windup.web.furnaceserviceprovider;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.util.AnnotationLiteral;
+
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.addons.Addon;
+import org.jboss.forge.furnace.addons.AddonStatus;
+
+/**
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+public class FurnaceExtension implements Extension
+{
+    private static Logger LOG = Logger.getLogger(FurnaceExtension.class.getName());
+
+    public static final String WINDUP_WEB_SUPPORT = "windup-web-support";
+    public static final String PACKAGE_PREFIX = "org.jboss.windup.web";
+
+    private FurnaceProducer furnaceProducer;
+
+    private FurnaceProducer getFurnaceProducer()
+    {
+        if (furnaceProducer == null)
+        {
+            synchronized (FurnaceExtension.class)
+            {
+                FurnaceProducer furnaceProducer = new FurnaceProducer();
+                furnaceProducer.setup(WebProperties.getInstance().getAddonRepository());
+                this.furnaceProducer = furnaceProducer;
+            }
+        }
+        return furnaceProducer;
+    }
+
+    public void afterBeanDiscovery(@Observes AfterBeanDiscovery abd, BeanManager beanManager)
+    {
+        FurnaceProducer furnaceProducer = getFurnaceProducer();
+        addFurnace(abd, beanManager, furnaceProducer);
+
+        HashSet<String> duplicateCheck = new HashSet<>();
+        for (Addon addon : furnaceProducer.getFurnace().getAddonRegistry().getAddons())
+        {
+            if (addon.getId() != null && addon.getStatus() == AddonStatus.STARTED && addon.getId().toString().contains(WINDUP_WEB_SUPPORT))
+            {
+                for (Class<?> exportedType : addon.getServiceRegistry().getExportedTypes())
+                {
+                    addService(duplicateCheck, abd, beanManager, exportedType);
+                }
+            }
+        }
+    }
+
+    private <T> void addService(final Set<String> duplicateCheck, final AfterBeanDiscovery abd, final BeanManager beanManager, final Class<T> incomingType)
+    {
+        final FurnaceProducer furnaceProducer = getFurnaceProducer();
+        if (incomingType.getPackage() == null || !incomingType.getPackage().getName().startsWith(PACKAGE_PREFIX))
+            return;
+
+        if (duplicateCheck.contains(incomingType.getCanonicalName()))
+            return;
+
+        duplicateCheck.add(incomingType.getCanonicalName());
+
+        final Class<T> type;
+        boolean registerWithWeld = true;
+
+        // Try to make sure that we are using the one from the local classloader instead of a Furnace addon classloader
+        if (incomingType.getClassLoader().equals(FurnaceExtension.class.getClassLoader()))
+        {
+            type = incomingType;
+        }
+        else
+        {
+            Class<?> localType = incomingType;
+            try
+            {
+                localType = getClass().getClassLoader().loadClass(incomingType.getCanonicalName());
+            }
+            catch (Throwable t)
+            {
+                LOG.fine("Failed to load: " + incomingType.getCanonicalName() + " due to: " + t.getMessage());
+                registerWithWeld = false;
+            }
+            type = (Class<T>)localType;
+        }
+
+        if (registerWithWeld)
+        {
+            LOG.info("Registering type: " + type.getCanonicalName() + " Package: " + type.getPackage().getName());
+            try
+            {
+                final InjectionTarget<T> it = new InjectionTarget<T>()
+                {
+                    @Override
+                    public void inject(T instance, CreationalContext<T> ctx)
+                    {
+                    }
+
+                    @Override
+                    public void postConstruct(Object instance)
+                    {
+
+                    }
+
+                    @Override
+                    public void preDestroy(Object instance)
+                    {
+
+                    }
+
+                    @Override
+                    public T produce(CreationalContext<T> ctx)
+                    {
+                        T object = furnaceProducer.getFurnace().getAddonRegistry().getServices(type).get();
+                        return object;
+                    }
+
+                    @Override
+                    public void dispose(Object instance)
+                    {
+                    }
+
+                    @Override
+                    public Set<InjectionPoint> getInjectionPoints()
+                    {
+                        return Collections.emptySet();
+                    }
+
+                    @Override
+                    public String toString()
+                    {
+                        return "InjectionTarget: " + type.getCanonicalName();
+                    }
+                };
+
+                abd.addBean(new Bean<T>()
+                {
+                    @Override
+                    public Class<?> getBeanClass()
+                    {
+                        return type;
+                    }
+
+                    @Override
+                    public Set<InjectionPoint> getInjectionPoints()
+                    {
+                        return it.getInjectionPoints();
+                    }
+
+                    @Override
+                    public boolean isNullable()
+                    {
+                        return false;
+                    }
+
+                    @Override
+                    public Set<Type> getTypes()
+                    {
+                        return Collections.singleton(type);
+                    }
+
+                    @Override
+                    public Set<Annotation> getQualifiers()
+                    {
+                        Set<Annotation> qualifiers = new HashSet<>();
+                        qualifiers.add(new AnnotationLiteral<FromFurnace>(){});
+                        return qualifiers;
+                    }
+
+                    @Override
+                    public Class<? extends Annotation> getScope()
+                    {
+                        return ApplicationScoped.class;
+                    }
+
+                    @Override
+                    public String getName()
+                    {
+                        String name = type.getSimpleName();
+                        return name.substring(0, 1).toLowerCase() + name.substring(1);
+                    }
+
+                    @Override
+                    public Set<Class<? extends Annotation>> getStereotypes()
+                    {
+                        return Collections.emptySet();
+                    }
+
+                    @Override
+                    public boolean isAlternative()
+                    {
+                        return false;
+                    }
+
+                    @Override
+                    public T create(CreationalContext<T> creationalContext)
+                    {
+                        T instance = it.produce(creationalContext);
+                        it.inject(instance, creationalContext);
+                        it.postConstruct(instance);
+                        return instance;
+                    }
+
+                    @Override
+                    public void destroy(T instance, CreationalContext<T> creationalContext)
+                    {
+                        it.preDestroy(instance);
+                        it.dispose(instance);
+                        creationalContext.release();
+                    }
+
+                    @Override
+                    public String toString()
+                    {
+                        return "Bean: type = " + type.getCanonicalName();
+                    }
+                });
+            }
+            catch (Throwable t)
+            {
+                t.printStackTrace();
+            }
+        }
+
+        if (type.getInterfaces() != null)
+        {
+            for (Class<?> iface : type.getInterfaces())
+            {
+                addService(duplicateCheck, abd, beanManager, iface);
+            }
+        }
+    }
+
+    private void addFurnace(AfterBeanDiscovery abd, BeanManager beanManager, FurnaceProducer furnaceProducer)
+    {
+        try
+        {
+            final InjectionTarget<Furnace> it = new InjectionTarget<Furnace>()
+            {
+                @Override
+                public void inject(Furnace instance, CreationalContext<Furnace> ctx)
+                {
+                }
+
+                @Override
+                public void postConstruct(Furnace instance)
+                {
+
+                }
+
+                @Override
+                public void preDestroy(Furnace instance)
+                {
+
+                }
+
+                @Override
+                public Furnace produce(CreationalContext<Furnace> ctx)
+                {
+                    return furnaceProducer.getFurnace();
+                }
+
+                @Override
+                public void dispose(Furnace instance)
+                {
+                    furnaceProducer.destroy(beanManager);
+                }
+
+                @Override
+                public Set<InjectionPoint> getInjectionPoints()
+                {
+                    return Collections.emptySet();
+                }
+
+                @Override
+                public String toString()
+                {
+                    return "FurnaceInjectionTarget";
+                }
+            };
+
+            abd.addBean(new Bean<Furnace>()
+            {
+                @Override
+                public Class<?> getBeanClass()
+                {
+                    return Furnace.class;
+                }
+
+                @Override
+                public Set<InjectionPoint> getInjectionPoints()
+                {
+                    return it.getInjectionPoints();
+                }
+
+                @Override
+                public boolean isNullable()
+                {
+                    return false;
+                }
+
+                @Override
+                public Set<Type> getTypes()
+                {
+                    return Collections.singleton(Furnace.class);
+                }
+
+                @Override
+                public Set<Annotation> getQualifiers()
+                {
+                    Set<Annotation> qualifiers = new HashSet<>();
+                    qualifiers.add(new AnnotationLiteral<Default>()
+                    {
+                    });
+                    qualifiers.add(new AnnotationLiteral<Any>()
+                    {
+                    });
+                    return qualifiers;
+                }
+
+                @Override
+                public Class<? extends Annotation> getScope()
+                {
+                    return ApplicationScoped.class;
+                }
+
+                @Override
+                public String getName()
+                {
+                    return "furnace";
+                }
+
+                @Override
+                public Set<Class<? extends Annotation>> getStereotypes()
+                {
+                    return Collections.emptySet();
+                }
+
+                @Override
+                public boolean isAlternative()
+                {
+                    return false;
+                }
+
+                @Override
+                public Furnace create(CreationalContext<Furnace> creationalContext)
+                {
+                    Furnace instance = it.produce(creationalContext);
+                    it.inject(instance, creationalContext);
+                    it.postConstruct(instance);
+                    return instance;
+                }
+
+                @Override
+                public void destroy(Furnace instance, CreationalContext<Furnace> creationalContext)
+                {
+                    it.preDestroy(instance);
+                    it.dispose(instance);
+                    creationalContext.release();
+                }
+
+                @Override
+                public String toString()
+                {
+                    return "FurnaceBean";
+                }
+            });
+        }
+        catch (Throwable t)
+        {
+            t.printStackTrace();
+        }
+    }
+}

--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FurnaceProducer.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FurnaceProducer.java
@@ -3,6 +3,7 @@ package org.jboss.windup.web.furnaceserviceprovider;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.logging.Logger;
 
 import javax.enterprise.inject.spi.BeanManager;
 
@@ -14,6 +15,8 @@ import org.jboss.forge.furnace.spi.ContainerLifecycleListener;
 
 public class FurnaceProducer
 {
+    private static Logger LOG = Logger.getLogger(FurnaceProducer.class.getName());
+
     private Furnace furnace;
 
     public Furnace getFurnace()
@@ -23,7 +26,7 @@ public class FurnaceProducer
 
     public void setup(Path repoDir)
     {
-        System.out.println("Starting with repo: " + repoDir);
+        LOG.info("Starting with repo: " + repoDir);
         Furnace furnace = FurnaceFactory.getInstance(Thread.currentThread()
                     .getContextClassLoader(), Thread.currentThread()
                                 .getContextClassLoader());
@@ -44,7 +47,7 @@ public class FurnaceProducer
 
     public void destroy(BeanManager beanManager)
     {
-        System.out.println("Shutting down forge!");
+        LOG.info("Shutting down furnace!");
         beanManager.fireEvent(new FurnaceShutdownEvent());
 
         if (furnace != null)

--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FurnaceShutdownEvent.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/FurnaceShutdownEvent.java
@@ -1,4 +1,4 @@
-package org.jboss.windup.web.services.producer;
+package org.jboss.windup.web.furnaceserviceprovider;
 
 /**
  * Indicates that Furnace is about to be shut down. Beans listening to this should insure that

--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
@@ -6,8 +6,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 /**
+ * Implements tools for finding the addon and rules directories.
+ *
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
 public class WebProperties
@@ -16,41 +19,38 @@ public class WebProperties
     public static final String ADDON_REPOSITORY = "addon.repository";
     public static final String RULES_REPOSITORY = "rules.repository";
 
-    private static WebProperties instance;
+    private static Logger LOG = Logger.getLogger(WebProperties.class.getName());
+
+    private static class LazyHolder
+    {
+        private static final WebProperties INSTANCE = new WebProperties();
+    }
+
     private Properties properties = new Properties();
     private Path addonRepository;
     private Path rulesRepository;
 
     public static WebProperties getInstance()
     {
-        if (instance == null)
-        {
-            synchronized (WebProperties.class)
-            {
-                if (instance == null)
-                    instance = new WebProperties();
-            }
-        }
-        return instance;
+        return LazyHolder.INSTANCE;
     }
 
     private WebProperties()
     {
+        init();
     }
 
     public Path getAddonRepository()
     {
-        init();
         return addonRepository;
     }
 
     public Path getRulesRepository()
     {
-        init();
         return rulesRepository;
     }
 
-    public void init()
+    private void init()
     {
         if (addonRepository != null)
             return;
@@ -97,7 +97,7 @@ public class WebProperties
         try
         {
             String pathString = FurnaceExtension.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
-            System.out.println("Path String: " + pathString);
+            LOG.info("Path String: " + pathString);
             Path path = Paths.get(pathString);
             if (!Files.isRegularFile(path))
                 return null;

--- a/furnace-service-provider/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/furnace-service-provider/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.jboss.windup.web.furnaceserviceprovider.FurnaceExtension

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 
     <modules>
         <module>addons</module>
+        <module>furnace-service-provider</module>
         <module>services</module>
         <module>ui</module>
     </modules>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -38,6 +38,13 @@
             <artifactId>furnace-se</artifactId>
         </dependency>
 
+        <!-- Furnace -> Java EE CDI Bridge -->
+        <dependency>
+            <groupId>org.jboss.windup.web</groupId>
+            <artifactId>furnace-service-provider</artifactId>
+            <version>3.0.0-SNAPSHOT</version>
+        </dependency>
+
         <!-- Windup Web Addons -->
         <dependency>
             <groupId>org.jboss.windup.web.addons</groupId>

--- a/services/src/main/java/org/jboss/windup/web/services/producer/WindupServicesProducer.java
+++ b/services/src/main/java/org/jboss/windup/web/services/producer/WindupServicesProducer.java
@@ -13,6 +13,7 @@ import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.web.addons.websupport.WebPathUtil;
 import org.jboss.windup.web.addons.websupport.WindupWebServiceFactory;
 import org.jboss.windup.web.addons.websupport.service.RegisteredApplicationService;
+import org.jboss.windup.web.furnaceserviceprovider.FurnaceShutdownEvent;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -37,21 +38,9 @@ public class WindupServicesProducer
     }
 
     @Produces
-    public WebPathUtil getWebPathUtil()
-    {
-        return furnace.getAddonRegistry().getServices(WebPathUtil.class).get();
-    }
-
-    @Produces
     public RuleProviderRegistryCache getRuleProviderRegistryCache()
     {
         return furnace.getAddonRegistry().getServices(RuleProviderRegistryCache.class).get();
-    }
-
-    @Produces
-    public RegisteredApplicationService getRegisteredApplicationService()
-    {
-        return getWindupWebServiceFactory().getRegisteredApplicationService();
     }
 
     /**

--- a/services/src/main/java/org/jboss/windup/web/services/producer/WindupServicesProducer.java
+++ b/services/src/main/java/org/jboss/windup/web/services/producer/WindupServicesProducer.java
@@ -13,6 +13,7 @@ import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.web.addons.websupport.WebPathUtil;
 import org.jboss.windup.web.addons.websupport.WindupWebServiceFactory;
 import org.jboss.windup.web.addons.websupport.service.RegisteredApplicationService;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 import org.jboss.windup.web.furnaceserviceprovider.FurnaceShutdownEvent;
 
 /**

--- a/services/src/main/java/org/jboss/windup/web/services/rest/RegisteredApplicationEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/RegisteredApplicationEndpointImpl.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 
 import org.jboss.windup.web.addons.websupport.model.RegisteredApplicationModel;
 import org.jboss.windup.web.addons.websupport.service.RegisteredApplicationService;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 import org.jboss.windup.web.services.dto.RegisteredApplicationDto;
 
 /**
@@ -21,7 +22,7 @@ public class RegisteredApplicationEndpointImpl implements RegisteredApplicationE
 {
     private static Logger LOG = Logger.getLogger(RegisteredApplicationEndpointImpl.class.getSimpleName());
 
-    @Inject
+    @Inject @FromFurnace
     private RegisteredApplicationService registeredApplicationService;
 
     @Override

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -21,6 +21,7 @@ import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.web.addons.websupport.model.RegisteredApplicationModel;
 import org.jboss.windup.web.addons.websupport.service.RegisteredApplicationService;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 import org.jboss.windup.web.furnaceserviceprovider.WebProperties;
 import org.jboss.windup.web.services.WindupWebProgressMonitor;
 import org.jboss.windup.web.services.dto.ProgressStatusDto;
@@ -32,12 +33,13 @@ public class WindupEndpointImpl implements WindupEndpoint
     private static Logger LOG = Logger.getLogger(WindupEndpointImpl.class.getSimpleName());
 
     private static Map<RegisteredApplicationModel, WindupWebProgressMonitor> progressMonitors = new ConcurrentHashMap<>();
+
     @Inject
     private Furnace furnace;
 
     private WebProperties webProperties = WebProperties.getInstance();
 
-    @Inject
+    @Inject @FromFurnace
     private RegisteredApplicationService registeredApplicationService;
     @Resource
     private ManagedExecutorService managedExecutorService;

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -21,7 +21,7 @@ import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.web.addons.websupport.model.RegisteredApplicationModel;
 import org.jboss.windup.web.addons.websupport.service.RegisteredApplicationService;
-import org.jboss.windup.web.services.WebProperties;
+import org.jboss.windup.web.furnaceserviceprovider.WebProperties;
 import org.jboss.windup.web.services.WindupWebProgressMonitor;
 import org.jboss.windup.web.services.dto.ProgressStatusDto;
 import org.jboss.windup.web.services.dto.RegisteredApplicationDto;
@@ -34,8 +34,9 @@ public class WindupEndpointImpl implements WindupEndpoint
     private static Map<RegisteredApplicationModel, WindupWebProgressMonitor> progressMonitors = new ConcurrentHashMap<>();
     @Inject
     private Furnace furnace;
-    @Inject
-    private WebProperties webProperties;
+
+    private WebProperties webProperties = WebProperties.getInstance();
+
     @Inject
     private RegisteredApplicationService registeredApplicationService;
     @Resource

--- a/services/src/main/java/org/jboss/windup/web/services/servlet/FileDefaultServlet.java
+++ b/services/src/main/java/org/jboss/windup/web/services/servlet/FileDefaultServlet.java
@@ -56,6 +56,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import org.jboss.windup.web.addons.websupport.WebPathUtil;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 
 /**
  * Default servlet responsible for serving up resources. This is both a handler and a servlet. If no filters
@@ -104,7 +105,7 @@ public class FileDefaultServlet extends HttpServlet
     private String basePath;
     private FileResourceManager fileResourceManager;
 
-    @Inject
+    @Inject @FromFurnace
     private WebPathUtil webPathUtil;
 
     @Override

--- a/services/src/test/java/org/jboss/windup/web/services/AbstractTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/AbstractTest.java
@@ -3,7 +3,6 @@ package org.jboss.windup.web.services;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.GenericArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.importer.ExplodedImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;

--- a/services/src/test/java/org/jboss/windup/web/services/ServerCleanupOnStartup.java
+++ b/services/src/test/java/org/jboss/windup/web/services/ServerCleanupOnStartup.java
@@ -10,6 +10,7 @@ import javax.servlet.annotation.WebListener;
 
 import org.apache.commons.io.FileUtils;
 import org.jboss.windup.web.addons.websupport.WebPathUtil;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -19,7 +20,7 @@ public class ServerCleanupOnStartup implements ServletContextListener
 {
     private static Logger LOG = Logger.getLogger(ServerCleanupOnStartup.class.getSimpleName());
 
-    @Inject
+    @Inject @FromFurnace
     private WebPathUtil webPathUtil;
 
     public ServerCleanupOnStartup()

--- a/services/src/test/java/org/jboss/windup/web/services/servlet/FileDefaultServletTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/servlet/FileDefaultServletTest.java
@@ -8,6 +8,7 @@ import java.util.logging.Logger;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 import org.jboss.windup.web.services.AbstractTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,7 +27,7 @@ public class FileDefaultServletTest extends AbstractTest
     @ArquillianResource
     private URL baseURL;
 
-    @Inject
+    @Inject @FromFurnace
     private WebPathUtil webPathUtil;
 
     @Test

--- a/ui/src/test/java/org/jboss/windup/web/ui/AbstractUITest.java
+++ b/ui/src/test/java/org/jboss/windup/web/ui/AbstractUITest.java
@@ -40,6 +40,7 @@ public abstract class AbstractUITest
         WebArchive war = ShrinkWrap.create(WebArchive.class, "windup-web-services.war");
         File servicesWarFile = Maven.resolver().resolve("org.jboss.windup.web:windup-web-services:war:3.0.0-SNAPSHOT").withoutTransitivity().asSingleFile();
         war.merge(ShrinkWrap.create(GenericArchive.class).as(ZipImporter.class).importFrom(servicesWarFile).as(GenericArchive.class));
+        war.merge(ShrinkWrap.create(ExplodedImporter.class).importDirectory("src/test/resources/WEB-INF").as(GenericArchive.class), "/WEB-INF");
         return war;
     }
 

--- a/ui/src/test/resources/WEB-INF/classes/windupweb.properties
+++ b/ui/src/test/resources/WEB-INF/classes/windupweb.properties
@@ -1,0 +1,2 @@
+addon.repository=target/export/_DEFAULT__windup-web-services_windup-web-services.war/WEB-INF/addon-repository/
+rules.repository=target/export/_DEFAULT__windup-web-services_windup-web-services.war/WEB-INF/rules/

--- a/ui/src/test/resources/arquillian.xml
+++ b/ui/src/test/resources/arquillian.xml
@@ -5,7 +5,8 @@
         http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
     
     <engine>
-        <property name="deploymentExportExploded">target/deployments</property>
+        <property name="deploymentExportPath">target/export</property>
+        <property name="deploymentExportExploded">true</property>
     </engine>
 
     <extension qualifier="webdriver">


### PR DESCRIPTION
@gastaldi @OndraZizka @mareknovotny 

Please take a look... it seems to work for my basic tests. At the moment it works with no qualifiers, but I have been thinking of making it only look in Furnace if a @FromFurnace qualifier is applied at the injection site. What do you think?

Also, feel free to point any the other issues. Obviously the spurious printlns need to be cleaned up (yes, I should have used a Logger).