### PR TITLE
List endpoints - windup-web-services/resteasy/registry

### DIFF
--- a/services/src/main/webapp/WEB-INF/web.xml
+++ b/services/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,12 @@
         </auth-constraint>
     </security-constraint>
 
+    <!-- windup-web-services/resteasy/registry - See https://issues.jboss.org/browse/JBEAP-3669 -->
+    <context-param>
+        <param-name>resteasy.resources</param-name>
+        <param-value>org.jboss.resteasy.plugins.stats.RegistryStatsResource</param-value>
+    </context-param>
+
     <login-config>
         <auth-method>KEYCLOAK</auth-method>
     </login-config>


### PR DESCRIPTION
According to https://issues.jboss.org/browse/JBEAP-3669 , this should reveal the resteasy stats at /windup-web-services/resteasy/registry .  But it doesn't work for me. Did anyone see this ever working? It would come in handy for me.