### PR TITLE
Better karma testing

### DIFF
--- a/ui/src/main/webapp/karma-systemjs.config.js
+++ b/ui/src/main/webapp/karma-systemjs.config.js
@@ -1,0 +1,49 @@
+/**
+ * System configuration for Angular 2 samples
+ * Adjust as necessary for your application needs.
+ */
+(function (global) {
+    System.config({
+        paths: {
+            // paths serve as alias
+            'npm:': 'node_modules/'
+        },
+        // map tells the System loader where to look for things
+        map: {
+            // our app is within the app folder
+            app: 'app',
+            tests: 'tests',
+
+            // angular bundles
+            '@angular/core': 'npm:@angular/core/bundles/core.umd.js',
+            '@angular/common': 'npm:@angular/common/bundles/common.umd.js',
+            '@angular/compiler': 'npm:@angular/compiler/bundles/compiler.umd.js',
+            '@angular/platform-browser': 'npm:@angular/platform-browser/bundles/platform-browser.umd.js',
+            '@angular/platform-browser-dynamic': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
+            '@angular/http': 'npm:@angular/http/bundles/http.umd.js',
+            '@angular/router': 'npm:@angular/router/bundles/router.umd.js',
+            '@angular/forms': 'npm:@angular/forms/bundles/forms.umd.js',
+
+            // other libraries
+            'rxjs':                       'npm:rxjs',
+            'angular2-in-memory-web-api': 'npm:angular2-in-memory-web-api',
+            'ng2-file-upload': 'npm:ng2-file-upload'
+        },
+        // packages tells the System loader how to load when no filename and/or no extension
+        packages: {
+            app: {
+                main: './main.js',
+                defaultExtension: 'js'
+            },
+            tests: {
+                defaultExtension: 'js'
+            },
+            rxjs: {
+                defaultExtension: 'js'
+            },
+            '../../app':                  { main: 'main.js',  defaultExtension: 'js' },
+            '../app':                     { main: 'main.js',  defaultExtension: 'js' },
+            'ng2-file-upload': { defaultExtension: 'js' }
+        }
+    });
+})(this);

--- a/ui/src/main/webapp/karma-test-shim.js
+++ b/ui/src/main/webapp/karma-test-shim.js
@@ -1,0 +1,83 @@
+// #docregion
+// /*global jasmine, __karma__, window*/
+Error.stackTraceLimit = 0;
+
+// Uncomment to get full stacktrace output. Sometimes helpful, usually not.
+// Error.stackTraceLimit = Infinity; //
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+
+var builtPath = '/base/app/';
+
+__karma__.loaded = function () { };
+
+function isJsFile(path) {
+    return path.slice(-3) == '.js';
+}
+
+function isSpecFile(path) {
+    return /\.spec\.(.*\.)?js$/.test(path);
+}
+
+function isBuiltFile(path) {
+    var builtPath = '/base/app/';
+    var testBuiltPath = '/base/tests/';
+
+    return isJsFile(path) && (
+            path.substr(0, builtPath.length) == builtPath ||
+            path.substr(0, testBuiltPath.length) == testBuiltPath
+        );
+}
+
+var allSpecFiles = Object.keys(window.__karma__.files)
+    .filter(isSpecFile)
+    .filter(isBuiltFile);
+
+System.config({
+    baseURL: '/base',
+    // Extend usual application package list with test folder
+    packages: { 'test': {  defaultExtension: 'js' } },
+
+    // Assume npm: is set in `paths` in systemjs.config
+    // Map the angular testing umd bundles
+    map: {
+        '@angular/core/testing': 'npm:@angular/core/bundles/core-testing.umd.js',
+        '@angular/common/testing': 'npm:@angular/common/bundles/common-testing.umd.js',
+        '@angular/compiler/testing': 'npm:@angular/compiler/bundles/compiler-testing.umd.js',
+        '@angular/platform-browser/testing': 'npm:@angular/platform-browser/bundles/platform-browser-testing.umd.js',
+        '@angular/platform-browser-dynamic/testing': 'npm:@angular/platform-browser-dynamic/bundles/platform-browser-dynamic-testing.umd.js',
+        '@angular/http/testing': 'npm:@angular/http/bundles/http-testing.umd.js',
+        '@angular/router/testing': 'npm:@angular/router/bundles/router-testing.umd.js',
+        '@angular/forms/testing': 'npm:@angular/forms/bundles/forms-testing.umd.js'
+    }
+});
+
+System.import('karma-systemjs.config.js')
+    .then(initTestBed)
+    .then(initTesting);
+
+function initTestBed(){
+    return Promise.all([
+        System.import('@angular/core/testing'),
+        System.import('@angular/platform-browser-dynamic/testing')
+    ])
+
+        .then(function (providers) {
+            var coreTesting    = providers[0];
+            var browserTesting = providers[1];
+
+            coreTesting.TestBed.initTestEnvironment(
+                browserTesting.BrowserDynamicTestingModule,
+                browserTesting.platformBrowserDynamicTesting());
+        })
+}
+
+// Import all spec files and start karma
+function initTesting () {
+    return Promise.all(
+        allSpecFiles.map(function (moduleName) {
+            return System.import(moduleName);
+        })
+    )
+        .then(__karma__.start, __karma__.error);
+}

--- a/ui/src/main/webapp/karma.conf.js
+++ b/ui/src/main/webapp/karma.conf.js
@@ -1,0 +1,98 @@
+module.exports = function(config) {
+    var appBase    = 'app/';          // transpiled app JS and map files
+    var appSrcBase = 'app/';          // app source TS files
+    var appAssets  = '/base/app/';    // component assets fetched by Angular's compiler
+
+    var testBase    = 'tests/';       // transpiled test JS and map files
+    var testSrcBase = 'tests/';       // test source TS files
+
+    config.set({
+        basePath: '.',
+        frameworks: ['jasmine'],
+        files: [
+            // System.js for module loading
+            'node_modules/systemjs/dist/system.src.js',
+
+            // Polyfills
+            'node_modules/core-js/client/shim.js',
+            'node_modules/reflect-metadata/Reflect.js',
+
+            // zone.js
+            'node_modules/zone.js/dist/zone.js',
+            'node_modules/zone.js/dist/long-stack-trace-zone.js',
+            'node_modules/zone.js/dist/proxy.js',
+            'node_modules/zone.js/dist/sync-test.js',
+            'node_modules/zone.js/dist/jasmine-patch.js',
+            'node_modules/zone.js/dist/async-test.js',
+            'node_modules/zone.js/dist/fake-async-test.js',
+
+            // RxJs
+            { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
+            { pattern: 'node_modules/rxjs/**/*.js.map', included: false, watched: false },
+
+            // Paths loaded via module imports:
+            // Angular itself
+            {pattern: 'node_modules/@angular/**/*.js', included: false, watched: false},
+            {pattern: 'node_modules/@angular/**/*.js.map', included: false, watched: false},
+
+            {pattern: 'node_modules/**/*.js', included: false, watched: false},
+
+            {pattern: 'karma-systemjs.config.js', included: false, watched: false},
+            'karma-test-shim.js',
+
+            // transpiled application & spec code paths loaded via module imports
+            {pattern: appBase + '**/*.js', included: false, watched: true},
+            {pattern: testBase + '**/*.js', included: false, watched: true},
+
+
+            // Asset (HTML & CSS) paths loaded via Angular's component compiler
+            // (these paths need to be rewritten, see proxies section)
+            {pattern: appBase + '**/*.html', included: false, watched: true},
+            {pattern: appBase + '**/*.css', included: false, watched: true},
+
+            // Paths for debugging with source maps in dev tools
+            {pattern: appSrcBase + '**/*.ts', included: false, watched: false},
+            {pattern: appBase + '**/*.js.map', included: false, watched: false},
+            {pattern: testSrcBase + '**/*.ts', included: false, watched: false},
+            {pattern: testBase + '**/*.js.map', included: false, watched: false}
+        ],
+
+        // proxied base paths
+        proxies: {
+            // required for component assests fetched by Angular's compiler
+            '/app/': appAssets
+        },
+
+        port: 9876,
+        logLevel: config.LOG_INFO,
+        colors: true,
+        autoWatch: true,
+        browsers: ['PhantomJS'],
+
+        // Karma plugins loaded
+        plugins: [
+            require('karma-jasmine'),
+            require('karma-phantomjs-launcher'),
+            require('karma-chrome-launcher'),
+            require('karma-coverage'),
+            require('karma-junit-reporter')
+        ],
+
+        // Coverage reporter generates the coverage
+        reporters: ['progress', 'dots', 'junit', 'coverage'],
+
+        // Source files that you wanna generate coverage for.
+        // Do not include tests or libraries (these files will be instrumented by Istanbul)
+        preprocessors: {
+            'dist/**/!(*spec).js': ['coverage']
+        },
+
+        coverageReporter: {
+            reporters:[
+                {type: 'html', subdir: '.', file: 'coverage-final.html'}
+            ]
+        },
+
+        singleRun: false
+    })
+};

--- a/ui/src/main/webapp/package.json
+++ b/ui/src/main/webapp/package.json
@@ -10,12 +10,12 @@
     "postinstall": "./node_modules/.bin/typings install"
   },
   "dependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
+    "@angular/common": "^2.0.0",
+    "@angular/compiler": "^2.0.0",
+    "@angular/core": "^2.0.0",
     "@angular/forms": "2.0.0",
     "@angular/http": "2.0.0",
-    "@angular/platform-browser": "2.0.0",
+    "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "bootstrap": "3.3.6",
@@ -25,10 +25,10 @@
     "bootstrap-touchspin": "3.1.1",
     "bootstrap-treeview": "1.2.0",
     "c3": "0.4.10",
+    "core-js": "2.4.1",
     "datatables": "1.10.9",
     "datatables-colreorder": "1.2.0",
     "drmonty-datatables-colvis": "1.1.2",
-    "core-js": "2.4.1",
     "font-awesome": "4.3.0",
     "google-code-prettify": "1.0.1",
     "jquery": "2.1.4",
@@ -42,8 +42,17 @@
     "zone.js": "0.6.23"
   },
   "devDependencies": {
+    "jasmine-core": "^2.4.1",
+    "jasmine-spec-reporter": "^2.7.0",
+    "karma": "^1.3.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-cli": "^1.0.1",
+    "karma-coverage": "^1.1.1",
+    "karma-jasmine": "^1.0.2",
+    "karma-junit-reporter": "^1.1.0",
+    "karma-phantomjs-launcher": "^1.0.2",
+    "traceur": "0.0.111",
     "typescript": "2.0.2",
-    "typings": "1.3.3",
-    "jasmine-core": "2.4.1"
+    "typings": "1.3.3"
   }
 }


### PR DESCRIPTION
I'm working on better way of angular2 unit testing. By using this configuration, we don't have to register spec files anymore - they will be automatically detected and run by karma. We also don't need unit-tests.html.ftl file anymore. 

Karma can be also integrated into several IDEs so it could simplify on the fly testing while developing. And it can generate JUnit based .xml file with test reports which could be easily consumed by Jenkins. 

Another thing we should take care of is mocking backend. I can currently see 2 options: 
1. Use swagger generated mock server
2. Use angular 2 mock backend

I like swagger generated server because by using it we can focus on documenting API and it will be in sync. On the other hand, I don't know how exactly it generates mock data and I don't know if they will be same if we generate it again.

What do you think @jsight ?
