### PR TITLE
Fixed bugs in progress monitoring and core services setup.

### DIFF
--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
@@ -78,7 +78,7 @@ public class WebProperties
 
         if (addonRepository == null)
         {
-            addonRepository = servletContextPath.resolve("WEB-INF").resolve("addon-repository");
+            addonRepository = servletContextPath.resolve("WEB-INF").resolve("windup-distribution").resolve("addons");
 
             if (!Files.isDirectory(addonRepository))
                 throw new IllegalStateException("Cannot load addon repository: " + addonRepository);
@@ -86,10 +86,13 @@ public class WebProperties
 
         if (rulesRepository == null)
         {
-            rulesRepository = servletContextPath.resolve("WEB-INF").resolve("rules");
+            rulesRepository = servletContextPath.resolve("WEB-INF").resolve("windup-distribution").resolve("rules");
             if (!Files.isDirectory(rulesRepository))
                 throw new IllegalStateException("Cannot load rules repository: " + rulesRepository);
         }
+
+        if (System.getProperty("windup.home") == null)
+            System.setProperty("windup.home", rulesRepository.getParent().toAbsolutePath().toString());
     }
 
     private Path getServletContextPhysicalPath()

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -119,12 +119,6 @@
             <version>${version.windup}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.windup.rules</groupId>
-            <artifactId>windup-rulesets</artifactId>
-            <version>${version.windup}</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
@@ -238,6 +232,30 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-windup-dist</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.jboss.windup</groupId>
+                                    <artifactId>windup-distribution</artifactId>
+                                    <version>${version.windup}</version>
+                                    <classifier>offline</classifier>
+                                    <type>zip</type>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/${project.artifactId}/WEB-INF/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jboss.forge.furnace</groupId>
                 <artifactId>furnace-maven-plugin</artifactId>
                 <version>${version.furnace}</version>
@@ -250,14 +268,9 @@
                         </goals>
                         <inherited>false</inherited>
                         <configuration>
-                            <addonRepository>${project.build.directory}/${project.artifactId}/WEB-INF/addon-repository</addonRepository>
+                            <overwrite>false</overwrite>
+                            <addonRepository>${project.build.directory}/${project.artifactId}/WEB-INF/windup-distribution-${version.windup}/addons</addonRepository>
                             <addonIds>
-                                <addonId>org.jboss.forge.furnace.container:cdi,${version.furnace}</addonId>
-                                <addonId>org.jboss.forge.furnace.container:simple,${version.furnace}</addonId>
-                                <addonId>org.jboss.windup.ui:windup-ui,${version.windup}</addonId>
-                                <addonId>org.jboss.windup.rules.apps:windup-rules-java,${version.windup}</addonId>
-                                <addonId>org.jboss.windup.rules.apps:windup-rules-java-project,${version.windup}</addonId>
-                                <addonId>org.jboss.windup.rules.apps:windup-rules-java-ee,${version.windup}</addonId>
                                 <addonId>org.jboss.windup.web.addons:windup-web-support,${project.version}</addonId>
                             </addonIds>
                         </configuration>
@@ -265,26 +278,18 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack-rules</id>
+                        <id>rename-windup-dist</id>
                         <phase>test-compile</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>run</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.jboss.windup.rules</groupId>
-                                    <artifactId>windup-rulesets</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}/${project.artifactId}/WEB-INF/rules</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                            <excludes>**/tests/**</excludes>
+                            <tasks>
+                                <move file="${project.build.directory}/${project.artifactId}/WEB-INF/windup-distribution-${version.windup}" tofile="${project.build.directory}/${project.artifactId}/WEB-INF/windup-distribution" />
+                            </tasks>
                         </configuration>
                     </execution>
                 </executions>
@@ -406,24 +411,6 @@
                     <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
-                            <execution>
-                                <id>unpack-rules</id>
-                                <phase>test-compile</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.jboss.windup.rules</groupId>
-                                            <artifactId>windup-rulesets</artifactId>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/${project.artifactId}/WEB-INF/rules</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                    <excludes>**/tests/**</excludes>
-                                </configuration>
-                            </execution>
                             <execution>
                                 <id>unpack</id>
                                 <phase>process-test-classes</phase>

--- a/services/src/main/java/org/jboss/windup/web/services/ServiceUtil.java
+++ b/services/src/main/java/org/jboss/windup/web/services/ServiceUtil.java
@@ -1,0 +1,56 @@
+package org.jboss.windup.web.services;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
+import javax.jms.Queue;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.UserTransaction;
+
+/**
+ * This contains useful utility methods for the services module.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+public class ServiceUtil
+{
+
+    /**
+     * Lookup a JMS Queue.
+     */
+    public static Queue getJMSQueue(String jndiName)
+    {
+        return lookup("JMSQueue", Queue.class, jndiName);
+    }
+
+    /**
+     * Lookup the JMSContext from JNDI.
+     */
+    public static JMSContext getJMSContext()
+    {
+        ConnectionFactory connectionFactory = lookup("JMSContext", ConnectionFactory.class, "java:/ConnectionFactory");
+        return connectionFactory.createContext();
+    }
+
+    /**
+     * Lookup the {@link UserTransaction} manually from the container.
+     */
+    public static UserTransaction getUserTransaction()
+    {
+        return lookup("UserTransaction", UserTransaction.class, "java:jboss/UserTransaction");
+    }
+
+    private static <T> T lookup(String description, Class<T> clazz, String jndiName)
+    {
+        try
+        {
+            // Begin of task
+            InitialContext ctx = new InitialContext();
+            return (T) ctx.lookup(jndiName);
+        }
+        catch (NamingException e)
+        {
+            throw new RuntimeException("Failed to lookup " + description + " due to: " + e.getMessage());
+        }
+    }
+}

--- a/services/src/main/java/org/jboss/windup/web/services/messaging/StatusUpdateMDB.java
+++ b/services/src/main/java/org/jboss/windup/web/services/messaging/StatusUpdateMDB.java
@@ -62,6 +62,10 @@ public class StatusUpdateMDB extends AbstractMDB implements MessageListener
             LOG.info("Received execution update event: " + execution);
 
             WindupExecution fromDB = entityManager.find(WindupExecution.class, execution.getId());
+
+            if (fromDB == null)
+                LOG.warning("Received unrecognized status update for execution: " + fromDB);
+
             fromDB.setLastModified(new GregorianCalendar());
             fromDB.setTimeStarted(execution.getTimeStarted());
             fromDB.setTimeCompleted(execution.getTimeCompleted());

--- a/services/src/main/java/org/jboss/windup/web/services/model/ExecutionState.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/ExecutionState.java
@@ -9,5 +9,16 @@ public enum ExecutionState
     STARTED,
     COMPLETED,
     FAILED,
-    CANCELLED
+    CANCELLED;
+
+    /**
+     * This indicates whether processing has ceased for some reason. This includes a normal completion, as well
+     * as failure or cancellation of the task.
+     *
+     * @return
+     */
+    public boolean isDone()
+    {
+        return this == COMPLETED || this == FAILED || this == CANCELLED;
+    }
 }

--- a/services/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
@@ -41,7 +41,7 @@ public class MigrationProject implements Serializable
     private int version;
 
     @Column(length = 256)
-    @Size(min = 4, max = 256)
+    @Size(min = 1, max = 256)
     @NotNull
     private String title;
 

--- a/services/src/main/java/org/jboss/windup/web/services/model/Package.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/Package.java
@@ -29,12 +29,12 @@ public class Package implements Serializable
     private Long id;
 
     @Column(length = 256)
-    @Size(min = 1, max = 256)
+    @Size(min = 0, max = 256)
     @NotNull
     private String name;
 
     @Column(length = 256)
-    @Size(min = 1, max = 256)
+    @Size(min = 0, max = 256)
     @NotNull
     private String fullName;
 

--- a/services/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
@@ -296,7 +296,8 @@ public class WindupExecution implements Serializable
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return "WindupExecution{" +
                 "outputPath='" + outputPath + '\'' +
                 ", totalWork=" + totalWork +
@@ -311,7 +312,8 @@ public class WindupExecution implements Serializable
     }
     
     private static final DateFormat FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    private String formatCalendar(Calendar cal) {
+    private String formatCalendar(Calendar cal)
+    {
         if (cal == null)
             return "null";
         FORMATTER.setTimeZone(cal.getTimeZone());

--- a/services/src/test/resources/WEB-INF/classes/windupweb.properties
+++ b/services/src/test/resources/WEB-INF/classes/windupweb.properties
@@ -1,2 +1,2 @@
-addon.repository=target/windup-web-services/WEB-INF/addon-repository/
-rules.repository=target/windup-web-services/WEB-INF/rules/
+addon.repository=target/windup-web-services/WEB-INF/windup-distribution/addons/
+rules.repository=target/windup-web-services/WEB-INF/windup-distribution/rules/

--- a/ui/src/main/webapp/app/components/applicationgroupform.component.html
+++ b/ui/src/main/webapp/app/components/applicationgroupform.component.html
@@ -18,7 +18,7 @@
                         [(ngModel)]="model.title"
                         [disabled]="loadingGroup"
                         required
-                        minlength="4"
+                        minlength="1"
                         maxlength="128"
                         type="text"
                         id="idGroupTitle"

--- a/ui/src/main/webapp/app/components/grouplist.component.html
+++ b/ui/src/main/webapp/app/components/grouplist.component.html
@@ -1,5 +1,5 @@
 <h1>
-    Groups
+    {{project?.title}} - Groups
     <button (click)="createGroup()" class="btn btn-primary" type="button">Create Group</button>
 </h1>
 <h3 *ngIf="errorMessage != null">{{errorMessage}}</h3>

--- a/ui/src/main/webapp/app/components/grouplist.component.ts
+++ b/ui/src/main/webapp/app/components/grouplist.component.ts
@@ -19,6 +19,7 @@ import {MigrationProjectService} from "../services/migrationproject.service";
 })
 export class GroupListComponent implements OnInit, OnDestroy {
     projectID:number;
+    project:MigrationProject;
     groups:ApplicationGroup[];
 
     processingStatus:Map<number, WindupExecution> = new Map<number, WindupExecution>();
@@ -43,6 +44,7 @@ export class GroupListComponent implements OnInit, OnDestroy {
             this._migrationProjectService.get(this.projectID)
                 .subscribe(
                     project => {
+                        this.project = project;
                         console.log('success');
                     },
                     error => {

--- a/ui/src/main/webapp/app/components/migrationprojectform.component.html
+++ b/ui/src/main/webapp/app/components/migrationprojectform.component.html
@@ -18,7 +18,7 @@
                        [(ngModel)]="model.title"
                        [disabled]="loading"
                        required
-                       minlength="4"
+                       minlength="1"
                        maxlength="128"
                        type="text"
                        id="idProjectTitle"

--- a/ui/src/test/resources/WEB-INF/classes/windupweb.properties
+++ b/ui/src/test/resources/WEB-INF/classes/windupweb.properties
@@ -1,2 +1,2 @@
-addon.repository=target/export/_DEFAULT__windup-web-services_windup-web-services.war/WEB-INF/addon-repository/
-rules.repository=target/export/_DEFAULT__windup-web-services_windup-web-services.war/WEB-INF/rules/
+addon.repository=target/export/_DEFAULT__windup-web-services_windup-web-services.war/WEB-INF/windup-distribution/addons/
+rules.repository=target/export/_DEFAULT__windup-web-services_windup-web-services.war/WEB-INF/windup-distribution/rules/


### PR DESCRIPTION
 - Previously, status updates from non-JavaEE threads were not being propagated. Now the ExecutorService is used to improve status updates even from decompilation and other multithreaded steps.
 - Windup dist is now used to get the ignore rules properly imported
 - Added a project title to the group list page