### PR TITLE
Started work on returning links properly

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/RestApplication.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/RestApplication.java
@@ -3,7 +3,8 @@ package org.jboss.windup.web.services.rest;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.ApplicationPath;
 
-@ApplicationPath("/rest")
+@ApplicationPath(RestApplication.REST_BASE)
 public class RestApplication extends Application
 {
+    public static final String REST_BASE = "/rest";
 }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/graph/AbstractGraphResource.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/graph/AbstractGraphResource.java
@@ -18,6 +18,8 @@ import org.jboss.windup.web.services.model.WindupExecution;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -25,8 +27,18 @@ import javax.persistence.PersistenceContext;
 public class AbstractGraphResource
 {
     public static final String KEY_ID = "_id";
+    public static final String TYPE = "_type";
+    public static final String TYPE_VERTEX = "vertex";
+    public static final String TYPE_LINK = "link";
+    public static final String LINK = "link";
+
     public static final String DIRECTION = "direction";
     public static final String VERTICES = "vertices";
+    public static final String VERTICES_OUT = "vertices_out";
+    public static final String VERTICES_IN = "vertices_in";
+
+    @Context
+    private UriInfo uri;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -34,30 +46,39 @@ public class AbstractGraphResource
     @Inject
     private GraphCache graphCache;
 
-    protected Map<String, Object> convertToMap(Vertex vertex, Integer depth)
+    private String getLink(long executionID, Vertex vertex, String direction, String label)
     {
+        String params = String.format("/%s/edges/%s/%s/%s", executionID, vertex.getId(), direction, label);
+        return uri.getBaseUri() + GraphResource.GRAPH_RESOURCE_URL + params;
+    }
+
+    protected Map<String, Object> convertToMap(long executionID, Vertex vertex, Integer depth)
+    {
+        if (depth == null)
+            depth = 0;
+
         Map<String, Object> result = new HashMap<>();
+
+        result.put(TYPE, TYPE_VERTEX);
         for (String key : vertex.getPropertyKeys())
         {
             result.put(key, vertex.getProperty(key));
         }
         result.put(KEY_ID, vertex.getId());
 
-        if (depth == null || depth == 0)
-            depth = 0;
-
-        addEdges(result, vertex, depth, Direction.OUT);
-        addEdges(result, vertex, depth, Direction.IN);
+        Map<String, Object> outVertices = new HashMap<>();
+        result.put(VERTICES_OUT, outVertices);
+        addEdges(executionID, outVertices, vertex, depth, Direction.OUT);
+        Map<String, Object> inVertices = new HashMap<>();
+        result.put(VERTICES_IN, inVertices);
+        addEdges(executionID, inVertices, vertex, depth, Direction.IN);
 
         return result;
     }
 
     @SuppressWarnings("unchecked")
-    private void addEdges(Map<String, Object> result, Vertex vertex, Integer remainingDepth, Direction direction)
+    private void addEdges(long executionID, Map<String, Object> result, Vertex vertex, Integer remainingDepth, Direction direction)
     {
-        if (remainingDepth == 0)
-            return;
-
         final Direction opposite = direction == Direction.OUT ? Direction.IN : Direction.OUT;
 
         for (Edge edge : vertex.getEdges(direction))
@@ -71,9 +92,19 @@ public class AbstractGraphResource
             {
                 edgeDetails = new HashMap<>();
                 edgeDetails.put(DIRECTION, direction.toString());
+                result.put(label, edgeDetails);
+
+                // If we aren't serializing any further, then just provide a link
+                if (remainingDepth == null || remainingDepth == 0)
+                {
+                    edgeDetails.put(TYPE, TYPE_LINK);
+                    String linkUri = getLink(executionID, vertex, direction.toString(), label);
+                    edgeDetails.put(LINK, linkUri);
+                    return;
+                }
+
                 linkedVertices = new ArrayList<>();
                 edgeDetails.put(VERTICES, linkedVertices);
-                result.put(label, edgeDetails);
             }
             else
             {
@@ -81,27 +112,25 @@ public class AbstractGraphResource
             }
 
             Vertex otherVertex = edge.getVertex(opposite);
-            Map<String, Object> otherVertexMap = convertToMap(otherVertex, remainingDepth - 1);
+            Map<String, Object> otherVertexMap = convertToMap(executionID, otherVertex, remainingDepth - 1);
             linkedVertices.add(otherVertexMap);
         }
     }
 
-    protected List<Map<String, Object>> frameIterableToResult(Iterable<? extends WindupVertexFrame> frames, int depth)
+    protected List<Map<String, Object>> frameIterableToResult(long executionID, Iterable<? extends WindupVertexFrame> frames, int depth)
     {
         List<Map<String, Object>> result = new ArrayList<>();
         for (WindupVertexFrame frame : frames)
         {
-            result.add(convertToMap(frame.asVertex(), depth));
+            result.add(convertToMap(executionID, frame.asVertex(), depth));
         }
         return result;
     }
 
     protected GraphContext getGraph(Long executionID)
     {
-
         WindupExecution execution = entityManager.find(WindupExecution.class, executionID);
         Path graphPath = Paths.get(execution.getGroup().getOutputPath()).resolve(GraphContextFactory.DEFAULT_GRAPH_SUBDIRECTORY);
-
         return graphCache.getGraph(graphPath);
     }
 }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/graph/FileModelResourceImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/graph/FileModelResourceImpl.java
@@ -21,7 +21,7 @@ public class FileModelResourceImpl extends AbstractGraphResource implements File
         {
             FileService fileService = new FileService(context);
             Iterable<FileModel> models = fileService.findByFilenameRegex(filename);
-            return frameIterableToResult(models, 1);
+            return frameIterableToResult(executionID, models, 1);
         }
         catch (IOException e)
         {

--- a/services/src/main/java/org/jboss/windup/web/services/rest/graph/GraphResource.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/graph/GraphResource.java
@@ -12,14 +12,20 @@ import java.util.Map;
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
-@Path("/graph")
+@Path(GraphResource.GRAPH_RESOURCE_URL)
 @Consumes("application/json")
 @Produces("application/json")
 public interface GraphResource
 {
+    String GRAPH_RESOURCE_URL = "graph";
+
     @GET
     @Path("/{executionID}/{id}")
-    Map<String, Object> get(@PathParam("executionID") Long executionID, @PathParam("id") Integer id, @QueryParam("depth") Integer depth);
+    Map<String, Object> get(@PathParam("executionID") Long executionID, @PathParam("id") Integer vertexID, @QueryParam("depth") Integer depth);
+
+    @GET()
+    @Path("/{executionID}/edges/{vertexID}/{edgeDirection}/{edgeLabel}")
+    List<Map<String, Object>> getEdges(@PathParam("executionID") Long executionID, @PathParam("vertexID") Integer vertexID, @PathParam("edgeDirection") String edgeDirection, @PathParam("edgeLabel") String edgeLabel);
 
     @GET()
     @Path("/{executionID}/by-type/{vertexType}")

--- a/services/src/test/java/org/jboss/windup/web/services/rest/graph/FileResourceTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/graph/FileResourceTest.java
@@ -50,7 +50,9 @@ public class FileResourceTest extends GraphResourceTest
         {
             Assert.assertEquals(true, result.get(FileModel.IS_DIRECTORY));
             Assert.assertEquals("windup-src-example", result.get(FileModel.FILE_NAME));
-            Assert.assertNotNull(result.get(FileModel.PARENT_FILE));
+
+            Object parentFile = ((Map<String, Object>)result.get(AbstractGraphResource.VERTICES_OUT)).get(FileModel.PARENT_FILE);
+            Assert.assertNotNull(parentFile);
         }
     }
 }

--- a/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
@@ -62,6 +62,33 @@ public class GraphResourceTest extends AbstractTest
 
     @Test
     @RunAsClient
+    public void testEdgeQuery()
+    {
+        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, FileModel.FILE_NAME, "windup-src-example", 0);
+        Assert.assertNotNull(fileModels);
+        Assert.assertTrue(fileModels.size() == 1);
+
+        for (Map<String, Object> fileModel : fileModels)
+        {
+            Map<String, Object> verticesOut = (Map<String, Object>)fileModel.get(AbstractGraphResource.VERTICES_OUT);
+            Assert.assertNotNull(verticesOut);
+
+            Map<String, Object> parentFileLinkDetails = (Map<String, Object>)verticesOut.get(FileModel.PARENT_FILE);
+            Assert.assertEquals(AbstractGraphResource.TYPE_LINK, parentFileLinkDetails.get(AbstractGraphResource.TYPE));
+
+            String edgesUri = (String)parentFileLinkDetails.get(AbstractGraphResource.LINK);
+            Assert.assertNotNull(edgesUri);
+
+            Object vertexID = fileModel.get(AbstractGraphResource.KEY_ID);
+            List<Map<String, Object>> edges = graphResource.getEdges(execution.getId(), (Integer)vertexID, "OUT", FileModel.PARENT_FILE);
+            Assert.assertNotNull(edges);
+            Assert.assertEquals(1, edges.size());
+            Assert.assertNotNull(edges.get(0));
+        }
+    }
+
+    @Test
+    @RunAsClient
     public void testQueryByTypeAndProperty()
     {
         List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, FileModel.FILE_NAME, "windup-src-example", 1);
@@ -71,6 +98,22 @@ public class GraphResourceTest extends AbstractTest
         for (Map<String, Object> fileModel : fileModels)
         {
             System.out.println("FileModel: " + fileModel);
+            System.out.println("File Path: " + fileModel.get(FileModel.FILE_PATH));
+
+            Map<String, Object> verticesOut = (Map<String, Object>)fileModel.get(AbstractGraphResource.VERTICES_OUT);
+            Assert.assertNotNull(verticesOut);
+
+            Map<String, Object> parentFileInfo = (Map<String, Object>)verticesOut.get(FileModel.PARENT_FILE);
+            Assert.assertNotNull(parentFileInfo);
+            List<Object> parentFiles = (List<Object>)parentFileInfo.get(AbstractGraphResource.VERTICES);
+            Assert.assertEquals(1, parentFiles.size());
+
+            Map<String, Object> verticesIn = (Map<String, Object>)fileModel.get(AbstractGraphResource.VERTICES_IN);
+            Map<String, Object> childFiles = (Map<String, Object>)verticesIn.get(FileModel.PARENT_FILE);
+            Assert.assertNotNull(childFiles);
+
+            List<Object> vertices = (List)childFiles.get(AbstractGraphResource.VERTICES);
+            Assert.assertTrue(vertices.size() > 0);
         }
     }
 }

--- a/ui/src/main/webapp/app/services/graph/base.model.ts
+++ b/ui/src/main/webapp/app/services/graph/base.model.ts
@@ -1,3 +1,4 @@
+import {Http} from "@angular/http";
 /**
  * Things common to all models on the Typescript side.
  */
@@ -5,6 +6,7 @@ export class BaseModel
 {
     // Model metadata
 	static discriminator: string;
+    http:Http;
 
     constructor(private discriminator:string[], public vertexId: number, public data:any){
     }

--- a/ui/src/main/webapp/app/services/graph/graph-adjacency.decorator.ts
+++ b/ui/src/main/webapp/app/services/graph/graph-adjacency.decorator.ts
@@ -2,14 +2,15 @@
 import {GraphJSONToModelService} from "./graph-json-to-model.service";
 import {Observable} from "rxjs/Observable";
 
-export function GraphAdjacency (name:string, array:boolean = true):any {
+export function GraphAdjacency (name:string, direction:string, array:boolean = true):any {
     return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
-        console.log("Property key: " + target);
         if (descriptor) {
             descriptor.get = function () {
 
+                let verticesLabel = direction == "IN" ? "vertices_in" : "vertices_out";
+
                 // data is empty, just return null (or an empty array)
-                if (!this.data || !this.data[name] || !this.data[name].vertices)
+                if (!this.data || !this.data[verticesLabel] || !this.data[verticesLabel] || !this.data[verticesLabel][name])
                     return Observable.create(function(observer) {
                         if (array)
                             observer.next([]);
@@ -18,18 +19,37 @@ export function GraphAdjacency (name:string, array:boolean = true):any {
                         observer.complete();
                     });
 
+                // If data is a link, so return a result of a service call
+                if (this.data[verticesLabel][name]["_type"] == "link") {
+                    // make an HTTP Call
+                    let url = this.data[verticesLabel][name]["link"];
+                    if (array) {
+                        return this.http.get(url).map((vertices:any) => {
+                            return vertices.map((vertice:any) => {
+                                return new GraphJSONToModelService().fromJSON(vertice, target.http);
+                            });
+                        });
+                    } else {
+                        console.log("Should return a single item for: " + name);
+                        return this.http.get(url).map((vertices:any) => {
+                            return new GraphJSONToModelService().fromJSON(vertices[0], target.http);
+                        });
+                    }
+                }
+                
+
                 // Data is not null, so return a valid value
-                var vertices = this.data[name].vertices;
+                var vertices = this.data[verticesLabel][name].vertices;
+
                 return Observable.create(function(observer) {
                     let value:any;
                     if (array)
                         value = vertices.map((vertice:any) => {
-                            return new GraphJSONToModelService().fromJSON(vertice);
+                            return new GraphJSONToModelService().fromJSON(vertice, target.http);
                         });
                     else
-                        value = new GraphJSONToModelService().fromJSON(vertices[0]);
+                        value = new GraphJSONToModelService().fromJSON(vertices[0], target.http);
 
-                    console.log("For property: " + name + " returning: " + value + ", json: " + JSON.stringify(value));
                     observer.next(value);
                     observer.complete();
                 });

--- a/ui/src/main/webapp/app/services/graph/graph-json-to-model.service.ts
+++ b/ui/src/main/webapp/app/services/graph/graph-json-to-model.service.ts
@@ -1,10 +1,9 @@
-//import {Inject, Injectable} from '@angular/core';
-//import {Headers, Http, RequestOptions, Response} from '@angular/http';
-//import {Observable} from 'rxjs/Observable';
+import {Injectable} from "@angular/core";
+import {Observable} from "rxjs/Observable";
 
 import {DiscriminatorMapping, getParentClass} from './discriminator-mapping';
 import {BaseModel} from './base.model';
-import {Observable} from "rxjs/Observable";
+import {Http} from "@angular/http";
 
 /**
  * Converts the JSON Graph representation to TypeScript models.
@@ -26,31 +25,26 @@ import {Observable} from "rxjs/Observable";
         "otherEdgeLabel": { }
     }
  */
-//@Injectable()
+@Injectable()
 export class GraphJSONToModelService<T extends BaseModel>
 {
     static MODE = "_mode";
     static DISCRIMINATOR = "w:winduptype";
-
 
     public getTypeScriptClassByDiscriminator(discriminator: string): typeof BaseModel {
         return DiscriminatorMapping.getModelClassByDiscriminator(discriminator);
     }
 
 
-    public fromJSON(input: Object, clazz?: typeof BaseModel): T
+    public fromJSON(input: Object, http:Http, clazz?: typeof BaseModel): T
     {
         let discriminator:string[] = input[GraphJSONToModelService.DISCRIMINATOR];
         clazz = this.getClass(input, clazz);
         let frameModel:BaseModel = Object.create(clazz.prototype);
         frameModel.constructor.apply(frameModel, [discriminator, input["_id"], input]);
+        console.log("Setting http on object: " + frameModel + " to: " + http);
+        frameModel.http = http;
         return <T>frameModel;
-    }
-
-    public fromLink <T extends BaseModel> (link: string):  Observable<T>
-    {
-        // TODO - This should store some kind of metadata to allow the vertices to be loaded lazily.
-        return null;
     }
 
     private getClass(input: Object, clazz?: typeof BaseModel):typeof BaseModel {

--- a/ui/src/main/webapp/app/services/graph/graph-property.decorator.ts
+++ b/ui/src/main/webapp/app/services/graph/graph-property.decorator.ts
@@ -3,6 +3,8 @@ export function GraphProperty (name:string):any {
     return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
         if (descriptor) {
             descriptor.get = function () {
+                if (!this.data)
+                    return null;
                 return this.data[name];
             };
         }

--- a/ui/src/main/webapp/tests/app/models/test-graph-data.ts
+++ b/ui/src/main/webapp/tests/app/models/test-graph-data.ts
@@ -7,12 +7,12 @@ export class TestGraphData
         "fetchRemoteResources": false,
         "csv": false,
         "keepWorkDirs": true,
-        "edgeLabel": {
-            "direction": "out", //|'in'|'both',
-            "vertices": [
-                { "_type": "vertex", }, // Normal vertex
-                { "_type": "link", "link": "http://localhost/rest/graph/by-id/{id}" } // A link to a vertex
-            ]
+        "vertices_out": {
+            "edgeLabel": {
+                "direction": "OUT", //|'IN'
+                "_type": "link",
+                "link": "http://localhost/rest/graph/by-id/256" // A link to a set of vertices
+            },
         },
         "otherEdgeLabel": { }
     };
@@ -24,19 +24,31 @@ export class TestGraphData
 
         "bar": "bar123", "name": "Blake Ross", "rank": "capitain",
 
-        // -> ship
-        "commands": {
-            "vertices": [
-                { "_id": 123, "w:winduptype": ["TestShip"], "name": "USS Firefox"},
-            ]
-        },
-        // -> colonizedPlanet
-        "colonizes": {
-            "vertices": [
-                { "_id": 213, "w:winduptype": ["TestPlanet"],  "name": "Mars" },
-                { "_id": 214, "w:winduptype": ["TestPlanet"],  "name": "Venus" },
-                //{ "_mode": "link", "link": "by-id=215" },
-            ]
+        "vertices_out": {
+            // -> ship
+            "commands": {
+                "vertices": [
+                    { "_id": 123, "w:winduptype": ["TestShip"], "name": "USS Firefox"},
+                ]
+            },
+            // -> colonizedPlanet
+            "colonizes": {
+                "vertices": [
+                    { "_id": 213, "w:winduptype": ["TestPlanet"],  "name": "Mars" },
+                    { "_id": 214, "w:winduptype": ["TestPlanet"],  "name": "Venus" },
+                    //{ "_mode": "link", "link": "by-id=215" },
+                ]
+            },
+            "shuttles": {
+                "direction": "OUT", //|'IN'
+                "_type": "link",
+                "link": "http://localhost/rest/graph/by-id/456" // A link to a set of vertices
+            },
+            "fighter": {
+                "direction": "OUT", //|'IN'
+                "_type": "link",
+                "link": "http://localhost/rest/graph/by-id/456" // A link to a set of vertices
+            },
         },
     };
 }

--- a/ui/src/main/webapp/tests/app/models/test.models.ts
+++ b/ui/src/main/webapp/tests/app/models/test.models.ts
@@ -15,11 +15,17 @@ export class TestGeneratorModel extends BaseModel
     @GraphProperty("rank")
     get rank():string { return null; };
 
-    @GraphAdjacency("colonizes")
+    @GraphAdjacency("colonizes", "OUT")
     get colonizedPlanet(): Observable<TestPlanetModel[]> { return null; }; // edge label 'colonizes'
 
-    @GraphAdjacency("commands", false)
+    @GraphAdjacency("commands", "OUT", false)
     get ship(): Observable<TestShipModel> { return null; }; // edge label 'commands'
+
+    @GraphAdjacency("shuttles", "OUT", true)
+    get shuttles(): Observable<TestShipModel[]> { return null; }; // edge label 'commands'
+
+    @GraphAdjacency("fighter", "OUT", false)
+    get fighter(): Observable<TestShipModel> { return null; }; // edge label 'commands'
 }
 
 export class TestPlanetModel extends BaseModel

--- a/ui/src/main/webapp/tests/unit-tests.html.ftl
+++ b/ui/src/main/webapp/tests/unit-tests.html.ftl
@@ -23,8 +23,6 @@
     <script src="../node_modules/zone.js/dist/proxy.js"></script>
     <script src="../node_modules/zone.js/dist/sync-test.js"></script>
     <script src="../node_modules/zone.js/dist/jasmine-patch.js"></script>
-    <script src="../node_modules/zone.js/dist/"></script>
-    <script src="../node_modules/zone.js/dist/"></script>
     <script src="../node_modules/zone.js/dist/async-test.js"></script>
     <script src="../node_modules/zone.js/dist/fake-async-test.js"></script>
 


### PR DESCRIPTION
This is an extension of the format that was already in master. A couple of notes:

- The vertices format has been changed, to make it clearer that all related vertices can be loaded at once
- The client code has been updated to be able to lazy load related data
- The client test has been updated with examples of lazy loaded data (mock data)

The generator (https://github.com/windup/windup-web/pull/64) will need to be updated to emit this format.