### PR TITLE
324 migration issues rest api

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpoint.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpoint.java
@@ -1,0 +1,23 @@
+package org.jboss.windup.web.addons.websupport.rest;
+
+// TODO: Come on class loader, classes not present?!
+// import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummary;
+// import org.jboss.windup.reporting.model.Severity;
+// import java.util.List;
+// import java.util.Map;
+
+import javax.ws.rs.*;
+
+/**
+ * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
+ */
+@Path("reports/{executionId}/migrationIssues")
+@Consumes("application/json")
+@Produces("application/json")
+public interface MigrationIssuesEndpoint extends FurnaceRESTGraphAPI
+{
+
+    @GET
+    @Path("aggregatedIssues")
+    Object getAggregatedIssues(@PathParam("executionId") Long executionId);
+}

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
@@ -1,6 +1,9 @@
 package org.jboss.windup.web.addons.websupport.rest;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.windup.graph.GraphContext;
 import org.jboss.windup.graph.model.ProjectModel;
@@ -38,5 +41,16 @@ public class MigrationIssuesEndpointImpl extends AbstractGraphResource implement
                     excludeTags);
 
         return categorizedProblems;
+    }
+
+    @Override
+    public Object getIssueFiles(Long executionId, String issueId)
+    {
+        Map<Severity, List<ProblemSummary>> categorizedProblems = this.getAggregatedIssues(executionId);
+
+        /*
+         * Collection<ProblemSummary> problemSummaries = categorizedProblems.entrySet().stream() .map(Map.Entry::getValue);
+         */
+        return null;
     }
 }

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
@@ -1,0 +1,42 @@
+package org.jboss.windup.web.addons.websupport.rest;
+
+import java.util.*;
+
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.graph.service.WindupConfigurationService;
+import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummary;
+import org.jboss.windup.reporting.freemarker.problemsummary.ProblemSummaryService;
+import org.jboss.windup.reporting.model.Severity;
+import org.jboss.windup.web.addons.websupport.rest.graph.AbstractGraphResource;
+
+/**
+ * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
+ */
+public class MigrationIssuesEndpointImpl extends AbstractGraphResource implements MigrationIssuesEndpoint
+{
+
+    @Override
+    public Map<Severity, List<ProblemSummary>> getAggregatedIssues(Long reportId)
+    {
+        GraphContext graphContext = this.getGraph(reportId);
+
+        ProblemSummaryService problemSummaryService = new ProblemSummaryService();
+
+        Set<ProjectModel> projectModels = new HashSet<>();
+
+        for (FileModel inputPath : WindupConfigurationService.getConfigurationModel(graphContext).getInputPaths())
+        {
+            projectModels.add(inputPath.getProjectModel());
+        }
+
+        Set<String> includeTags = new HashSet<>();
+        Set<String> excludeTags = new HashSet<>();
+
+        Map<Severity, List<ProblemSummary>> categorizedProblems = ProblemSummaryService.getProblemSummaries(graphContext, projectModels, includeTags,
+                    excludeTags);
+
+        return categorizedProblems;
+    }
+}

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/AbstractGraphResource.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/AbstractGraphResource.java
@@ -17,6 +17,7 @@ import org.jboss.windup.web.addons.websupport.rest.GraphPathLookup;
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.NotFoundException;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -215,6 +215,10 @@
             <version>1.6.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.windup.reporting</groupId>
+            <artifactId>windup-reporting-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
@@ -1,7 +1,6 @@
 package org.jboss.windup.web.services.model;
 
 import java.io.Serializable;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -63,7 +62,7 @@ public class ApplicationGroup implements Serializable
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "group")
     @Fetch(FetchMode.SELECT)
-    private Collection<WindupExecution> executions;
+    private Set<WindupExecution> executions;
 
     @ManyToOne(cascade = CascadeType.ALL)
     private PackageMetadata packageMetadata;
@@ -248,7 +247,7 @@ public class ApplicationGroup implements Serializable
     /**
      * Contains a collection of {@link WindupExecution}s.
      */
-    public Collection<WindupExecution> getExecutions()
+    public Set<WindupExecution> getExecutions()
     {
         return executions;
     }
@@ -256,7 +255,7 @@ public class ApplicationGroup implements Serializable
     /**
      * Contains a collection of {@link WindupExecution}s.
      */
-    public void setExecutions(Collection<WindupExecution> executions)
+    public void setExecutions(Set<WindupExecution> executions)
     {
         this.executions = executions;
     }

--- a/services/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
@@ -1,24 +1,16 @@
 package org.jboss.windup.web.services.model;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import java.io.Serializable;
 import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-import javax.persistence.Version;
+import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 /**
  * Contains the current execution status for a Windup run.
@@ -310,7 +302,7 @@ public class WindupExecution implements Serializable
                 ", timeStarted=" + formatCalendar(timeStarted) +
                 '}';
     }
-    
+
     private static final DateFormat FORMATTER = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     private String formatCalendar(Calendar cal)
     {
@@ -318,5 +310,32 @@ public class WindupExecution implements Serializable
             return "null";
         FORMATTER.setTimeZone(cal.getTimeZone());
         return FORMATTER.format(cal.getTime());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        WindupExecution that = (WindupExecution) o;
+
+        if (version != that.version)
+            return false;
+
+        return id != null ? id.equals(that.id) : that.id == null;
+
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + version;
+
+        return result;
     }
 }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/RestApplicationFurnace.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/RestApplicationFurnace.java
@@ -1,6 +1,7 @@
 package org.jboss.windup.web.services.rest;
 
 import org.jboss.windup.web.addons.websupport.rest.FurnaceRESTGraphAPI;
+import org.jboss.windup.web.addons.websupport.rest.MigrationIssuesEndpoint;
 import org.jboss.windup.web.services.service.DefaultGraphPathLookup;
 import org.jboss.windup.web.addons.websupport.rest.graph.FileModelResource;
 import org.jboss.windup.web.addons.websupport.rest.graph.GraphResource;
@@ -30,6 +31,9 @@ public class RestApplicationFurnace extends Application {
     @Inject @FromFurnace
     private FileModelResource fileModelResource;
 
+    @Inject @FromFurnace
+    private MigrationIssuesEndpoint migrationIssuesEndpoint;
+
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -39,6 +43,7 @@ public class RestApplicationFurnace extends Application {
         Set<Object> singletons = new HashSet<>(super.getSingletons());
         addService(singletons, graphResource);
         addService(singletons, fileModelResource);
+        addService(singletons, migrationIssuesEndpoint);
         return singletons;
     }
 

--- a/services/src/main/resources/META-INF/persistence.xml
+++ b/services/src/main/resources/META-INF/persistence.xml
@@ -2,10 +2,10 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
   <persistence-unit name="windup-web-services-persistence-unit" transaction-type="JTA">
     <description>Windup Persistence Unit</description>
-    <jta-data-source>java:jboss/datasources/WindupServicesDS</jta-data-source>
+    <jta-data-source>java:jboss/datasources/WindupServicesDSPermanent</jta-data-source>
     <exclude-unlisted-classes>false</exclude-unlisted-classes>
     <properties>
-      <property name="hibernate.hbm2ddl.auto" value="create"/>
+      <property name="hibernate.hbm2ddl.auto" value="update"/>
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.format_sql" value="false"/>
       <property name="hibernate.transaction.flush_before_completion" value="true"/>

--- a/services/src/main/webapp/WEB-INF/web.xml
+++ b/services/src/main/webapp/WEB-INF/web.xml
@@ -23,7 +23,7 @@
         <servlet-name>FileServlet</servlet-name>
         <url-pattern>/staticReport/*</url-pattern>
     </servlet-mapping>
-
+<!--
     <security-constraint>
         <web-resource-collection>
             <web-resource-name>secured</web-resource-name>
@@ -33,7 +33,7 @@
             <role-name>user</role-name>
         </auth-constraint>
     </security-constraint>
-
+-->
     <login-config>
         <auth-method>KEYCLOAK</auth-method>
     </login-config>

--- a/services/src/main/webapp/WEB-INF/windupservices-ds.xml
+++ b/services/src/main/webapp/WEB-INF/windupservices-ds.xml
@@ -10,4 +10,15 @@
             <password>sa</password>
         </security>
     </datasource>
+    <datasource jndi-name="java:jboss/datasources/WindupServicesDSPermanent" pool-name="WindupServicesPool">
+        <connection-url>jdbc:h2:${jboss.server.data.dir}${/}h2${/}windup-web</connection-url>
+        <driver>h2</driver>
+        <pool>
+            <max-pool-size>30</max-pool-size>
+        </pool>
+        <security>
+            <user-name>sa</user-name>
+            <password>sa</password>
+        </security>
+    </datasource>
 </datasources>


### PR DESCRIPTION
Work in progress, still has issues with ClassCastException. Currently depends on https://github.com/windup/windup/pull/1031 

`org.jboss.resteasy.spi.UnhandledException: java.lang.ClassCastException: com.tinkerpop.frames.FramedGraphQuery_$$_javassist_34027636-11e4-4b26-8837-82ae4130cf08 cannot be cast to org.jboss.windup.graph.frames.TypeAwareFramedGraphQuery`
More details: http://pastebin.com/sdvPaPnQ 

This exception occurs when

`GraphService.getUnique()` is called, more specifically in 

`protected FramedGraphQuery findAllQuery()
    {
        return context.getQuery().type(type);
    }`

this method. Note: `getQuery()` seems to correctly return `TypeAwareFramedGraphQuery` instance, but DI container then messes it up and creates some kind of incompatible proxy class or whatever and it doesn't work. 
