### PR TITLE
Set webpack version to beta.25.

### DIFF
--- a/ui/src/main/webapp/package.json
+++ b/ui/src/main/webapp/package.json
@@ -109,7 +109,7 @@
     "typescript": "2.0.2",
     "typings": "1.4.0",
     "url-loader": "^0.5.6",
-    "webpack": "^2.1.0-beta.25",
+    "webpack": "2.1.0-beta.25",
     "webpack-dev-server": "2.1.0-beta.9"
   }
 }


### PR DESCRIPTION
For now webpack version must be beta.25

They made some backward incompatible changes in 26 causing compilation issues.
For more details see: https://github.com/webpack/webpack/issues/3296