### PR TITLE
364 breadcrumbs

### DIFF
--- a/ui/src/main/webapp/css/windup-web.css
+++ b/ui/src/main/webapp/css/windup-web.css
@@ -1,3 +1,16 @@
 .form-errors {
     margin-bottom: 10px;
 }
+
+.layout-pf.layout-pf-fixed body {
+    padding-top: unset;
+}
+
+.container-fluid {
+    padding-top: 140px;
+}
+
+
+table.datatable, table.dataTable {
+    height: unset;
+}

--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -119,8 +119,7 @@ import {BreadCrumbsService} from "./components/navigation/breadcrumbs.service";
         LoginComponent,
         ContextMenuComponent,
         GroupLayoutComponent,
-        DefaultLayoutComponent
-        MigrationIssuesTableComponent,
+        DefaultLayoutComponent,
         BreadCrumbsNavigationComponent
     ],
     providers: [

--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -65,6 +65,8 @@ import {RouteLinkProviderService} from "./services/route-link-provider-service";
 import {ConfigurationResolve} from "./services/configuration.resolve";
 import {ProjectResolve} from "./services/project.resolve";
 import {ApplicationResolve} from "./services/application.resolve";
+import {BreadCrumbsComponent as BreadCrumbsNavigationComponent} from "./components/navigation/breadcrumbs.component";
+import {BreadCrumbsService} from "./components/navigation/breadcrumbs.service";
 
 
 @NgModule({
@@ -118,6 +120,8 @@ import {ApplicationResolve} from "./services/application.resolve";
         ContextMenuComponent,
         GroupLayoutComponent,
         DefaultLayoutComponent
+        MigrationIssuesTableComponent,
+        BreadCrumbsNavigationComponent
     ],
     providers: [
         appRoutingProviders,
@@ -149,6 +153,7 @@ import {ApplicationResolve} from "./services/application.resolve";
                 return new RouteLinkProviderService(appRoutes);
             }
         },
+        BreadCrumbsService,
         {
             provide: Http,
             useFactory:

--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -67,6 +67,7 @@ import {ProjectResolve} from "./services/project.resolve";
 import {ApplicationResolve} from "./services/application.resolve";
 import {BreadCrumbsComponent as BreadCrumbsNavigationComponent} from "./components/navigation/breadcrumbs.component";
 import {BreadCrumbsService} from "./components/navigation/breadcrumbs.service";
+import {RouteFlattenerService} from "./services/route-flattener.service";
 
 
 @NgModule({
@@ -146,6 +147,7 @@ import {BreadCrumbsService} from "./components/navigation/breadcrumbs.service";
         ConfigurationResolve,
         ProjectResolve,
         ApplicationResolve,
+        RouteFlattenerService,
         {
             provide: RouteLinkProviderService,
             useFactory: () => {

--- a/ui/src/main/webapp/src/app/app.routing.ts
+++ b/ui/src/main/webapp/src/app/app.routing.ts
@@ -51,56 +51,63 @@ export const appRoutes: Routes = [
             },
             {
                 path: 'projects',
-                component: DefaultLayoutComponent,
                 children: [
-                    {path: '', component: ProjectListComponent, data: {displayName: "Project List"}},
-                    {path: 'create', component: MigrationProjectFormComponent, data: {displayName: 'Create Project'}},
+                    {path: '', component: DefaultLayoutComponent, children: [
+                        {path: '', component: ProjectListComponent, data: {displayName: "Project List"}},
+                        {path: 'create', component: MigrationProjectFormComponent, data: {displayName: 'Create Project'}},
+                    ]},
                     {
                         path: ':projectId',
-                        data: {displayName: 'Group List'},
+                        data: {
+                            breadcrumbTitle: (route: FullFlattenedRoute) => {
+                                return `Project ${route.data['project'].title}`;
+                            }
+                        },
                         resolve: {
                             project: ProjectResolve
                         },
                         children: [
-                            {path: '', component: GroupListComponent, data: {displayName: 'Group List'}},
-                            {path: 'edit', component: MigrationProjectFormComponent, data: {displayName: 'Edit Project'}},
-                            {path: 'groups/create', component: ApplicationGroupForm, data: {displayName: 'Create Application Group'}},
+                            { path: '', component: DefaultLayoutComponent, children: [
+                                {path: '', component: GroupListComponent, data: {displayName: 'Group List'}},
+                                {path: 'edit', component: MigrationProjectFormComponent, data: {displayName: 'Edit Project'}},
+                                {path: 'groups/create', component: ApplicationGroupForm, data: {displayName: 'Create Application Group'}},
+                            ]},
+                            {
+                                path: 'groups/:groupId',
+                                component: GroupLayoutComponent,
+                                resolve: {
+                                    applicationGroup: ApplicationGroupResolve
+                                },
+                                data: {
+                                    breadcrumbTitle: (route: FullFlattenedRoute) => {
+                                        return `Group ${route.data['applicationGroup'].title}`;
+                                    }
+                                },
+                                children: [
+                                    { path: '', component: GroupPageComponent },
+                                    { path: 'edit', component: ApplicationGroupForm, data: {displayName: 'Edit Application Group'}},
+                                    { path: 'analysis-context', component: AnalysisContextFormComponent, data: {displayName: "Edit Analysis Context"}, canDeactivate: [ConfirmDeactivateGuard]},
+                                    { path: 'applications', children: [
+                                        { path: 'register', component: RegisterApplicationFormComponent, data: {displayName: "Application Registration"}},
+                                        {
+                                            path: ':applicationId/edit',
+                                            component: EditApplicationFormComponent,
+                                            resolve: {
+                                                application: ApplicationResolve
+                                            },
+                                            data: {displayName: "Edit Application"}
+                                        },
+                                    ]},
+                                    { path: 'reports/:executionId', children: [
+                                        {path: 'technology-report', component: TechnologiesReportComponent, data: {displayName: 'Technology Report'}},
+                                        {path: 'migration-issues', component: MigrationIssuesComponent, data: {displayName: 'Migration Issues'}}
+                                    ]}
+                                ]
+                            },
                         ]
                     }
                 ]
-            },
-            {
-                path: 'groups/:groupId',
-                component: GroupLayoutComponent,
-                resolve: {
-                    applicationGroup: ApplicationGroupResolve
-                },
-                data: {
-                    breadcrumbTitle: (route: FullFlattenedRoute) => {
-                        return `Group ${route.data['applicationGroup'].title}`;
-                    }
-                },
-                children: [
-                    { path: '', component: GroupPageComponent },
-                    { path: 'edit', component: ApplicationGroupForm, data: {displayName: 'Edit Application Group'}},
-                    { path: 'analysis-context', component: AnalysisContextFormComponent, data: {displayName: "Edit Analysis Context"}, canDeactivate: [ConfirmDeactivateGuard]},
-                    { path: 'applications', children: [
-                        { path: 'register', component: RegisterApplicationFormComponent, data: {displayName: "Application Registration"}},
-                        {
-                            path: ':applicationId/edit',
-                            component: EditApplicationFormComponent,
-                            resolve: {
-                                application: ApplicationResolve
-                            },
-                            data: {displayName: "Edit Application"}
-                        },
-                    ]},
-                    { path: 'reports/:executionId', children: [
-                        {path: 'technology-report', component: TechnologiesReportComponent, data: {displayName: 'Technology Report'}},
-                        {path: 'migration-issues', component: MigrationIssuesComponent, data: {displayName: 'Migration Issues'}}
-                    ]}
-                ]
-            },
+            }
         ]
     }
 ];

--- a/ui/src/main/webapp/src/app/app.routing.ts
+++ b/ui/src/main/webapp/src/app/app.routing.ts
@@ -19,6 +19,7 @@ import {MigrationIssuesComponent} from "./components/reports/migration-issues/mi
 import {ProjectResolve} from "./services/project.resolve";
 import {ConfigurationResolve} from "./services/configuration.resolve";
 import {ApplicationResolve} from "./services/application.resolve";
+import {FullFlattenedRoute} from "./services/route-flattener.service";
 
 export const appRoutes: Routes = [
     {path: "login", component: LoginComponent},
@@ -75,7 +76,9 @@ export const appRoutes: Routes = [
                     applicationGroup: ApplicationGroupResolve
                 },
                 data: {
-                    breadcrumbTitle: 'Group {applicationGroup.title}'
+                    breadcrumbTitle: (route: FullFlattenedRoute) => {
+                        return `Group ${route.data['applicationGroup'].title}`;
+                    }
                 },
                 children: [
                     { path: '', component: GroupPageComponent },

--- a/ui/src/main/webapp/src/app/app.routing.ts
+++ b/ui/src/main/webapp/src/app/app.routing.ts
@@ -45,7 +45,7 @@ export const appRoutes: Routes = [
                         }
                     },
                     {path: "project-list",           component: ProjectListComponent,   data: {displayName: "Project List"}},
-                    {path: "application-group-form", component: ApplicationGroupForm,             data: {displayName: "Edit Application Group"}}
+                    {path: "application-group-form", component: ApplicationGroupForm,   data: {displayName: "Edit Application Group"}}
                 ]
             },
             {
@@ -74,6 +74,9 @@ export const appRoutes: Routes = [
                 resolve: {
                     applicationGroup: ApplicationGroupResolve
                 },
+                data: {
+                    breadcrumbTitle: 'Group {applicationGroup.title}'
+                },
                 children: [
                     { path: '', component: GroupPageComponent },
                     { path: 'edit', component: ApplicationGroupForm, data: {displayName: 'Edit Application Group'}},
@@ -91,7 +94,7 @@ export const appRoutes: Routes = [
                     ]},
                     { path: 'reports/:executionId', children: [
                         {path: 'technology-report', component: TechnologiesReportComponent, data: {displayName: 'Technology Report'}},
-                        {path: 'migration-issues', component: MigrationIssuesComponent}
+                        {path: 'migration-issues', component: MigrationIssuesComponent, data: {displayName: 'Migration Issues'}}
                     ]}
                 ]
             },

--- a/ui/src/main/webapp/src/app/components/group-list.component.html
+++ b/ui/src/main/webapp/src/app/components/group-list.component.html
@@ -13,7 +13,7 @@
 <tbody>
     <tr *ngFor="let group of groups" class="group">
         <td class="title">
-            <a [routerLink]="['/groups', group.id]">{{group.title}}</a>
+            <a [routerLink]="['/projects/' + project.id + '/groups', group.id]">{{group.title}}</a>
 
             <a *ngIf="!group.readOnly" href="#" (click)="editGroup(group, $event)">
                 <span class="glyphicon glyphicon-pencil"></span>
@@ -23,7 +23,7 @@
             <span *ngFor="let app of group.applications; let i = index;">{{i > 0 ? "," : ""}} {{app.title}}</span>
         </td>
         <td class="actions">
-            <a [routerLink]="['/groups/' + group.id + '/analysis-context']">Edit Analysis Configuration</a>
+            <a [routerLink]="['/projects/' + project.id + '/groups/' + group.id + '/analysis-context']">Edit Analysis Configuration</a>
             <span *ngIf="groupReportURL(group) != null">
                 |
                 <a target="_blank" href="{{groupReportURL(group)}}">

--- a/ui/src/main/webapp/src/app/components/layout/group-layout.component.ts
+++ b/ui/src/main/webapp/src/app/components/layout/group-layout.component.ts
@@ -10,6 +10,7 @@ import {AnalysisContextFormComponent} from "../analysis-context-form.component";
 import {NotificationService} from "../../services/notification.service";
 import {GroupListComponent} from "../group-list.component";
 import {utils} from '../../utils';
+import {GroupPageComponent} from "../group.page.component";
 
 
 @Component({
@@ -50,13 +51,17 @@ export class GroupLayoutComponent implements OnInit {
             },
             {
                 label: 'Applications',
-                link: '/groups/' + this.applicationGroup.id,
+                link: this._routeLinkProviderService.getRouteForComponent(GroupPageComponent, {
+                    projectId: this.applicationGroup.migrationProject.id,
+                    groupId: this.applicationGroup.id
+                }),
                 icon: 'fa-cubes',
                 isEnabled: true
             },
             {
                 label: 'Config',
                 link: this._routeLinkProviderService.getRouteForComponent(AnalysisContextFormComponent, {
+                    projectId: this.applicationGroup.migrationProject.id,
                     groupId: this.applicationGroup.id
                 }),
                 icon: 'fa-cogs',

--- a/ui/src/main/webapp/src/app/components/layout/group-layout.component.ts
+++ b/ui/src/main/webapp/src/app/components/layout/group-layout.component.ts
@@ -16,7 +16,7 @@ import {GroupPageComponent} from "../group.page.component";
 @Component({
     templateUrl: './group-layout.component.html',
     styles: [
-        `:host /deep/ .nav-pf-vertical { top: 82px; }`
+        `:host /deep/ .nav-pf-vertical { top: 139px; }`
     ]
 })
 export class GroupLayoutComponent implements OnInit {

--- a/ui/src/main/webapp/src/app/components/navbar.component.html
+++ b/ui/src/main/webapp/src/app/components/navbar.component.html
@@ -33,5 +33,5 @@
             </li>
         </ul>
     </div>
+    <wu-breadcrumbs></wu-breadcrumbs>
 </nav>
-<wu-breadcrumbs></wu-breadcrumbs>

--- a/ui/src/main/webapp/src/app/components/navbar.component.html
+++ b/ui/src/main/webapp/src/app/components/navbar.component.html
@@ -34,3 +34,4 @@
         </ul>
     </div>
 </nav>
+<wu-breadcrumbs></wu-breadcrumbs>

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs-link.interface.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs-link.interface.ts
@@ -1,0 +1,4 @@
+export interface BreadCrumbLink {
+    name: string;
+    route: any[];
+}

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.html
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.html
@@ -1,6 +1,6 @@
 <ol class="breadcrumb">
     <li *ngFor="let link of breadCrumbLinks" [ngClass]="{'active': last}">
         <a *ngIf="!last" [routerLink]="link.route">{{link.name}}</a>
-        <a *ngIf="last">{{link.name}}</a>
+        <span *ngIf="last">{{link.name}}</span>
     </li>
 </ol>

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.html
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.html
@@ -1,0 +1,6 @@
+<ol class="breadcrumb">
+    <li *ngFor="let link of breadCrumbLinks" [ngClass]="{'active': last}">
+        <a *ngIf="!last" [routerLink]="link.route">{{link.name}}</a>
+        <a *ngIf="last">{{link.name}}</a>
+    </li>
+</ol>

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
@@ -98,7 +98,7 @@ export class BreadCrumbsComponent implements OnInit, OnDestroy {
 
         snapshotData.reduce((previous, current) => {
             let sum = {
-                name: this.getName(current.snapshot),
+                name: this.getName(current.snapshot, route),
                 route: previous.route + current.route,
                 snapshot: current.snapshot
             };
@@ -113,11 +113,13 @@ export class BreadCrumbsComponent implements OnInit, OnDestroy {
         console.log(links);
     }
 
-    protected getName(route: ActivatedRouteSnapshot) {
+    protected getName(route: ActivatedRouteSnapshot, flattenedRouteData: FlattenedRouteData) {
         if (route.data && route.data.hasOwnProperty('breadcrumbTitle')) {
-            //let placeholders = route.data.breadcrumbTitle._lastCasesMatched
-
-            return route.data['breadcrumbTitle'];
+            if (typeof route.data['breadcrumbTitle'] === 'function') {
+                return route.data['breadcrumbTitle'](flattenedRouteData);
+            } else {
+                return route.data['breadcrumbTitle'];
+            }
         } else if (route.data && route.data.hasOwnProperty('displayName')) {
             return route.data['displayName'];
         } else {

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
@@ -1,23 +1,33 @@
-import {Component, OnInit} from "@angular/core";
+import {Component, OnInit, OnDestroy} from "@angular/core";
 import {BreadCrumbsService, BreadCrumbLink} from "./breadcrumbs.service";
 import {Router, NavigationEnd, ActivatedRoute} from "@angular/router";
+import {Subscription} from "rxjs";
+import {RouteFlattenerService} from "../../services/route-flattener.service";
 
 @Component({
     selector: 'wu-breadcrumbs',
     templateUrl: './breadcrumbs.component.html'
 })
-export class BreadCrumbsComponent implements OnInit {
+export class BreadCrumbsComponent implements OnInit, OnDestroy {
 
     breadCrumbLinks: BreadCrumbLink[] = [];
+    subscription: Subscription;
 
+    constructor(
+        private _router: Router,
+        private _activatedRoute: ActivatedRoute,
+        private _breadCrumbsService: BreadCrumbsService,
+        private _routeFlattener: RouteFlattenerService
+    ) {
 
-    constructor(private _router: Router, private _activatedRoute: ActivatedRoute, private _breadCrumbsService: BreadCrumbsService) {
     }
 
     ngOnInit(): void {
-        this._router.events.filter(event => event instanceof NavigationEnd).subscribe((event: NavigationEnd) => {
+        this.subscription = this._router.events.filter(event => event instanceof NavigationEnd).subscribe((event: NavigationEnd) => {
+            console.log('-------------- Navigation end event ------------------');
             console.log(event);
             console.log(this._activatedRoute.snapshot);
+            console.log(this._routeFlattener.getFlattenedRouteData(this._activatedRoute.snapshot));
         });
         
         let hierarchy = { name: 'Project List', children: [
@@ -47,5 +57,10 @@ export class BreadCrumbsComponent implements OnInit {
             {name: 'Project: Test Project', route: ['/group-list', {projectID: 9}]},
             {name: 'Group: Default Group', route: ['/groups', 8]}
         ];
+    }
+
+
+    ngOnDestroy(): void {
+        this.subscription.unsubscribe();
     }
 }

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
@@ -1,8 +1,7 @@
 import {Component, OnInit, OnDestroy} from "@angular/core";
 import {BreadCrumbsService, BreadCrumbLink} from "./breadcrumbs.service";
-import {Router, NavigationEnd, ActivatedRoute, ActivatedRouteSnapshot, UrlSegment, Route, Data} from "@angular/router";
+import {Router, NavigationEnd, ActivatedRoute} from "@angular/router";
 import {Subscription} from "rxjs";
-import {RouteFlattenerService, FlattenedRouteData} from "../../services/route-flattener.service";
 
 @Component({
     selector: 'wu-breadcrumbs',
@@ -16,160 +15,17 @@ export class BreadCrumbsComponent implements OnInit, OnDestroy {
     constructor(
         private _router: Router,
         private _activatedRoute: ActivatedRoute,
-        private _breadCrumbsService: BreadCrumbsService,
-        private _routeFlattener: RouteFlattenerService
+        private _breadCrumbsService: BreadCrumbsService
     ) {
     }
 
     ngOnInit(): void {
         this.subscription = this._router.events.filter(event => event instanceof NavigationEnd).subscribe(_ => {
-            let flattenedRouteData = this._routeFlattener.getFlattenedRouteData(this._activatedRoute.snapshot);
-            this.breadCrumbLinks = this.getBreadCrumbLinks(flattenedRouteData);
+            this.breadCrumbLinks = this._breadCrumbsService.getBreadCrumbLinks(this._activatedRoute.snapshot);
         });
-    }
-
-    protected getBreadCrumbLinks(route: FlattenedRouteData): BreadCrumbLink[] {
-        let breadCrumbParts = this.getBreadCrumbParts(route);
-
-        return breadCrumbParts.map(part => {
-            return {
-                name: part.name,
-                route: [part.route],
-            };
-        })
-    }
-
-    /**
-     * This method get bread crumb parts from route
-     *
-     *
-     * I have /project/10/groups/15/reports/21/migration-issues
-     *
-     * And I need to get
-     * /projects
-     * /projects/10
-     * /projects/10/groups/
-     * /projects/10/groups/15
-     * /projects/10/groups/15/reports/21/migration-issues
-     *
-     */
-    protected getBreadCrumbParts(route: FlattenedRouteData) {
-        /*
-         * Route must have component or resolve to have special meaning. If it doesn't have a component, join it with previous one
-         */
-        let snapshotData = route.snapshotsHierarchy.filter(snapshot => {
-            return snapshot.url.length > 0 || (snapshot.routeConfig && snapshot.routeConfig.resolve);
-        }).map((snapshot: ActivatedRouteSnapshot) => {
-            return {
-                name: '',
-                route: snapshot.url.map((url: UrlSegment) => url.path).reduce((previous, current) => previous + "/" + current, ""),
-                snapshot: snapshot
-            };
-        });
-
-        let links = [];
-
-        snapshotData.reduce((previous, current) => {
-            let endRoute = this.getEndRoute(current.snapshot.routeConfig);
-
-            let sum = {
-                name: this.getName(current.snapshot, endRoute, route),
-                route: previous.route + current.route,
-                snapshot: current.snapshot
-            };
-
-            if (this.canReachToComponentRoute(current.snapshot.routeConfig)) {
-                links.push(sum);
-            }
-
-            return sum;
-        }, {name: '', route: '', snapshot: null});
-
-        return links;
-    }
-
-    protected getEndRoute(route: Route) {
-        let children = [];
-
-        if (route.children) {
-            children = route.children.filter(child => child.path === '' || child.path === '**');
-        }
-
-        if (children.length == 0) {
-            return route; // Do we care if it has component?
-        } else {
-            return this.getEndRoute(children[0]);
-        }
-    }
-
-    protected canReachToComponentRoute(route: Route) {
-        if (route.component) {
-            return true;
-        } else {
-            return route.children.filter(child => child.path === '' || child.path === '**')
-                .map(child => this.canReachToComponentRoute(child))
-                .reduce((previous, current) => previous || current, false);
-        }
-    }
-
-    protected getName(snapshot: ActivatedRouteSnapshot, route: Route, flattenedRouteData: FlattenedRouteData) {
-        if (snapshot.data && (snapshot.data.hasOwnProperty('breadcrumbTitle') || snapshot.data.hasOwnProperty('displayName'))) {
-            return this.getNameFromData(snapshot.data, flattenedRouteData);
-        } else {
-            return this.getNameFromData(route.data, flattenedRouteData);
-        }
-    }
-
-    protected getNameFromData(data: Data, flattenedRouteData: FlattenedRouteData) {
-        if (!data) {
-            return '';
-        }
-
-        if (data.hasOwnProperty('breadcrumbTitle')) {
-            if (typeof data['breadcrumbTitle'] === 'function') {
-                return data['breadcrumbTitle'](flattenedRouteData);
-            } else {
-                return data['breadcrumbTitle'];
-            }
-        } else if (data.hasOwnProperty('displayName')) {
-            return data['displayName'];
-        } else {
-            return '';
-        }
     }
 
     ngOnDestroy(): void {
         this.subscription.unsubscribe();
     }
 }
-
-/*
- * Available routes:
- *
- * /login
- *
- * ''/'' - layout
- * ''/''/'' => project-list
- * ''/''/configuration + res
- * ''/''/project-list
- * ''/''/app-group-form
- *
- * ''/projects - layout def.
- * ''/projects/'' project list comp.
- * ''/projects/create
- * ''/projects/:projectId - resolve
- * ''/projects/:projectId/'' - group list
- * ''/projects/:projectId/edit
- * ''/projects/:projectId/groups/create
- *
- * ''/groups/:groupId - layout, resolve
- * ''/groups/:groupId/'' - page
- * ''/groups/:groupId/edit
- * ''/groups/:groupId/analysis-context
- * ''/groups/:groupId/applications !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!(NOTHING!)
- * ''/groups/:groupId/applications/register
- * ''/groups/:groupId/applications/:applicationId/edit
- * ''/groups/:groupId/reports/:executionId !!!!!!!!!!!!!!!!!!!!!!!!!(NOTHING)
- * ''/groups/:groupId/reports/:executionId/tech-report
- * ''/groups/:groupId/reports/:executionId/migration-issues
- */

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
@@ -1,8 +1,8 @@
 import {Component, OnInit, OnDestroy} from "@angular/core";
 import {BreadCrumbsService, BreadCrumbLink} from "./breadcrumbs.service";
-import {Router, NavigationEnd, ActivatedRoute} from "@angular/router";
+import {Router, NavigationEnd, ActivatedRoute, ActivatedRouteSnapshot, UrlSegment} from "@angular/router";
 import {Subscription} from "rxjs";
-import {RouteFlattenerService} from "../../services/route-flattener.service";
+import {RouteFlattenerService, FlattenedRouteData} from "../../services/route-flattener.service";
 
 @Component({
     selector: 'wu-breadcrumbs',
@@ -12,6 +12,8 @@ export class BreadCrumbsComponent implements OnInit, OnDestroy {
 
     breadCrumbLinks: BreadCrumbLink[] = [];
     subscription: Subscription;
+    routeParentMap: Map<string, FlattenedRouteData>;
+
 
     constructor(
         private _router: Router,
@@ -19,48 +21,146 @@ export class BreadCrumbsComponent implements OnInit, OnDestroy {
         private _breadCrumbsService: BreadCrumbsService,
         private _routeFlattener: RouteFlattenerService
     ) {
+        this.routeParentMap = new Map<string, FlattenedRouteData>();
+       /*
+        this.routeParentMap.set('groups/:groupId', {
 
+        });
+        */
     }
 
     ngOnInit(): void {
-        this.subscription = this._router.events.filter(event => event instanceof NavigationEnd).subscribe((event: NavigationEnd) => {
-            console.log('-------------- Navigation end event ------------------');
-            console.log(event);
-            console.log(this._activatedRoute.snapshot);
-            console.log(this._routeFlattener.getFlattenedRouteData(this._activatedRoute.snapshot));
+        this.subscription = this._router.events.filter(event => event instanceof NavigationEnd).subscribe(_ => {
+            let flattenedRouteData = this._routeFlattener.getFlattenedRouteData(this._activatedRoute.snapshot);
+            this.getBreadCrumbParts(flattenedRouteData);
         });
-        
-        let hierarchy = { name: 'Project List', children: [
-            { name: 'Project',  children: [
-                { name: 'Group', children: [
-                    { name: 'Application', children: [
-                        { name: 'Add' },
-                        { name: 'Edit' },
-                        { name: 'Report?' }
-                    ]},
-                    { name: 'Analysis Configuration' },
-                    { name: 'Executions', children: [
-                        { name: 'Execution' }
-                    ]},
-                    { name: 'Reports (Dashboard)', children: [
-                        { name: 'Technologies' },
-                        { name: 'Issues' },
-                        { name: 'Dependencies' }
+
+        /*
+            let hierarchy = { name: 'Project List', children: [
+                { name: 'Project',  children: [
+                    { name: 'Group', children: [
+                        { name: 'Application', children: [
+                            { name: 'Add' },
+                            { name: 'Edit' }
+                        ]},
+                        { name: 'Analysis Configuration' },
+                        { name: 'Executions', children: [
+                            { name: 'Execution' }
+                        ]},
+                        { name: 'Reports (Dashboard)', children: [
+                            { name: 'Technologies' },
+                            { name: 'Issues' },
+                            { name: 'Dependencies' }
+                        ]}
                     ]}
                 ]}
-            ]}
-        ]};
-
+            ]};
+        */
+/*
 
         this.breadCrumbLinks = [
             {name: 'Project List', route: ['/project-list']},
             {name: 'Project: Test Project', route: ['/group-list', {projectID: 9}]},
             {name: 'Group: Default Group', route: ['/groups', 8]}
         ];
+        */
     }
 
+    /**
+     * This method get bread crumb parts from route
+     *
+     *
+     * I have /project/10/groups/15/reports/21/migration-issues
+     *
+     * And I need to get
+     * /projects
+     * /projects/10
+     * /projects/10/groups/
+     * /projects/10/groups/15
+     * /projects/10/groups/15/reports/21/migration-issues
+     *
+     */
+    protected getBreadCrumbParts(route: FlattenedRouteData) {
+        /*
+         * Route must have component or resolve to have special meaning. If it doesn't have a component, join it with previous one
+         */
+        let snapshotData = route.snapshotsHierarchy.filter(snapshot => {
+            return snapshot.url.length > 0 || (snapshot.routeConfig && snapshot.routeConfig.resolve);
+        }).map((snapshot: ActivatedRouteSnapshot) => {
+            return {
+                name: '',
+                route: snapshot.url.map((url: UrlSegment) => url.path).reduce((previous, current) => previous + "/" + current, ""),
+                snapshot: snapshot
+            };
+        });
+
+        let links = [];
+
+        snapshotData.reduce((previous, current) => {
+            let sum = {
+                name: this.getName(current.snapshot),
+                route: previous.route + current.route,
+                snapshot: current.snapshot
+            };
+
+            if (current.snapshot.component) {
+                links.push(sum);
+            }
+
+            return sum;
+        }, {name: '', route: '', snapshot: null});
+
+        console.log(links);
+    }
+
+    protected getName(route: ActivatedRouteSnapshot) {
+        if (route.data && route.data.hasOwnProperty('breadcrumbTitle')) {
+            //let placeholders = route.data.breadcrumbTitle._lastCasesMatched
+
+            return route.data['breadcrumbTitle'];
+        } else if (route.data && route.data.hasOwnProperty('displayName')) {
+            return route.data['displayName'];
+        } else {
+            return '';
+        }
+    }
+
+    protected getHiddenParent(route: FlattenedRouteData) {
+
+    }
 
     ngOnDestroy(): void {
         this.subscription.unsubscribe();
     }
 }
+
+/*
+ * Available routes:
+ *
+ * /login
+ *
+ * ''/'' - layout
+ * ''/''/'' => project-list
+ * ''/''/configuration + res
+ * ''/''/project-list
+ * ''/''/app-group-form
+ *
+ * ''/projects - layout def.
+ * ''/projects/'' project list comp.
+ * ''/projects/create
+ * ''/projects/:projectId - resolve
+ * ''/projects/:projectId/'' - group list
+ * ''/projects/:projectId/edit
+ * ''/projects/:projectId/groups/create
+ *
+ * ''/groups/:groupId - layout, resolve
+ * ''/groups/:groupId/'' - page
+ * ''/groups/:groupId/edit
+ * ''/groups/:groupId/analysis-context
+ * ''/groups/:groupId/applications !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!(NOTHING!)
+ * ''/groups/:groupId/applications/register
+ * ''/groups/:groupId/applications/:applicationId/edit
+ * ''/groups/:groupId/reports/:executionId !!!!!!!!!!!!!!!!!!!!!!!!!(NOTHING)
+ * ''/groups/:groupId/reports/:executionId/tech-report
+ * ''/groups/:groupId/reports/:executionId/migration-issues
+ */

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
@@ -1,0 +1,51 @@
+import {Component, OnInit} from "@angular/core";
+import {BreadCrumbsService, BreadCrumbLink} from "./breadcrumbs.service";
+import {Router, NavigationEnd, ActivatedRoute} from "@angular/router";
+
+@Component({
+    selector: 'wu-breadcrumbs',
+    templateUrl: './breadcrumbs.component.html'
+})
+export class BreadCrumbsComponent implements OnInit {
+
+    breadCrumbLinks: BreadCrumbLink[] = [];
+
+
+    constructor(private _router: Router, private _activatedRoute: ActivatedRoute, private _breadCrumbsService: BreadCrumbsService) {
+    }
+
+    ngOnInit(): void {
+        this._router.events.filter(event => event instanceof NavigationEnd).subscribe((event: NavigationEnd) => {
+            console.log(event);
+            console.log(this._activatedRoute.snapshot);
+        });
+        
+        let hierarchy = { name: 'Project List', children: [
+            { name: 'Project',  children: [
+                { name: 'Group', children: [
+                    { name: 'Application', children: [
+                        { name: 'Add' },
+                        { name: 'Edit' },
+                        { name: 'Report?' }
+                    ]},
+                    { name: 'Analysis Configuration' },
+                    { name: 'Executions', children: [
+                        { name: 'Execution' }
+                    ]},
+                    { name: 'Reports (Dashboard)', children: [
+                        { name: 'Technologies' },
+                        { name: 'Issues' },
+                        { name: 'Dependencies' }
+                    ]}
+                ]}
+            ]}
+        ]};
+
+
+        this.breadCrumbLinks = [
+            {name: 'Project List', route: ['/project-list']},
+            {name: 'Project: Test Project', route: ['/group-list', {projectID: 9}]},
+            {name: 'Group: Default Group', route: ['/groups', 8]}
+        ];
+    }
+}

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit, OnDestroy} from "@angular/core";
 import {BreadCrumbsService, BreadCrumbLink} from "./breadcrumbs.service";
-import {Router, NavigationEnd, ActivatedRoute, ActivatedRouteSnapshot, UrlSegment} from "@angular/router";
+import {Router, NavigationEnd, ActivatedRoute, ActivatedRouteSnapshot, UrlSegment, Route} from "@angular/router";
 import {Subscription} from "rxjs";
 import {RouteFlattenerService, FlattenedRouteData} from "../../services/route-flattener.service";
 
@@ -103,7 +103,7 @@ export class BreadCrumbsComponent implements OnInit, OnDestroy {
                 snapshot: current.snapshot
             };
 
-            if (current.snapshot.component) {
+            if (this.canReachToComponentRoute(current.snapshot.routeConfig)) {
                 links.push(sum);
             }
 
@@ -111,6 +111,16 @@ export class BreadCrumbsComponent implements OnInit, OnDestroy {
         }, {name: '', route: '', snapshot: null});
 
         console.log(links);
+    }
+
+    protected canReachToComponentRoute(route: Route) {
+        if (route.component) {
+            return true;
+        } else {
+            return route.children.filter(child => child.path === '' || child.path === '**')
+                .map(child => this.canReachToComponentRoute(child))
+                .reduce((previous, current) => previous || current, false);
+        }
     }
 
     protected getName(route: ActivatedRouteSnapshot, flattenedRouteData: FlattenedRouteData) {

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.service.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.service.ts
@@ -1,29 +1,122 @@
 import {Injectable} from "@angular/core";
-import {Observable, Subject} from "rxjs";
-
+import {ActivatedRouteSnapshot, UrlSegment, Route, Data} from "@angular/router";
+import {RouteFlattenerService, FlattenedRouteData} from "../../services/route-flattener.service";
 
 @Injectable()
 export class BreadCrumbsService {
+    constructor(private _routeFlattener: RouteFlattenerService) {
 
-    breadCrumbsSubject: Subject<BreadCrumbLink[]>;
-    breadCrumbsObservable: Observable<BreadCrumbLink[]>;
-
-    breadCrumbLinks: BreadCrumbLink[] = [];
-
-    constructor() {
-        this.breadCrumbsSubject = new Subject<BreadCrumbLink[]>();
-        this.breadCrumbsObservable = this.breadCrumbsSubject.asObservable();
     }
 
+    public getBreadCrumbLinks(route: ActivatedRouteSnapshot): BreadCrumbLink[] {
+        let flattenedRouteData = this._routeFlattener.getFlattenedRouteData(route);
+        let breadCrumbParts = this.getBreadCrumbParts(flattenedRouteData);
 
-
-    public get breadcrumbs(): Observable<BreadCrumbLink[]> {
-        return this.breadCrumbsObservable;
+        return breadCrumbParts.map(part => {
+            return {
+                name: part.name,
+                route: [part.route],
+            };
+        })
     }
 
-    public addLink(link: BreadCrumbLink): void {
-        this.breadCrumbLinks.push(link);
-        this.breadCrumbsSubject.next(this.breadCrumbLinks);
+    /**
+     * This method get bread crumb parts from route
+     *
+     *
+     * I have /project/10/groups/15/reports/21/migration-issues
+     *
+     * And I need to get
+     * /projects
+     * /projects/10
+     * /projects/10/groups/
+     * /projects/10/groups/15
+     * /projects/10/groups/15/reports/21/migration-issues
+     *
+     */
+    protected getBreadCrumbParts(route: FlattenedRouteData) {
+        /*
+         * Route must have component or resolve to have special meaning. If it doesn't have a component, join it with previous one
+         */
+        let snapshotData = route.snapshotsHierarchy.filter(snapshot => {
+            return snapshot.url.length > 0 || (snapshot.routeConfig && snapshot.routeConfig.resolve);
+        }).map((snapshot: ActivatedRouteSnapshot) => {
+            return {
+                name: '',
+                route: snapshot.url.map((url: UrlSegment) => url.path).reduce((previous, current) => previous + "/" + current, ""),
+                snapshot: snapshot
+            };
+        });
+
+        let links = [];
+
+        snapshotData.reduce((previous, current) => {
+            let endRoute = this.getEndRoute(current.snapshot.routeConfig);
+
+            let sum = {
+                name: this.getName(current.snapshot, endRoute, route),
+                route: previous.route + current.route,
+                snapshot: current.snapshot
+            };
+
+            if (this.canReachToComponentRoute(current.snapshot.routeConfig)) {
+                links.push(sum);
+            }
+
+            return sum;
+        }, {name: '', route: '', snapshot: null});
+
+        return links;
+    }
+
+    protected getEndRoute(route: Route) {
+        let children = [];
+
+        if (route.children) {
+            children = route.children.filter(child => child.path === '' || child.path === '**');
+        }
+
+        if (children.length == 0) {
+            return route; // Do we care if it has component?
+        } else {
+            return this.getEndRoute(children[0]);
+        }
+    }
+
+    protected canReachToComponentRoute(route: Route) {
+        if (route.component) {
+            return true;
+        } else {
+            return route.children.filter(child => child.path === '' || child.path === '**')
+                .map(child => this.canReachToComponentRoute(child))
+                .reduce((previous, current) => previous || current, false);
+        }
+    }
+
+    protected getName(snapshot: ActivatedRouteSnapshot, route: Route, flattenedRouteData: FlattenedRouteData) {
+        if (snapshot.data && (snapshot.data.hasOwnProperty('breadcrumbTitle') || snapshot.data.hasOwnProperty('displayName'))) {
+            return this.getNameFromData(snapshot.data, flattenedRouteData);
+        } else {
+            return this.getNameFromData(route.data, flattenedRouteData);
+        }
+    }
+
+    protected getNameFromData(data: Data, flattenedRouteData: FlattenedRouteData) {
+        if (!data) {
+            return '';
+        }
+
+        if (data.hasOwnProperty('breadcrumbTitle')) {
+            if (typeof data['breadcrumbTitle'] === 'function') {
+                return data['breadcrumbTitle'](flattenedRouteData);
+            } else {
+                return data['breadcrumbTitle'];
+            }
+        } else if (data.hasOwnProperty('displayName')) {
+            return data['displayName'];
+        } else {
+            return '';
+        }
     }
 }
 
@@ -31,3 +124,34 @@ export interface BreadCrumbLink {
     name: string;
     route: any[];
 }
+
+/*
+ * Available routes:
+ *
+ * /login
+ *
+ * ''/'' - layout
+ * ''/''/'' => project-list
+ * ''/''/configuration + res
+ * ''/''/project-list
+ * ''/''/app-group-form
+ *
+ * ''/projects - layout def.
+ * ''/projects/'' project list comp.
+ * ''/projects/create
+ * ''/projects/:projectId - resolve
+ * ''/projects/:projectId/'' - group list
+ * ''/projects/:projectId/edit
+ * ''/projects/:projectId/groups/create
+ *
+ * ''/groups/:groupId - layout, resolve
+ * ''/groups/:groupId/'' - page
+ * ''/groups/:groupId/edit
+ * ''/groups/:groupId/analysis-context
+ * ''/groups/:groupId/applications !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!(NOTHING!)
+ * ''/groups/:groupId/applications/register
+ * ''/groups/:groupId/applications/:applicationId/edit
+ * ''/groups/:groupId/reports/:executionId !!!!!!!!!!!!!!!!!!!!!!!!!(NOTHING)
+ * ''/groups/:groupId/reports/:executionId/tech-report
+ * ''/groups/:groupId/reports/:executionId/migration-issues
+ */

--- a/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.service.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/breadcrumbs.service.ts
@@ -1,0 +1,33 @@
+import {Injectable} from "@angular/core";
+import {Observable, Subject} from "rxjs";
+
+
+@Injectable()
+export class BreadCrumbsService {
+
+    breadCrumbsSubject: Subject<BreadCrumbLink[]>;
+    breadCrumbsObservable: Observable<BreadCrumbLink[]>;
+
+    breadCrumbLinks: BreadCrumbLink[] = [];
+
+    constructor() {
+        this.breadCrumbsSubject = new Subject<BreadCrumbLink[]>();
+        this.breadCrumbsObservable = this.breadCrumbsSubject.asObservable();
+    }
+
+
+
+    public get breadcrumbs(): Observable<BreadCrumbLink[]> {
+        return this.breadCrumbsObservable;
+    }
+
+    public addLink(link: BreadCrumbLink): void {
+        this.breadCrumbLinks.push(link);
+        this.breadCrumbsSubject.next(this.breadCrumbLinks);
+    }
+}
+
+export interface BreadCrumbLink {
+    name: string;
+    route: any[];
+}

--- a/ui/src/main/webapp/src/app/components/navigation/context-menu-item.class.ts
+++ b/ui/src/main/webapp/src/app/components/navigation/context-menu-item.class.ts
@@ -74,7 +74,8 @@ export class ReportMenuItem extends ContextMenuItem {
 
         return this._routeLinkProviderService.getRouteForComponent(this.component, {
             groupId: this.applicationGroup.id,
-            executionId: execution.id
+            executionId: execution.id,
+            projectId: this.applicationGroup.migrationProject.id,
         });
     }
 

--- a/ui/src/main/webapp/src/app/services/route-flattener.service.ts
+++ b/ui/src/main/webapp/src/app/services/route-flattener.service.ts
@@ -1,0 +1,236 @@
+import {ActivatedRouteSnapshot, UrlSegment, Params, Data, Route} from "@angular/router";
+import {Type, Injectable} from "@angular/core";
+
+/**
+ * This service is used to get ActivatedRouteSnapshot-like object with flattened data and parameters
+ *
+ * There are several quite annoying issues with angular router, which can be partially used by using this class.
+ * To get correct parameters, inject Router and ActivatedRouteSnapshot into required component.
+ * Listen to router events, when NavigationEnd event occurs, ActivatedRouteSnapshot should be updated.
+ * Then use this service to get required data.
+ *
+ * Related angular issues:
+ * https://github.com/angular/angular/issues/12767 - Router data and parameters not inherited
+ * https://github.com/angular/angular/issues/12306 - Resolve data are not inherited
+ * https://github.com/angular/angular/issues/13058 - My feature request to get some option to inherit router data
+ * https://github.com/angular/angular/issues/11023 - Issue with different level components see different router data
+ *
+ */
+@Injectable()
+export class RouteFlattenerService {
+
+    public getFlattenedRouteData(route: ActivatedRouteSnapshot): FlattenedRouteData {
+        let downLevel = this.getActivatedRouteSnapshotWithChildren(route);
+        downLevel.splice(0, 1);
+        let upLevel = this.getActivatedRouteSnapshotWithParents(route);
+        upLevel.pop();
+
+        let result: FlattenedRouteData = this.mergeAllRoutes(
+            ...upLevel,
+            this.getRoute(route),
+            ...downLevel
+        );
+
+        return result;
+    }
+
+    public getActivatedRouteSnapshotWithParents(route: ActivatedRouteSnapshot): ActivatedRouteSnapshot[] {
+        let result = [ route ];
+
+        if (route.parent) {
+            let parents = this.getActivatedRouteSnapshotWithParents(route.parent);
+            result = parents.concat(result);
+        }
+
+        return result;
+    }
+
+    public getActivatedRouteSnapshotWithChildren(route: ActivatedRouteSnapshot): ActivatedRouteSnapshot[] {
+        let result = [ route ];
+
+        if (route.firstChild) {
+            let children = this.getActivatedRouteSnapshotWithChildren(route.firstChild);
+            result = result.concat(children);
+        }
+
+        return result;
+    }
+
+
+    public getFlattenedRouteBottomUp(route: ActivatedRouteSnapshot, includeSelf: boolean = true): FlattenedRouteData {
+        let result = { params: {}, data: {} };
+
+        if (includeSelf) {
+            result = this.getRoute(route);
+        }
+
+        if (route.parent) {
+            let parent = this.getFlattenedRouteBottomUp(route.parent);
+            result = this.mergeRoutes(parent, result);
+        }
+
+        return result;
+    }
+
+    public getFlattenedRouteTopDown(route: ActivatedRouteSnapshot, includeSelf: boolean = true): FlattenedRouteData {
+        let result = { params: {}, data: {} };
+
+        if (includeSelf) {
+            result = this.getRoute(route);
+        }
+
+        if (route.firstChild) {
+            let child = this.getFlattenedRouteTopDown(route.firstChild);
+            result = this.mergeRoutes(result, child);
+        }
+
+        return result;
+    }
+
+    protected getRoute(route: ActivatedRouteSnapshot): FlattenedRouteData {
+        let result: FlattenedRouteData = Object.assign({
+            snapshotsHierarchy: [ route ],
+            routeConfig: route.routeConfig
+        }, route);
+
+
+        return result;
+    }
+
+    protected getRouteConfigHierarchy(route: FlattenedRouteData): Route[] {
+        let routeConfig = [];
+
+        if (route.routeConfigHierarchy) {
+            routeConfig = [].concat(route.routeConfigHierarchy);
+        } else if (route.routeConfig) {
+            routeConfig = [].concat([ route.routeConfig ]);
+        }
+
+        return routeConfig;
+    }
+
+    protected mergeAllRoutes(...routes: FlattenedRouteData[]): FlattenedRouteData
+    {
+        let result = {
+            data: {},
+            params: {},
+            url: [],
+            routeConfigHierarchy: [],
+            snapshotsHierarchy: []
+        };
+
+        Object.assign(result.data, ...(routes.map(route => route.data)));
+        Object.assign(result.params, ...(routes.map(route => route.params)));
+
+        result.routeConfigHierarchy = [].concat(
+            ...routes.map(route => this.getRouteConfigHierarchy(route))
+        );
+
+        result.snapshotsHierarchy = routes;
+        result.url = routes.map(route => route.url).filter(array => array.length > 0);
+
+        return result;
+    }
+
+    protected mergeRoutes(parent: FlattenedRouteData, child: FlattenedRouteData): FlattenedRouteData {
+        let result = {
+            data: {},
+            params: {},
+            url: [],
+            routeConfigHierarchy: [],
+            snapshotsHierarchy: []
+        };
+
+        Object.assign(result.data, parent.data, child.data);
+        Object.assign(result.params, parent.params, child.params);
+
+        result.routeConfigHierarchy = [].concat(
+            this.getRouteConfigHierarchy(parent),
+            this.getRouteConfigHierarchy(child)
+        );
+
+        result.snapshotsHierarchy = [].concat(parent.snapshotsHierarchy, child.snapshotsHierarchy);
+
+        result.url = parent.url.concat(child.url);
+
+        return result;
+    }
+}
+
+export interface FlattenedRouteData {
+    params: Params;
+    data: Data;
+
+    url?: UrlSegment[];
+    routeConfig?: Route;
+    routeConfigHierarchy?: Route[];
+    snapshotsHierarchy?: ActivatedRouteSnapshot[];
+}
+
+
+export interface FullFlattenedRoute {
+    /**
+     *  The URL segments matched by this route.
+     */
+    url: UrlSegment[];
+
+    /**
+     * The matrix parameters scoped to this route.
+     */
+    params: Params;
+
+    /**
+     * The query parameters shared by all the routes.
+     */
+    queryParams: Params;
+
+    /**
+     * The URL fragment shared by all the routes.
+     */
+    fragment: string;
+
+    /**
+     * The static and resolved data of this route.
+     */
+    data: Data;
+
+    /**
+     * The outlet name of the route.
+     */
+    outlet: string;
+
+    /**
+     * The component of the route.
+     */
+    component: Type<any> | string;
+
+    /**
+     * The configuration used to match this route.
+     */
+    routeConfig: Route;
+
+    /**
+     * The root of the router state.
+     */
+    root: ActivatedRouteSnapshot;
+
+    /**
+     * The parent of this route in the router state tree.
+     */
+    parent: ActivatedRouteSnapshot;
+
+    /**
+     * The first child of this route in the router state tree.
+     */
+    firstChild: ActivatedRouteSnapshot;
+
+    /**
+     * The children of this route in the router state tree.
+     */
+    children: ActivatedRouteSnapshot[];
+
+    /**
+     * The path from the root of the router state tree to this route.
+     */
+    pathFromRoot: ActivatedRouteSnapshot[];
+}


### PR DESCRIPTION
What looked quite simple at the beginning, ended up being quite complex...

There are several problems with Angular 2 router, most significant ones are: 
- `params` and `data` from parent routes are not inherited
- `ActivatedRouteSnapshot` provided to components is different for each level of component based on its position in router-outlet hierarchy

These are solved by `RouteFlattenerService`. This service gets ActivatedRouteSnapshot and traverses its hierarchy up and down and merges required data. It should give the same results independently on current component's placement in hierarchy.

Another non trivial thing is to create breadcrumb links for meaningful parts of URL.

For example:
For given route
`/groups/15/reports/21/migration-issues`

meaningful breadcrumbs are: 

`/groups/15`
`/groups/15/reports/21/migration-issues`

but not
`/groups`
`/groups/15/reports`
`/groups/15/reports/21`

because these routes don't belong to any component.
