### PR TITLE
Fix analysis context not being properly set for user created groups.

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
@@ -20,6 +20,10 @@ import javax.persistence.OneToOne;
 import javax.persistence.Version;
 import javax.validation.Valid;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
@@ -30,6 +34,7 @@ import org.hibernate.annotations.FetchMode;
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
 @Entity
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id", scope = AnalysisContext.class)
 public class AnalysisContext implements Serializable
 {
     private static final long serialVersionUID = 1L;
@@ -50,6 +55,7 @@ public class AnalysisContext implements Serializable
     @Fetch(FetchMode.SELECT)
     private Collection<AdvancedOption> advancedOptions;
 
+//    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @OneToOne
     private ApplicationGroup applicationGroup;
 
@@ -65,10 +71,16 @@ public class AnalysisContext implements Serializable
     @JoinTable(name = "analysis_context_exclude_packages")
     private Set<Package> excludePackages;
 
-    public AnalysisContext()
+    protected AnalysisContext()
     {
         this.includePackages = new HashSet<>();
         this.excludePackages = new HashSet<>();
+    }
+
+    public AnalysisContext(ApplicationGroup applicationGroup)
+    {
+        this();
+        this.applicationGroup = applicationGroup;
     }
 
     public Long getId()

--- a/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
@@ -54,7 +54,8 @@ public class ApplicationGroup implements Serializable
     @ManyToOne(fetch = FetchType.EAGER)
     private MigrationProject migrationProject;
 
-    @OneToOne(mappedBy = "applicationGroup", cascade = CascadeType.REMOVE)
+    @OneToOne(mappedBy = "applicationGroup", cascade = CascadeType.ALL)
+    @Fetch(FetchMode.SELECT)
     private AnalysisContext analysisContext;
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "applicationGroup", cascade = CascadeType.REMOVE)
@@ -71,6 +72,13 @@ public class ApplicationGroup implements Serializable
     public ApplicationGroup()
     {
         this.applications = new HashSet<>();
+        this.executions = new HashSet<>();
+    }
+
+    public ApplicationGroup(MigrationProject project)
+    {
+        this();
+        this.migrationProject = project;
     }
 
     public Long getId()

--- a/services/src/main/java/org/jboss/windup/web/services/rest/AnalysisContextEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/AnalysisContextEndpointImpl.java
@@ -5,9 +5,11 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.validation.Valid;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
 import org.jboss.windup.web.services.model.AnalysisContext;
+import org.jboss.windup.web.services.model.ApplicationGroup;
 import org.jboss.windup.web.services.service.AnalysisContextService;
 
 /**
@@ -35,9 +37,24 @@ public class AnalysisContextEndpointImpl implements AnalysisContextEndpoint
         return context;
     }
 
+    protected boolean validateApplicationGroup(ApplicationGroup applicationGroup)
+    {
+        if (applicationGroup == null || applicationGroup.getId() == null) {
+            return false;
+        }
+
+        ApplicationGroup persistedAppGroup = this.entityManager.find(ApplicationGroup.class, applicationGroup.getId());
+
+        return persistedAppGroup != null;
+    }
+
     @Override
     public AnalysisContext create(@Valid AnalysisContext analysisContext)
     {
+        if (!this.validateApplicationGroup(analysisContext.getApplicationGroup())) {
+            throw new BadRequestException("Invalid application group");
+        }
+
         return analysisContextService.create(analysisContext);
     }
 

--- a/services/src/main/java/org/jboss/windup/web/services/rest/ApplicationGroupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ApplicationGroupEndpointImpl.java
@@ -16,9 +16,11 @@ import javax.ws.rs.NotFoundException;
 
 import org.jboss.windup.web.addons.websupport.WebPathUtil;
 import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
+import org.jboss.windup.web.services.model.AnalysisContext;
 import org.jboss.windup.web.services.model.ApplicationGroup;
 import org.jboss.windup.web.services.model.MigrationProject;
 import org.jboss.windup.web.services.model.PackageMetadata;
+import org.jboss.windup.web.services.service.AnalysisContextService;
 import org.jboss.windup.web.services.service.PackageService;
 
 /**
@@ -36,6 +38,9 @@ public class ApplicationGroupEndpointImpl implements ApplicationGroupEndpoint
 
     @Inject
     private PackageService packageServiceNew;
+
+    @Inject
+    private AnalysisContextService analysisContextService;
 
     @Inject
     @FromFurnace
@@ -94,6 +99,9 @@ public class ApplicationGroupEndpointImpl implements ApplicationGroupEndpoint
         }
 
         entityManager.persist(applicationGroup);
+
+        AnalysisContext analysisContext = this.analysisContextService.createDefaultAnalysisContext(applicationGroup);
+        applicationGroup.setAnalysisContext(analysisContext);
 
         Path outputPath = webPathUtil.createApplicationGroupPath(
                     applicationGroup.getMigrationProject().getId().toString(),

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -96,7 +96,7 @@ public class WindupEndpointImpl implements WindupEndpoint
 
         if (group.getAnalysisContext() == null)
         {
-            group.setAnalysisContext(analysisContextService.createDefaultAnalysisContext());
+            group.setAnalysisContext(analysisContextService.createDefaultAnalysisContext(group));
         }
         entityManager.merge(execution);
 

--- a/services/src/main/java/org/jboss/windup/web/services/service/AnalysisContextService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/AnalysisContextService.java
@@ -5,6 +5,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.jboss.windup.web.services.model.AnalysisContext;
+import org.jboss.windup.web.services.model.ApplicationGroup;
 import org.jboss.windup.web.services.model.Package;
 import org.jboss.windup.web.services.model.RulesPath;
 
@@ -29,9 +30,9 @@ public class AnalysisContextService
     /**
      * Creates a default instance.
      */
-    public AnalysisContext createDefaultAnalysisContext()
+    public AnalysisContext createDefaultAnalysisContext(ApplicationGroup group)
     {
-        AnalysisContext defaultAnalysisContext = new AnalysisContext();
+        AnalysisContext defaultAnalysisContext = new AnalysisContext(group);
         ensureSystemRulesPathsPresent(defaultAnalysisContext);
         entityManager.persist(defaultAnalysisContext);
         return defaultAnalysisContext;

--- a/services/src/test/java/org/jboss/windup/web/services/rest/AnalysisContextEndpointTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/AnalysisContextEndpointTest.java
@@ -62,8 +62,7 @@ public class AnalysisContextEndpointTest extends AbstractTest
         configuration.setRulesPaths(Collections.singleton(new RulesPath(ConfigurationEndpointTest.CUSTOM_RULESPATH, RulesPathType.USER_PROVIDED)));
         configurationEndpoint.saveConfiguration(configuration);
 
-        AnalysisContext analysisContext = new AnalysisContext();
-        analysisContext.setApplicationGroup(group);
+        AnalysisContext analysisContext = new AnalysisContext(group);
         analysisContext.setMigrationPath(path);
 
         analysisContext.setRulesPaths(configurationEndpoint.getConfiguration().getRulesPaths());

--- a/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
@@ -84,6 +84,10 @@ public class ApplicationGroupTest extends AbstractTest
         Assert.assertNotNull(retrievedGroup);
         Assert.assertEquals(applicationGroup.getId(), retrievedGroup.getId());
         Assert.assertEquals(applicationGroup.getTitle(), retrievedGroup.getTitle());
+        Assert.assertNotNull(retrievedGroup.getAnalysisContext());
+        Assert.assertNotNull(retrievedGroup.getExecutions());
+        Assert.assertNotNull(retrievedGroup.getApplications());
+        Assert.assertNotNull(retrievedGroup.getMigrationProject());
     }
 
     /**


### PR DESCRIPTION
We had a bug which caused analysis context not being properly set for user created groups. 

It was set for Default Group, because this one was handled differently. 

For all other groups, it was created at the time of execution. But property ApplicationGroup on AnalysisContext was not set. So any time ApplicationGroup was fetched from entityManager, it didn't have any AnalysisContext. And for each execution, it would create new one again and again...

AnalysisContext should not be created without ApplicationGroup.
