### PR TITLE
Add endpoint to force configuration reload.

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/ConfigurationEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ConfigurationEndpoint.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -42,4 +43,9 @@ public interface ConfigurationEndpoint
     @GET
     @Path("custom-rulesets")
     Set<RulesPath> getCustomRulesetPaths();
+
+
+    @POST
+    @Path("reload")
+    Configuration reloadConfiguration();
 }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/ConfigurationEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ConfigurationEndpointImpl.java
@@ -41,4 +41,13 @@ public class ConfigurationEndpointImpl implements ConfigurationEndpoint
     {
         return configurationService.getCustomRulesPath();
     }
+
+    @Override
+    public Configuration reloadConfiguration()
+    {
+        Configuration configuration = configurationService.getConfiguration();
+        this.configurationEvent.fire(configuration);
+
+        return configuration;
+    }
 }

--- a/ui/src/main/webapp/src/app/components/configuration.component.html
+++ b/ui/src/main/webapp/src/app/components/configuration.component.html
@@ -5,6 +5,7 @@
         <span class="glyphicon glyphicon-plus"></span>
         Register Custom Rule Path
     </button>
+    <button class="btn btn-primary" (click)="reloadConfiguration()">Force Reload Configuration</button>
 </h1>
 
 <template [ngIf]="configuration != null && configuration.rulesPaths != null && configuration.rulesPaths.length > 0">

--- a/ui/src/main/webapp/src/app/components/configuration.component.ts
+++ b/ui/src/main/webapp/src/app/components/configuration.component.ts
@@ -5,6 +5,8 @@ import {RuleService} from "../services/rule.service";
 import {RulesModalComponent} from "./rules-modal.component";
 import {AddRulesPathModalComponent, ConfigurationEvent} from "./add-rules-path-modal.component";
 import {ActivatedRoute} from "@angular/router";
+import {NotificationService} from "../services/notification.service";
+import {utils} from "../utils";
 
 @Component({
     selector: 'application-list',
@@ -26,7 +28,8 @@ export class ConfigurationComponent implements OnInit {
     constructor(
         private _activatedRoute: ActivatedRoute,
         private _configurationService:ConfigurationService,
-        private _ruleService:RuleService
+        private _ruleService:RuleService,
+        private _notificationService: NotificationService
     ) {
 
     }
@@ -99,5 +102,17 @@ export class ConfigurationComponent implements OnInit {
             },
             error => console.log("Error: " + error)
         )
+    }
+
+    reloadConfiguration() {
+        this._configurationService.reloadConfigration().subscribe(
+            configuration => {
+                this.configuration = configuration;
+                this.loadProviders();
+
+                this._notificationService.success('Configuration was reloaded');
+            },
+            error => this._notificationService.error(utils.getErrorMessage(error))
+        );
     }
 }

--- a/ui/src/main/webapp/src/app/services/configuration.service.ts
+++ b/ui/src/main/webapp/src/app/services/configuration.service.ts
@@ -10,6 +10,7 @@ import {AbstractService} from "./abtract.service";
 export class ConfigurationService extends AbstractService {
     private GET_URL = "/configuration";
     private SAVE_URL = "/configuration";
+    private CONFIGURATION_RELOAD_URL = '/configuration/reload';
 
     constructor (private _http: Http) {
         super();
@@ -47,5 +48,11 @@ export class ConfigurationService extends AbstractService {
             .map(res => <RulesPath[]> res.json())
             .catch(this.handleError);
 
+    }
+
+    reloadConfigration(): Observable<Configuration> {
+        return this._http.post(Constants.REST_BASE + this.CONFIGURATION_RELOAD_URL, null)
+            .map(res => res.json())
+            .catch(this.handleError);
     }
 }


### PR DESCRIPTION
I think it would be helpful to have some endpoint which would reload configuration. 

Right now it is reloaded automatically every 12 minutes, but sometimes you need to reload it right away. 
I'm not sure where to put it in UI, maybe somewhere into settings.

What do you think @jsight ?