### PR TITLE
Fix group edit

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
@@ -65,7 +65,7 @@ public class ApplicationGroup implements Serializable
     @ManyToOne(fetch = FetchType.EAGER, optional = false)
     private MigrationProject migrationProject;
 
-    @OneToOne(mappedBy = "applicationGroup", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "applicationGroup", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @Fetch(FetchMode.SELECT)
     private AnalysisContext analysisContext;
 
@@ -77,10 +77,10 @@ public class ApplicationGroup implements Serializable
     @Fetch(FetchMode.SELECT)
     private Set<WindupExecution> executions;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, fetch = FetchType.LAZY)
     private PackageMetadata packageMetadata;
 
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "applicationGroup")
+    @OneToOne(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, mappedBy = "applicationGroup")
     private ReportFilter reportFilter;
 
     public ApplicationGroup()

--- a/services/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.persistence.Column;
@@ -48,6 +49,11 @@ public class MigrationProject implements Serializable
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "migrationProject", cascade = CascadeType.REMOVE)
     private Set<ApplicationGroup> groups;
+
+    public MigrationProject()
+    {
+        this.groups = new HashSet<>();
+    }
 
     public Long getId()
     {
@@ -101,6 +107,16 @@ public class MigrationProject implements Serializable
     public void setGroups(Set<ApplicationGroup> groups)
     {
         this.groups = groups;
+    }
+
+    public void addGroup(ApplicationGroup group)
+    {
+        this.groups.add(group);
+    }
+
+    public void removeGroup(ApplicationGroup group)
+    {
+        this.groups.remove(group);
     }
 
     @Override

--- a/services/src/main/java/org/jboss/windup/web/services/rest/ApplicationGroupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ApplicationGroupEndpointImpl.java
@@ -104,7 +104,10 @@ public class ApplicationGroupEndpointImpl implements ApplicationGroupEndpoint
     @Override
     public ApplicationGroup update(@Valid ApplicationGroup applicationGroup)
     {
-        return entityManager.merge(applicationGroup);
+        ApplicationGroup original = this.entityManager.find(ApplicationGroup.class, applicationGroup.getId());
+        original.setTitle(applicationGroup.getTitle());
+
+        return original;
     }
 
     @Override

--- a/services/src/main/java/org/jboss/windup/web/services/rest/ApplicationGroupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ApplicationGroupEndpointImpl.java
@@ -91,30 +91,14 @@ public class ApplicationGroupEndpointImpl implements ApplicationGroupEndpoint
     {
         LOG.info("Creating group: " + applicationGroup + " with project: " + applicationGroup.getMigrationProject());
 
-        if (this.getMigrationProject(applicationGroup) == null)
+        MigrationProject migrationProject = this.getMigrationProject(applicationGroup);
+
+        if (migrationProject == null)
         {
             throw new BadRequestException("Invalid MigrationProject");
         }
 
-        applicationGroup.setReportFilter(new ReportFilter(applicationGroup));
-
-        entityManager.persist(applicationGroup);
-
-        AnalysisContext analysisContext = this.analysisContextService.createDefaultAnalysisContext(applicationGroup);
-        applicationGroup.setAnalysisContext(analysisContext);
-
-        Path outputPath = webPathUtil.createApplicationGroupPath(
-                    applicationGroup.getMigrationProject().getId().toString(),
-                    applicationGroup.getId().toString());
-        applicationGroup.setOutputPath(outputPath.toAbsolutePath().toString());
-
-        if (applicationGroup.getPackageMetadata() == null)
-        {
-            applicationGroup.setPackageMetadata(new PackageMetadata());
-        }
-
-        entityManager.merge(applicationGroup);
-        return entityManager.find(ApplicationGroup.class, applicationGroup.getId());
+        return this.applicationGroupService.createApplicationGroup(applicationGroup.getTitle(), migrationProject);
     }
 
     @Override

--- a/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectEndpointImpl.java
@@ -16,6 +16,7 @@ import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 import org.jboss.windup.web.services.model.ApplicationGroup;
 import org.jboss.windup.web.services.model.MigrationProject;
 import org.jboss.windup.web.services.model.PackageMetadata;
+import org.jboss.windup.web.services.service.ApplicationGroupService;
 
 /**
  * @author <a href="http://ondra.zizka.cz/">Ondrej Zizka, zizka@seznam.cz</a>
@@ -27,6 +28,9 @@ public class MigrationProjectEndpointImpl implements MigrationProjectEndpoint
 
     @PersistenceContext(type = PersistenceContextType.EXTENDED)
     private EntityManager entityManager;
+
+    @Inject
+    private ApplicationGroupService applicationGroupService;
 
     @Inject
     @FromFurnace
@@ -58,24 +62,7 @@ public class MigrationProjectEndpointImpl implements MigrationProjectEndpoint
         entityManager.persist(migrationProject);
 
         LOG.info("Creating a migration project: " + migrationProject.getId());
-        ApplicationGroup defaultGroup = new ApplicationGroup();
-        defaultGroup.setTitle(ApplicationGroup.DEFAULT_NAME);
-        defaultGroup.setMigrationProject(migrationProject);
-        defaultGroup.setReadOnly(true);
-
-        entityManager.persist(defaultGroup);
-
-        defaultGroup.setOutputPath(webPathUtil.createApplicationGroupPath(
-                    migrationProject.getId().toString(),
-                    defaultGroup.getId().toString()).toString());
-
-        PackageMetadata packageMetadata = new PackageMetadata();
-        entityManager.persist(packageMetadata);
-
-        defaultGroup.setPackageMetadata(packageMetadata);
-        entityManager.merge(defaultGroup);
-
-        entityManager.merge(migrationProject);
+        this.applicationGroupService.createDefaultApplicationGroup(migrationProject);
 
         return migrationProject;
     }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/ReportFilterEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ReportFilterEndpoint.java
@@ -37,5 +37,5 @@ public interface ReportFilterEndpoint
     ReportFilter setFilter(@PathParam("groupId") Long groupId, ReportFilter filter);
 
     @DELETE
-    void clearFilter(@PathParam("groupId") Long groupId);
+    ReportFilter clearFilter(@PathParam("groupId") Long groupId);
 }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/ReportFilterEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ReportFilterEndpointImpl.java
@@ -66,13 +66,15 @@ public class ReportFilterEndpointImpl implements ReportFilterEndpoint
     }
 
     @Override
-    public void clearFilter(Long groupId)
+    public ReportFilter clearFilter(Long groupId)
     {
         ApplicationGroup group = this.applicationGroupService.getApplicationGroup(groupId);
 
         ReportFilter filter = group.getReportFilter();
         filter.clear();
         this.entityManager.merge(filter);
+
+        return filter;
     }
 
     @Override

--- a/services/src/main/java/org/jboss/windup/web/services/rest/ReportFilterEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ReportFilterEndpointImpl.java
@@ -54,9 +54,6 @@ public class ReportFilterEndpointImpl implements ReportFilterEndpoint
         newFilter.setApplicationGroup(group);
         this.entityManager.merge(newFilter);
 
-        group.setReportFilter(newFilter);
-        this.entityManager.merge(group);
-
         return newFilter;
     }
 

--- a/services/src/main/java/org/jboss/windup/web/services/service/ApplicationGroupService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/ApplicationGroupService.java
@@ -1,10 +1,19 @@
 package org.jboss.windup.web.services.service;
 
+import org.jboss.windup.web.addons.websupport.WebPathUtil;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
+import org.jboss.windup.web.services.model.AnalysisContext;
 import org.jboss.windup.web.services.model.ApplicationGroup;
+import org.jboss.windup.web.services.model.MigrationProject;
+import org.jboss.windup.web.services.model.PackageMetadata;
+import org.jboss.windup.web.services.model.ReportFilter;
 
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
+import java.nio.file.Path;
 
 /**
  * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
@@ -13,6 +22,13 @@ public class ApplicationGroupService
 {
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Inject
+    private AnalysisContextService analysisContextService;
+
+    @Inject
+    @FromFurnace
+    WebPathUtil webPathUtil;
 
     public ApplicationGroup getApplicationGroup(Long groupID)
     {
@@ -24,5 +40,35 @@ public class ApplicationGroupService
         }
 
         return applicationGroup;
+    }
+
+    public ApplicationGroup createApplicationGroup(String title, MigrationProject project)
+    {
+        ApplicationGroup applicationGroup = new ApplicationGroup(project);
+        applicationGroup.setTitle(title);
+        applicationGroup.setReportFilter(new ReportFilter(applicationGroup));
+        applicationGroup.setPackageMetadata(new PackageMetadata());
+
+        entityManager.persist(applicationGroup);
+
+        AnalysisContext analysisContext = this.analysisContextService.createDefaultAnalysisContext(applicationGroup);
+        applicationGroup.setAnalysisContext(analysisContext);
+
+        Path outputPath = webPathUtil.createApplicationGroupPath(
+                applicationGroup.getMigrationProject().getId().toString(),
+                applicationGroup.getId().toString());
+
+        applicationGroup.setOutputPath(outputPath.toAbsolutePath().toString());
+
+        project.addGroup(applicationGroup);
+
+        entityManager.merge(applicationGroup);
+
+        return entityManager.find(ApplicationGroup.class, applicationGroup.getId());
+    }
+
+    public ApplicationGroup createDefaultApplicationGroup(MigrationProject project)
+    {
+        return this.createApplicationGroup(ApplicationGroup.DEFAULT_NAME, project);
     }
 }

--- a/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
@@ -1,5 +1,10 @@
 package org.jboss.windup.web.services.rest;
 
+import java.net.URL;
+
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -21,10 +26,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.ws.rs.core.Response;
-import javax.ws.rs.NotFoundException;
-import java.net.URL;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -141,8 +142,7 @@ public class ApplicationGroupTest extends AbstractTest
     }
 
     /**
-     * TODO: Write some meaningful test.
-     * Problem is how. Result of this endpoint depends on JMS queue processing.
+     * TODO: Write some meaningful test. Problem is how. Result of this endpoint depends on JMS queue processing.
      *
      * @throws Exception
      */
@@ -162,7 +162,8 @@ public class ApplicationGroupTest extends AbstractTest
         JSONObject json;
 
         long beginTime = System.currentTimeMillis();
-        do {
+        do
+        {
             Thread.sleep(1000L);
 
             response = registeredAppTarget.request().get();
@@ -179,7 +180,8 @@ public class ApplicationGroupTest extends AbstractTest
                 Assert.fail("Processing never completed. Current status: " + packageMetadata.getScanStatus());
             }
 
-        } while (packageMetadata.getScanStatus() != PackageMetadata.ScanStatus.COMPLETE);
+        }
+        while (packageMetadata.getScanStatus() != PackageMetadata.ScanStatus.COMPLETE);
 
         JSONArray packageTree = json.getJSONArray("packageTree");
 

--- a/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.NotFoundException;
 import java.net.URL;
 
 /**
@@ -89,6 +90,54 @@ public class ApplicationGroupTest extends AbstractTest
         Assert.assertNotNull(retrievedGroup.getExecutions());
         Assert.assertNotNull(retrievedGroup.getApplications());
         Assert.assertNotNull(retrievedGroup.getMigrationProject());
+    }
+
+    @Test
+    @RunAsClient
+    public void renameApplicationGroup()
+    {
+        MigrationProject project = this.dataProvider.getMigrationProject();
+        ApplicationGroup group = this.dataProvider.getApplicationGroup(project);
+
+        String newTitle = "Updated group";
+
+        group.setTitle(newTitle);
+
+        ApplicationGroup updated = applicationGroupEndpoint.update(group);
+        ApplicationGroup reloaded = applicationGroupEndpoint.getApplicationGroup(group.getId());
+
+        Assert.assertNotNull(updated);
+        Assert.assertNotNull(reloaded);
+
+        Assert.assertEquals(newTitle, updated.getTitle());
+        Assert.assertEquals(newTitle, reloaded.getTitle());
+
+        Assert.assertEquals(group.getId(), updated.getId());
+        Assert.assertNotNull(updated.getAnalysisContext());
+        Assert.assertNotNull(updated.getExecutions());
+        Assert.assertNotNull(updated.getApplications());
+        Assert.assertNotNull(updated.getMigrationProject());
+    }
+
+    @Test
+    @RunAsClient
+    public void deleteApplicationGroup()
+    {
+        MigrationProject project = this.dataProvider.getMigrationProject();
+        ApplicationGroup group = this.dataProvider.getApplicationGroup(project);
+
+        applicationGroupEndpoint.delete(group);
+
+        try
+        {
+            ApplicationGroup reloaded = applicationGroupEndpoint.getApplicationGroup(group.getId());
+            Assert.fail("Exception should have been thrown");
+        }
+        catch (NotFoundException e)
+        {
+            // String message = e.getMessage();
+            // Assert.assertTrue(message.matches("ApplicationGroup with id: [0-9]+ not found"));
+        }
     }
 
     /**

--- a/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/ApplicationGroupTest.java
@@ -91,6 +91,7 @@ public class ApplicationGroupTest extends AbstractTest
         Assert.assertNotNull(retrievedGroup.getExecutions());
         Assert.assertNotNull(retrievedGroup.getApplications());
         Assert.assertNotNull(retrievedGroup.getMigrationProject());
+        Assert.assertNotNull(retrievedGroup.getReportFilter());
     }
 
     @Test


### PR DESCRIPTION
I found bug in ApplicationGroup edit/delete. 

It was impossible to edit/delete group, because related entities were set to Cascade All and frontend didn't have properly set parents in child entities. (ReportFilter was missing ApplicationGroup and so on...).

We didn't have any tests for it, so I added some.