### PR TITLE
Default group should not be special anymore.

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/ApplicationGroup.java
@@ -50,9 +50,6 @@ public class ApplicationGroup implements Serializable
     @Column(name = "version")
     private int version;
 
-    @Column
-    private boolean readOnly;
-
     @Column(length = 256)
     @Size(min = 1, max = 256)
     @NotNull
@@ -114,26 +111,6 @@ public class ApplicationGroup implements Serializable
     public void setVersion(int version)
     {
         this.version = version;
-    }
-
-    /**
-     * Indicates whether or not the client should consider the properties associated with this group to be "readonly".
-     *
-     * This would be used with system generated groups to indicate that the name should be a constant.
-     */
-    public boolean isReadOnly()
-    {
-        return readOnly;
-    }
-
-    /**
-     * Indicates whether or not the client should consider the properties associated with this group to be "readonly".
-     *
-     * This would be used with system generated groups to indicate that the name should be a constant.
-     */
-    public void setReadOnly(boolean readOnly)
-    {
-        this.readOnly = readOnly;
     }
 
     /**

--- a/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectEndpointImpl.java
@@ -61,7 +61,6 @@ public class MigrationProjectEndpointImpl implements MigrationProjectEndpoint
         ApplicationGroup defaultGroup = new ApplicationGroup();
         defaultGroup.setTitle(ApplicationGroup.DEFAULT_NAME);
         defaultGroup.setMigrationProject(migrationProject);
-        defaultGroup.setReadOnly(true);
 
         entityManager.persist(defaultGroup);
 

--- a/ui/src/main/webapp/src/app/components/group-list.component.html
+++ b/ui/src/main/webapp/src/app/components/group-list.component.html
@@ -15,10 +15,10 @@
         <td class="title">
             <a [routerLink]="['/projects/' + project.id + '/groups', group.id]">{{group.title}}</a>
 
-            <a *ngIf="!group.readOnly" href="#" (click)="editGroup(group, $event)">
+            <a href="#" (click)="editGroup(group, $event)">
                 <span class="glyphicon glyphicon-pencil"></span>
             </a>
-            <a *ngIf="!group.readOnly" (click)="deleteGroup(group)">
+            <a (click)="deleteGroup(group)">
                 <span class="glyphicon glyphicon-trash"></span>
             </a>
         </td>


### PR DESCRIPTION
Based on [WINDUP-1255](https://issues.jboss.org/browse/WINDUP-1255) and our agreement we shouldn't treat default group in any special manner.

I removed readonly parameter from group. All ApplicationGroups are now handled the same - they can be renamed and deleted.