### PR TITLE
Backend error handling

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
@@ -1,0 +1,35 @@
+package org.jboss.windup.web.services.rest;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This exception handler should handle all runtime exceptions.
+ * It should prevent server from returning HTML Error page with stack trace and internals of error.
+ *
+ * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
+ */
+@Provider
+public class UnhandledExceptionHandler implements ExceptionMapper<RuntimeException>
+{
+    private ExceptionHandler applicationExceptionHandler = new ExceptionHandler();
+
+    @Override
+    public Response toResponse(RuntimeException exception)
+    {
+        Throwable cause = exception.getCause();
+
+        if (cause instanceof WebApplicationException)
+        {
+            return this.applicationExceptionHandler.toResponse((WebApplicationException) cause);
+        }
+
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(new ErrorMessage(Response.Status.INTERNAL_SERVER_ERROR.getReasonPhrase()))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+    }
+}


### PR DESCRIPTION
This PR was initially part of https://github.com/windup/windup-web/pull/117 but I would like to get it merged before, because I think it is quite useful. 

-----

Currently when there is unhandled exception server returns HTML page with stack trace and HTTP code 500. Angular tries to convert response to JSON which fails and it results into

- displaying a red error popup: "Error: Unknown error: undefined"
- following errors in console:

> abtract.service.ts:10 Service error: (object) SyntaxError: Unexpected end of JSON input
> abtract.service.ts:18 Service error - can't JSON: error.json is not a function 

I created global exception handler.
It should handle all exceptions and prevent server from returning HTML page with stack trace. Instead it will return proper JSON response with "Internal server error" message.

