### PR TITLE
GraphResource - use edges whitelists in REST endpoint

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
@@ -11,6 +11,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.DefaultValue;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -33,19 +34,48 @@ public interface GraphResource extends FurnaceRESTGraphAPI
     String VERTICES_OUT = "vertices_out";
     String VERTICES_IN = "vertices_in";
 
+    // @formatter:off
+
     @GET
     @Path("/{executionID}/{id}")
-    Map<String, Object> get(@PathParam("executionID") Long executionID, @PathParam("id") Integer vertexID, @QueryParam("depth") Integer depth);
+    Map<String, Object> get(
+        @PathParam("executionID") Long executionID,
+        @PathParam("id") Integer vertexID,
+        @QueryParam("depth") Integer depth
+    );
 
     @GET()
     @Path("/{executionID}/edges/{vertexID}/{edgeDirection}/{edgeLabel}")
-    List<Map<String, Object>> getEdges(@PathParam("executionID") Long executionID, @PathParam("vertexID") Integer vertexID, @PathParam("edgeDirection") String edgeDirection, @PathParam("edgeLabel") String edgeLabel);
+    List<Map<String, Object>> getEdges(
+        @PathParam("executionID") Long executionID,
+        @PathParam("vertexID") Integer vertexID,
+        @PathParam("edgeDirection") String edgeDirection,
+        @PathParam("edgeLabel") String edgeLabel
+    );
 
     @GET()
     @Path("/{executionID}/by-type/{vertexType}")
-    List<Map<String, Object>> getByType(@PathParam("executionID") Long executionID, @PathParam("vertexType") String vertexType, @QueryParam("depth") Integer depth);
+    List<Map<String, Object>> getByType(
+        @PathParam("executionID") Long executionID,
+        @PathParam("vertexType") String vertexType,
+        @QueryParam("depth") Integer depth,
+        @QueryParam("in") String inEdges,
+        @QueryParam("out") String outEdges
+    );
 
+
+    /**
+     * Filters the returned frames to those which have given @propertyName with a given @propertyValue.
+     */
     @GET()
     @Path("/{executionID}/by-type/{vertexType}/{propertyName}={propertyValue}")
-    List<Map<String, Object>> getByType(@PathParam("executionID") Long executionID, @PathParam("vertexType") String vertexType, @PathParam("propertyName") String propertyName, @PathParam("propertyValue") String propertyValue, @QueryParam("depth") Integer depth);
+    List<Map<String, Object>> getByType(
+        @PathParam("executionID") Long executionID,
+        @PathParam("vertexType") String vertexType,
+        @PathParam("propertyName") String propertyName,
+        @PathParam("propertyValue") String propertyValue,
+        @QueryParam("depth") Integer depth
+    );
+
+    // @formatter:on
 }

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
@@ -18,6 +18,9 @@ import com.thinkaurelius.titan.diskstorage.PermanentBackendException;
 import com.tinkerpop.blueprints.Direction;
 import com.tinkerpop.blueprints.Query;
 import com.tinkerpop.blueprints.Vertex;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -46,13 +49,16 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
     }
 
     @Override
-    public List<Map<String, Object>> getByType(Long executionID, String vertexType, Integer depth)
+    public List<Map<String, Object>> getByType(Long executionID, String vertexType, Integer depth, String inEdges, String outEdges)
     {
+        List<String> inEdges_ = inEdges == null ? Collections.emptyList() : Arrays.asList(StringUtils.split(inEdges, ','));
+        List<String> outEdges_ = outEdges == null ? Collections.emptyList() : Arrays.asList(StringUtils.split(outEdges, ','));
+
         GraphContext graphContext = getGraph(executionID);
         List<Map<String, Object>> vertices = new ArrayList<>();
         for (Vertex v : graphContext.getFramed().getVertices(WindupVertexFrame.TYPE_PROP, vertexType))
         {
-            vertices.add(convertToMap(executionID, v, depth));
+            vertices.add(convertToMap(executionID, v, depth, outEdges_, inEdges_));
         }
         return vertices;
     }

--- a/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
@@ -62,7 +62,7 @@ public class GraphResourceTest extends AbstractGraphResourceTest
     @RunAsClient
     public void testQueryByType()
     {
-        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, 1);
+        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, 1, null, null);
         Assert.assertNotNull(fileModels);
         Assert.assertTrue(fileModels.size() > 1);
 


### PR DESCRIPTION
Usage:
Limit OUT edges to "knows": .../rest-furnace/graph/77/by-type/SourceReportModel?depth=1&out=knows
Disable in vertices: .../rest-furnace/graph/77/by-type/SourceReportModel?depth=1&in=x