### PR TITLE
Graph REST - reuse vertices

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
@@ -32,6 +32,7 @@ public interface GraphResource extends FurnaceRESTGraphAPI
     String VERTICES = "vertices";
     String VERTICES_OUT = "vertices_out";
     String VERTICES_IN = "vertices_in";
+    String EDGE_DATA = "edgeData";
 
     @GET
     @Path("/{executionID}/{id}")

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
@@ -108,7 +108,7 @@ public class MigrationIssuesEndpointImpl extends AbstractGraphResource implement
         return StreamSupport.stream(summary.getDescriptions().spliterator(), false)
                     .flatMap(description -> StreamSupport.stream(summary.getFilesForDescription(description).spliterator(), false))
                     .map(fileSummary -> new ProblemFileSummaryWrapper(
-                                this.convertToMap(executionId, fileSummary.getFile().asVertex(), 0),
+                                this.convertVertexToMap(executionId, fileSummary.getFile().asVertex(), 0),
                                 fileSummary.getOccurrences()))
                     .collect(Collectors.toList());
     }

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
@@ -40,7 +40,7 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
 
         for (Vertex v : relatedVertices)
         {
-            vertices.add(convertToMap(executionID, v, 0));
+            vertices.add(convertVertexToMap(executionID, v, 0));
         }
         return vertices;
     }
@@ -52,7 +52,7 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
         List<Map<String, Object>> vertices = new ArrayList<>();
         for (Vertex v : graphContext.getFramed().getVertices(WindupVertexFrame.TYPE_PROP, vertexType))
         {
-            vertices.add(convertToMap(executionID, v, depth));
+            vertices.add(convertVertexToMap(executionID, v, depth));
         }
         return vertices;
     }
@@ -65,7 +65,7 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
         Query query = graphContext.getFramed().query().has(WindupVertexFrame.TYPE_PROP, vertexType).has(propertyName, propertyValue);
         for (Vertex vertex : query.vertices())
         {
-            vertices.add(convertToMap(executionID, vertex, depth));
+            vertices.add(convertVertexToMap(executionID, vertex, depth));
         }
         return vertices;
     }
@@ -89,7 +89,7 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
                 final Response response = RestUtil.createErrorResponse(Response.Status.NOT_FOUND, msg);
                 throw new NotFoundException(msg, response);
             }
-            return convertToMap(executionID, vertex, depth);
+            return convertVertexToMap(executionID, vertex, depth);
         }
         catch (IllegalStateException ex)
         {

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/ProjectTraversalResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/ProjectTraversalResourceImpl.java
@@ -53,7 +53,7 @@ public class ProjectTraversalResourceImpl extends AbstractGraphResource implemen
 
         for (PersistedProjectModelTraversalModel persistedTraversal : persistedTraversals)
         {
-            result.add(super.convertToMap(executionID, persistedTraversal.asVertex(), 0, whiteListedOutLabels, whiteListedInLabels));
+            result.add(super.convertVertexToMap(executionID, persistedTraversal.asVertex(), 0, whiteListedOutLabels, whiteListedInLabels));
         }
 
         return result;


### PR DESCRIPTION
This will not put the same vertex in the same REST response multiple times; instead, it will only add the _id and skip the rest.
Depends on #155