### PR TITLE
Graph REST API - don't repeat already marshalled vertices 

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
@@ -11,6 +11,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.DefaultValue;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -41,7 +42,8 @@ public interface GraphResource extends FurnaceRESTGraphAPI
     Map<String, Object> get(
         @PathParam("executionID") Long executionID,
         @PathParam("id") Integer vertexID,
-        @QueryParam("depth") Integer depth
+        @QueryParam("depth") Integer depth,
+        @QueryParam("dedup") @DefaultValue("false") Boolean dedup
     );
 
     @GET()
@@ -50,7 +52,8 @@ public interface GraphResource extends FurnaceRESTGraphAPI
         @PathParam("executionID") Long executionID,
         @PathParam("vertexID") Integer vertexID,
         @PathParam("edgeDirection") String edgeDirection,
-        @PathParam("edgeLabel") String edgeLabel
+        @PathParam("edgeLabel") String edgeLabel,
+        @QueryParam("dedup") @DefaultValue("false") Boolean dedup
     );
 
     @GET()
@@ -59,6 +62,7 @@ public interface GraphResource extends FurnaceRESTGraphAPI
         @PathParam("executionID") Long executionID,
         @PathParam("vertexType") String vertexType,
         @QueryParam("depth") Integer depth,
+        @QueryParam("dedup") @DefaultValue("false") Boolean dedup,
         @QueryParam("in") String inEdges,
         @QueryParam("out") String outEdges
     );
@@ -74,7 +78,8 @@ public interface GraphResource extends FurnaceRESTGraphAPI
         @PathParam("vertexType") String vertexType,
         @PathParam("propertyName") String propertyName,
         @PathParam("propertyValue") String propertyValue,
-        @QueryParam("depth") Integer depth
+        @QueryParam("depth") Integer depth,
+        @QueryParam("dedup") @DefaultValue("false") Boolean dedup
     );
 
     // @formatter:on

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/MigrationIssuesEndpointImpl.java
@@ -108,7 +108,7 @@ public class MigrationIssuesEndpointImpl extends AbstractGraphResource implement
         return StreamSupport.stream(summary.getDescriptions().spliterator(), false)
                     .flatMap(description -> StreamSupport.stream(summary.getFilesForDescription(description).spliterator(), false))
                     .map(fileSummary -> new ProblemFileSummaryWrapper(
-                                this.convertToMap(executionId, fileSummary.getFile().asVertex(), 0),
+                                this.convertToMap(executionId, fileSummary.getFile().asVertex(), 0, false),
                                 fileSummary.getOccurrences()))
                     .collect(Collectors.toList());
     }

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/AbstractGraphResource.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/AbstractGraphResource.java
@@ -66,18 +66,11 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
 
     protected Map<String, Object> convertToMap(long executionID, Vertex vertex, Integer depth, boolean dedup, List<String> whitelistedOutEdges, List<String> whitelistedInLabels)
     {
-        return convertToMap(
-                new GraphMarhallingContext(executionID, vertex, depth, dedup, whitelistedOutEdges, whitelistedInLabels),
-                executionID, vertex, depth, whitelistedOutEdges, whitelistedInLabels);
+        return convertToMap(new GraphMarhallingContext(executionID, vertex, depth, dedup, whitelistedOutEdges, whitelistedInLabels), vertex);
     }
 
-    private Map<String, Object> convertToMap(
-            GraphMarhallingContext ctx,
-            long executionID, Vertex vertex, Integer depth, List<String> whitelistedOutEdges, List<String> whitelistedInLabels)
+    private Map<String, Object> convertToMap(GraphMarhallingContext ctx, Vertex vertex)
     {
-        if (depth == null)
-            depth = 0;
-
         Map<String, Object> result = new HashMap<>();
 
         result.put(GraphResource.TYPE, GraphResource.TYPE_VERTEX);
@@ -95,11 +88,11 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
 
         Map<String, Object> outVertices = new HashMap<>();
         result.put(GraphResource.VERTICES_OUT, outVertices);
-        addEdges(ctx, executionID, outVertices, vertex, depth, Direction.OUT, whitelistedOutEdges, whitelistedInLabels);
+        addEdges(ctx, vertex, Direction.OUT, outVertices);
 
         Map<String, Object> inVertices = new HashMap<>();
         result.put(GraphResource.VERTICES_IN, inVertices);
-        addEdges(ctx, executionID, inVertices, vertex, depth, Direction.IN, whitelistedOutEdges, whitelistedInLabels);
+        addEdges(ctx, vertex, Direction.IN, inVertices);
 
         return result;
     }
@@ -111,14 +104,9 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
     }
 
     @SuppressWarnings("unchecked")
-    private void addEdges(
-            GraphMarhallingContext ctx,
-            long executionID, Map<String, Object> result, Vertex vertex, Integer remainingDepth, Direction direction,
-            List<String> whitelistedOutEdges, List<String> whitelistedInEdges)
+    private void addEdges(GraphMarhallingContext ctx, Vertex vertex, Direction direction, Map<String, Object> result)
     {
-        final Direction opposite = direction == Direction.OUT ? Direction.IN : Direction.OUT;
-
-        List<String> whitelistedLabels = direction == Direction.OUT ? whitelistedOutEdges : whitelistedInEdges;
+        List<String> whitelistedLabels = direction == Direction.OUT ? ctx.whitelistedOutEdges : ctx.whitelistedInEdges;
 
         Iterable<Edge> edges;
         if (whitelistedLabels == null || whitelistedLabels.isEmpty())
@@ -132,7 +120,7 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
 
             Map<String, Object> edgeDetails = (Map<String, Object>) result.get(label);
             // If the details are already there and we aren't recursing any further, then just skip
-            if (!isWhitelistedEdge(whitelistedOutEdges, whitelistedInEdges, direction, label) && edgeDetails != null && (remainingDepth == null || remainingDepth <= 0))
+            if (!isWhitelistedEdge(ctx.whitelistedOutEdges, ctx.whitelistedInEdges, direction, label) && edgeDetails != null && ctx.remainingDepth <= 0)
                 continue;
 
             final List<Map<String, Object>> linkedVertices;
@@ -143,10 +131,10 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
                 result.put(label, edgeDetails);
 
                 // If we aren't serializing any further, then just provide a link
-                if (!isWhitelistedEdge(whitelistedOutEdges, whitelistedInEdges, direction, label) && (remainingDepth == null || remainingDepth <= 0))
+                if (!isWhitelistedEdge(ctx.whitelistedOutEdges, ctx.whitelistedInEdges, direction, label) && ctx.remainingDepth <= 0)
                 {
                     edgeDetails.put(GraphResource.TYPE, GraphResource.TYPE_LINK);
-                    String linkUri = getLink(executionID, vertex, direction.toString(), label);
+                    String linkUri = getLink(ctx.executionID, vertex, direction.toString(), label);
                     edgeDetails.put(GraphResource.LINK, linkUri);
                     continue;
                 }
@@ -159,10 +147,12 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
                 linkedVertices = (List<Map<String, Object>>) edgeDetails.get(GraphResource.VERTICES);
             }
 
-            Vertex otherVertex = edge.getVertex(opposite);
+            Vertex otherVertex = edge.getVertex(direction == Direction.OUT ? Direction.IN : Direction.OUT);
 
             // Recursion
-            Map<String, Object> otherVertexMap = convertToMap(ctx, executionID, otherVertex, remainingDepth - 1, whitelistedOutEdges, whitelistedInEdges);
+            ctx.remainingDepth--;
+            Map<String, Object> otherVertexMap = convertToMap(ctx, otherVertex);
+            ctx.remainingDepth++;
 
             // Add edge properties if any
             if (!edge.getPropertyKeys().isEmpty())
@@ -182,7 +172,7 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
         List<Map<String, Object>> result = new ArrayList<>();
         for (WindupVertexFrame frame : frames)
         {
-            result.add(convertToMap(ctx, executionID, frame.asVertex(), depth, Collections.emptyList(), Collections.emptyList()));
+            result.add(convertToMap(ctx, frame.asVertex()));
         }
         return result;
     }
@@ -206,14 +196,14 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
  */
 class GraphMarhallingContext
 {
-    long executionID;
-    Vertex startVertex;
+    final long executionID;
+    final Vertex startVertex;
     int remainingDepth;
-    List<String> whitelistedOutEdges;
-    List<String> whitelistedInEdges;
+    final List<String> whitelistedOutEdges;
+    final List<String> whitelistedInEdges;
 
-    Set<Long> visitedVertices = new HashSet();
-    boolean deduplicateVertices = false;
+    final Set<Long> visitedVertices = new HashSet();
+    final boolean deduplicateVertices;
 
 
     public GraphMarhallingContext(long executionID, Vertex startVertex, Integer depth, boolean dedup, List<String> whitelistedOutEdges, List<String> whitelistedInLabels)

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 public class GraphResourceImpl extends AbstractGraphResource implements GraphResource
 {
     @Override
-    public List<Map<String, Object>> getEdges(Long executionID, Integer vertexID, String edgeDirection, String edgeLabel)
+    public List<Map<String, Object>> getEdges(Long executionID, Integer vertexID, String edgeDirection, String edgeLabel, Boolean dedup)
     {
         GraphContext graphContext = getGraph(executionID);
         if (vertexID == null)
@@ -43,13 +43,13 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
 
         for (Vertex v : relatedVertices)
         {
-            vertices.add(convertToMap(executionID, v, 0));
+            vertices.add(convertToMap(executionID, v, 0, dedup));
         }
         return vertices;
     }
 
     @Override
-    public List<Map<String, Object>> getByType(Long executionID, String vertexType, Integer depth, String inEdges, String outEdges)
+    public List<Map<String, Object>> getByType(Long executionID, String vertexType, Integer depth, Boolean dedup, String inEdges, String outEdges)
     {
         List<String> inEdges_ = inEdges == null ? Collections.emptyList() : Arrays.asList(StringUtils.split(inEdges, ','));
         List<String> outEdges_ = outEdges == null ? Collections.emptyList() : Arrays.asList(StringUtils.split(outEdges, ','));
@@ -58,26 +58,26 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
         List<Map<String, Object>> vertices = new ArrayList<>();
         for (Vertex v : graphContext.getFramed().getVertices(WindupVertexFrame.TYPE_PROP, vertexType))
         {
-            vertices.add(convertToMap(executionID, v, depth, outEdges_, inEdges_));
+            vertices.add(convertToMap(executionID, v, depth, dedup, outEdges_, inEdges_));
         }
         return vertices;
     }
 
     @Override
-    public List<Map<String, Object>> getByType(Long executionID, String vertexType, String propertyName, String propertyValue, Integer depth)
+    public List<Map<String, Object>> getByType(Long executionID, String vertexType, String propertyName, String propertyValue, Integer depth, Boolean dedup)
     {
         GraphContext graphContext = getGraph(executionID);
         List<Map<String, Object>> vertices = new ArrayList<>();
         Query query = graphContext.getFramed().query().has(WindupVertexFrame.TYPE_PROP, vertexType).has(propertyName, propertyValue);
         for (Vertex vertex : query.vertices())
         {
-            vertices.add(convertToMap(executionID, vertex, depth));
+            vertices.add(convertToMap(executionID, vertex, depth, dedup));
         }
         return vertices;
     }
 
     @Override
-    public Map<String, Object> get(Long executionID, Integer id, Integer depth)
+    public Map<String, Object> get(Long executionID, Integer id, Integer depth, Boolean dedup)
     {
         if (executionID == null)
             throw new IllegalArgumentException("Execution ID not specified.");
@@ -95,7 +95,7 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
                 final Response response = RestUtil.createErrorResponse(Response.Status.NOT_FOUND, msg);
                 throw new NotFoundException(msg, response);
             }
-            return convertToMap(executionID, vertex, depth);
+            return convertToMap(executionID, vertex, depth, dedup);
         }
         catch (IllegalStateException ex)
         {

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/ProjectTraversalResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/ProjectTraversalResourceImpl.java
@@ -53,7 +53,7 @@ public class ProjectTraversalResourceImpl extends AbstractGraphResource implemen
 
         for (PersistedProjectModelTraversalModel persistedTraversal : persistedTraversals)
         {
-            result.add(super.convertToMap(executionID, persistedTraversal.asVertex(), 0, whiteListedOutLabels, whiteListedInLabels));
+            result.add(super.convertToMap(executionID, persistedTraversal.asVertex(), 0, false, whiteListedOutLabels, whiteListedInLabels));
         }
 
         return result;

--- a/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
@@ -62,7 +62,7 @@ public class GraphResourceTest extends AbstractGraphResourceTest
     @RunAsClient
     public void testQueryByType()
     {
-        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, 1, null, null);
+        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, 1, false, null, null);
         Assert.assertNotNull(fileModels);
         Assert.assertTrue(fileModels.size() > 1);
 
@@ -76,7 +76,7 @@ public class GraphResourceTest extends AbstractGraphResourceTest
     @RunAsClient
     public void testEdgeQuery()
     {
-        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, FileModel.FILE_NAME, "windup-src-example", 0);
+        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, FileModel.FILE_NAME, "windup-src-example", 0, false);
         Assert.assertNotNull(fileModels);
         Assert.assertTrue(fileModels.size() == 1);
 
@@ -92,7 +92,7 @@ public class GraphResourceTest extends AbstractGraphResourceTest
             Assert.assertNotNull(edgesUri);
 
             Object vertexID = fileModel.get(GraphResource.KEY_ID);
-            List<Map<String, Object>> edges = graphResource.getEdges(execution.getId(), (Integer)vertexID, "OUT", FileModel.PARENT_FILE);
+            List<Map<String, Object>> edges = graphResource.getEdges(execution.getId(), (Integer)vertexID, "OUT", FileModel.PARENT_FILE, false);
             Assert.assertNotNull(edges);
             Assert.assertEquals(1, edges.size());
             Assert.assertNotNull(edges.get(0));
@@ -103,7 +103,7 @@ public class GraphResourceTest extends AbstractGraphResourceTest
     @RunAsClient
     public void testQueryByTypeAndProperty()
     {
-        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, FileModel.FILE_NAME, "windup-src-example", 1);
+        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, FileModel.FILE_NAME, "windup-src-example", 1, false);
         Assert.assertNotNull(fileModels);
         Assert.assertTrue(fileModels.size() == 1);
 


### PR DESCRIPTION
the client will have to cache.
The deduplication is optional - @PathParam("dedup") @DefaultValue("false") boolean dedup
