### PR TITLE
Fix cancel() button for application edit form.

### DIFF
--- a/ui/src/main/webapp/src/app/components/edit-application-form.component.ts
+++ b/ui/src/main/webapp/src/app/components/edit-application-form.component.ts
@@ -29,6 +29,8 @@ export class EditApplicationFormComponent extends RegisterApplicationFormCompone
     }
 
     ngOnInit():any {
+        super.ngOnInit();
+
         this.isMultiple = false;
 
         this.labels = {


### PR DESCRIPTION
ApplicationGroup property was not properly initialized. Use parent ngOnInit to initialize it.