### PR TITLE
Don't generate import {DiscriminatorMappingData} from './discriminato…

### DIFF
--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/tsmodelgen/TypeScriptModelsGenerator.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/tsmodelgen/TypeScriptModelsGenerator.java
@@ -464,7 +464,7 @@ public class TypeScriptModelsGenerator
         {
             final Path path = this.config.getImportPathToWebapp().resolve(PATH_TO_GRAPH_PKG).resolve(BaseModelPath);
             mappingWriter.write("import {" + BaseModelName + "} from '" + path + "';\n");
-            mappingWriter.write("import {" + DISCRIMINATOR_MAPPING_DATA + "} from './" + DISCRIMINATOR_MAPPING_DATA_PATH + "';\n\n");
+            //mappingWriter.write("import {" + DISCRIMINATOR_MAPPING_DATA + "} from './" + DISCRIMINATOR_MAPPING_DATA_PATH + "';\n\n");
 
             for (Map.Entry<String, ModelDescriptor> entry : discriminatorToClassMapping.entrySet())
             {


### PR DESCRIPTION
…r-mapping-data';

Current code puts the data directly to DiscriminatorMapping and this is missing.
That gives TS compilation error

```
src/app/generated/tsModels/index.ts(2,9): error TS2305: Module '"/home/ondra/work/Migration/windup-web/ui/src/main/webapp/src/app/generated/tsModels/discriminator-mapping-data"' has no exported member 'DiscriminatorMappingData'.
```