### PR TITLE
Fix FileEndpoint.

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/FileEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/FileEndpointImpl.java
@@ -15,8 +15,6 @@ public class FileEndpointImpl implements FileEndpoint
     {
         if (!Files.isReadable(path))
             return false;
-        if (!Files.isDirectory(path))
-            return false;
 
         return true;
     }


### PR DESCRIPTION
remoteUserCanQueryPath should not return false, if given path is pointing to file instead of directory.
User can register both - application file or directory containing multiple applications.