### PR TITLE
Fix analysis context form submit.

### DIFF
--- a/ui/src/main/webapp/src/app/components/analysis-context-form.component.html
+++ b/ui/src/main/webapp/src/app/components/analysis-context-form.component.html
@@ -2,7 +2,7 @@
     Analysis Context
 </h1>
 <h1 *ngIf="!applicationGroup">Loading...</h1>
-<form *ngIf="applicationGroup" #analysisContextForm="ngForm" (ngSubmit)="save()"  class="form-horizontal">
+<form *ngIf="applicationGroup" #analysisContextForm="ngForm" (ngSubmit)="onSubmit()"  class="form-horizontal">
     <div *ngFor="let errorMessage of errorMessages" class="row form-errors alert alert-danger">
         <div class="col-md-2">&nbsp;</div>
         <div class="col-md-10">

--- a/ui/src/main/webapp/src/app/components/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/components/analysis-context-form.component.ts
@@ -187,6 +187,10 @@ export class AnalysisContextFormComponent extends FormComponent implements OnIni
     }
 
     save() {
+        this.action = Action.Save;
+    }
+
+    onSubmit() {
         if (this.analysisContext.id != null) {
             console.log("Updating analysis context: " + this.analysisContext.migrationPath.id);
             this._analysisContextService.update(this.analysisContext).subscribe(


### PR DESCRIPTION
Previously there was the same action on save button and form submit, so the action was actually triggered twice.
It lead to server error caused by concurrent modification.
(after first change, analysis context version is incremented, but the second update was triggered with previous version number).