### PR TITLE
Skip the WF unpack if -DskipTests is set.

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -242,6 +242,7 @@
                             <goal>unpack</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.jboss.windup</groupId>


### PR DESCRIPTION
This saves quite some time in services rebuild.