### PR TITLE
Update webpack config - use AOT only for production.

### DIFF
--- a/ui/src/main/webapp/config/webpack.common.js
+++ b/ui/src/main/webapp/config/webpack.common.js
@@ -21,11 +21,6 @@ module.exports = {
     module: {
         loaders: [
             {
-                test: /\.ts$/,
-                exclude: /jquery*\.js/,
-                loaders: '@ngtools/webpack'
-            },
-            {
                 test: /\.html$/,
                 loader: 'html-loader'
             },

--- a/ui/src/main/webapp/config/webpack.dev.js
+++ b/ui/src/main/webapp/config/webpack.dev.js
@@ -2,8 +2,6 @@ var webpackMerge = require('webpack-merge');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var commonConfig = require('./webpack.common.js');
 var helpers = require('./helpers');
-var ngtools = require('@ngtools/webpack');
-var AotPlugin = ngtools.AotPlugin;
 
 module.exports = webpackMerge(commonConfig, {
     devtool: 'source-map', //devtool: 'cheap-module-eval-source-map',
@@ -14,13 +12,18 @@ module.exports = webpackMerge(commonConfig, {
         chunkFilename: 'js/[id].chunk.js'
     },
 
+    module: {
+        loaders: [
+            {
+                test: /\.ts$/,
+                exclude: /jquery*\.js/,
+                loaders: ['awesome-typescript-loader', 'angular2-template-loader']
+            }
+        ]
+    },
+
     plugins: [
-        new ExtractTextPlugin('css/[name].css'),
-        new AotPlugin({
-            tsConfigPath: './tsconfig.json',
-            basePath: '.',
-            mainPath: 'src/main.ts'
-        })
+        new ExtractTextPlugin('css/[name].css')
     ],
 
     devServer: {

--- a/ui/src/main/webapp/config/webpack.prod.js
+++ b/ui/src/main/webapp/config/webpack.prod.js
@@ -17,6 +17,15 @@ module.exports = webpackMerge(commonConfig, {
         chunkFilename: 'js/[id].chunk.js'
     },
 
+    module: {
+        loaders: [
+            {
+                test: /\.ts$/,
+                exclude: /jquery*\.js/,
+                loaders: '@ngtools/webpack'
+            }
+        ]
+    },
 
     plugins: [
         new webpack.NoEmitOnErrorsPlugin(),


### PR DESCRIPTION
I noticed build is significantly slower when using AOT and it also doesn't contain certain debug information which are handy for example for Augury browser extension. I think for dev mode it is better not to use AOT.