### PR TITLE
Upgraded to ngx-charts 4.1.3 -- Hardcoded H*W, as it didn't work otherwise

### DIFF
--- a/ui/src/main/webapp/package.json
+++ b/ui/src/main/webapp/package.json
@@ -60,7 +60,7 @@
     "jstree": "^3.3.2",
     "karma-junit-reporter": "^1.1.0",
     "ng2-file-upload": "^1.1.0",
-    "ngx-charts": "^3.0.2",
+    "@swimlane/ngx-charts": "^4.1.3",
     "patternfly": "^3.16.0",
     "patternfly-bootstrap-combobox": "1.1.7",
     "prismjs": "1.5.1",

--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -82,7 +82,7 @@ import {ReportFilterResolve} from "./components/reports/filter/report-filter.res
 import {CustomSelectComponent} from "./components/custom-select/custom-select.component";
 import {ReportFilterIndicatorComponent} from "./components/reports/filter/report-filter-indicator.component";
 import {ApplicationDetailsComponent} from "./components/reports/application-details/application-details.component";
-import {NgxChartsModule} from "ngx-charts";
+import {NgxChartsModule} from "@swimlane/ngx-charts";
 import {PackageChartComponent} from "./components/package-chart/package-chart.component";
 import {ApplicationDetailsService} from "./components/reports/application-details/application-details.service";
 import {TechnologyTagComponent} from "./components/reports/technology-tag/technology-tag.component";

--- a/ui/src/main/webapp/src/app/components/package-chart/package-chart.component.ts
+++ b/ui/src/main/webapp/src/app/components/package-chart/package-chart.component.ts
@@ -1,12 +1,15 @@
 import {
     Component, ElementRef, ChangeDetectorRef, NgZone, ChangeDetectionStrategy, OnChanges,
-    OnDestroy, AfterViewInit, SimpleChanges, EventEmitter, Output, Input
+    OnDestroy, AfterViewInit, SimpleChanges, EventEmitter, Output, Input, ViewEncapsulation
 } from "@angular/core";
-import {BaseChartComponent, calculateViewDimensions, ViewDimensions, formatLabel, ColorHelper} from "ngx-charts";
+import { Location } from "@angular/common";
+
+import { BaseChartComponent, calculateViewDimensions, ViewDimensions, formatLabel, ColorHelper } from "@swimlane/ngx-charts";
 
 @Component({
     selector: 'wu-package-chart',
     templateUrl: './package-chart.component.html',
+    encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PackageChartComponent extends BaseChartComponent implements OnChanges, OnDestroy, AfterViewInit {
@@ -32,8 +35,8 @@ export class PackageChartComponent extends BaseChartComponent implements OnChang
     colors: ColorHelper;
     legendWidth: number;
 
-    constructor(element: ElementRef, zone: NgZone, cd: ChangeDetectorRef) {
-        super(element, zone, cd);
+    constructor(element: ElementRef, zone: NgZone, cd: ChangeDetectorRef, location: Location) {
+        super(element, zone, cd, location);
     }
 
     label(item): string {

--- a/ui/src/main/webapp/src/app/components/reports/application-details/application-details.component.html
+++ b/ui/src/main/webapp/src/app/components/reports/application-details/application-details.component.html
@@ -42,6 +42,7 @@
                         <h4>Java Incidents by Package</h4>
                         <div id="application_pie" class="windupPieGraph">
                             <wu-package-chart
+                                    [view]="[500, 150]"
                                     [results]="globalPackageUseData"
                                     [scheme]="colorScheme"
                             ></wu-package-chart>
@@ -52,6 +53,7 @@
                     <div class="chartBoundary" *ngIf="tagFrequencies?.length > 0">
                         <h4>Technologies found - occurrence count</h4>
                         <ngx-charts-bar-horizontal
+                                [view]="[500, 258]"
                                 [scheme]="colorScheme"
                                 [results]="tagFrequencies"
                                 [showGridLines]="true"
@@ -178,6 +180,7 @@
                                     <h4>Java Incidents by Package</h4>
                                     <div class="windupPieGraph">
                                         <wu-package-chart
+                                                [view]="[500, 150]"
                                                 [results]="packageFrequenciesByProject.get(traversal.id)"
                                                 [scheme]="colorScheme"
                                         ></wu-package-chart>
@@ -189,6 +192,7 @@
                                     <h4>Technologies found - occurrence count</h4>
                                     <ngx-charts-bar-horizontal
                                             *ngIf="!isCollapsed(traversal)"
+                                            [view]="[500, 258]"
                                             [scheme]="colorScheme"
                                             [results]="this.tagFrequenciesByProject.get(traversal.id)"
                                             [showGridLines]="true"

--- a/ui/src/main/webapp/yarn.lock
+++ b/ui/src/main/webapp/yarn.lock
@@ -73,6 +73,10 @@
     magic-string "^0.19.0"
     source-map "^0.5.6"
 
+"@swimlane/ngx-charts@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@swimlane/ngx-charts/-/ngx-charts-4.1.3.tgz#5aa73260f245cc7914a02fc1befb03c00b998b68"
+
 "@types/bootstrap@^3.3.32":
   version "3.3.32"
   resolved "https://registry.yarnpkg.com/@types/bootstrap/-/bootstrap-3.3.32.tgz#abaf4b364d086de0cb7791db0cfd55703b591fad"
@@ -3903,10 +3907,6 @@ negotiator@0.6.1:
 ng2-file-upload@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ng2-file-upload/-/ng2-file-upload-1.2.0.tgz#4e8c7e8b55fd71fd5b90d5ce3657570597785a86"
-
-ngx-charts@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/ngx-charts/-/ngx-charts-3.0.2.tgz#4c83d4d27408d51af0cace4436a58b823aeaf53d"
 
 no-case@^2.2.0:
   version "2.3.1"


### PR DESCRIPTION
I looked at this for much of the day, and had no luck figuring out why the height and width can no longer be calculated correctly by ngx-charts. I just hardcoded them.

Feel free to fix this if you have better luck than I did.