### PR TITLE
Do not show Technologies and Dependencies reports in navigation.

### DIFF
--- a/ui/src/main/webapp/src/app/components/layout/group-layout.component.ts
+++ b/ui/src/main/webapp/src/app/components/layout/group-layout.component.ts
@@ -161,20 +161,29 @@ export class GroupLayoutComponent extends AbstractComponent implements OnInit, O
                 MigrationIssuesComponent,
                 this._routeLinkProviderService,
             ),
-            new ReportMenuItem(
-                'Technologies',
-                'fa-cubes',
-                this.applicationGroup,
-                TechnologiesReportComponent,
-                this._routeLinkProviderService,
-            ),
-            new ReportMenuItem(
-                'Dependencies',
-                'fa-code-fork',
-                this.applicationGroup,
-                DependenciesReportComponent,
-                this._routeLinkProviderService
-            )
         ];
+
+        // Hide technologies and dependencies report in production mode
+        // TODO: Use process.env.ENV !== 'production' when AOT is fixed
+        let showUnfinishedReports = false;
+
+        if (showUnfinishedReports) {
+            this.menuItems = [ ...this.menuItems,
+                new ReportMenuItem(
+                    'Technologies',
+                    'fa-cubes',
+                    this.applicationGroup,
+                    TechnologiesReportComponent,
+                    this._routeLinkProviderService,
+                 ),
+                 new ReportMenuItem(
+                     'Dependencies',
+                     'fa-code-fork',
+                     this.applicationGroup,
+                     DependenciesReportComponent,
+                     this._routeLinkProviderService
+                 )
+            ];
+        }
     }
 }


### PR DESCRIPTION
I tried to disable it only for production environment, but there are some issues with AOT which seems not to be working right now.
This is just temporary solution until AOT is fixed.