### PR TITLE
Update webpack test configuration - add scss.

### DIFF
--- a/ui/src/main/webapp/config/webpack.test.js
+++ b/ui/src/main/webapp/config/webpack.test.js
@@ -23,17 +23,17 @@ module.exports = {
             },
             {
                 test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/,
-                loader: 'null'
+                loader: 'null-loader'
             },
             {
                 test: /\.css$/,
-                exclude: helpers.root('src', 'app'),
-                loader: 'null'
-            },
-            {
-                test: /\.css$/,
-                include: helpers.root('src', 'app'),
+                exclude: /node_modules/,
                 loader: 'raw-loader'
+            },
+            {
+                test: /\.scss$/,
+                exclude: /node_modules/,
+                loaders: [ 'raw-loader', 'sass-loader' ]
             }
         ]
     },


### PR DESCRIPTION
It seems it is not possible to skip evaluation of styles. null-loader doesn't fill in any value, but angular expects styles to be string array. It seems it is required to use loaders even for tests.