### PR TITLE
Update navbar - change link isActive method.

### DIFF
--- a/ui/src/main/webapp/src/app/shared/navigation/navbar.component.html
+++ b/ui/src/main/webapp/src/app/shared/navigation/navbar.component.html
@@ -6,14 +6,14 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" routerLink="/project-list" href="#">
+        <a class="navbar-brand" [routerLink]="['/project-list']" href="#">
             Windup 3.0
         </a>
     </div>
     <div class="collapse navbar-collapse navbar-collapse-1">
         <ul class="nav navbar-nav navbar-utility">
-            <li [class.active]="isActive(settingsLink)">
-                <a #settingsLink routerLink="/configuration">Settings</a>
+            <li [routerLinkActive]="['active']">
+                <a [routerLink]="['/configuration']">Settings</a>
             </li>
             <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -28,13 +28,12 @@
             </li>
         </ul>
         <ul class="nav navbar-nav navbar-primary">
-            <li [class.active]="isActive(projectListLink)">
-                <a #projectListLink routerLink="/project-list">Home</a>
+            <li [routerLinkActive]="['active']">
+                <a [routerLink]="['/project-list']">Home</a>
             </li>
-            <li [class.active]="isActive(executionsListLink)">
-                <a #executionsListLink routerLink="/executions">Executions</a>
+            <li [routerLinkActive]="['active']">
+                <a [routerLink]="['/executions']">Executions</a>
             </li>
         </ul>
     </div>
 </nav>
-

--- a/ui/src/main/webapp/src/app/shared/navigation/navbar.component.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/navbar.component.ts
@@ -1,5 +1,4 @@
 import {Component, OnInit, ElementRef} from '@angular/core';
-import {Router} from "@angular/router";
 import {KeycloakService} from "../../core/authentication/keycloak.service";
 import * as $ from 'jquery';
 import 'bootstrap';
@@ -9,7 +8,7 @@ import 'bootstrap';
     templateUrl: './navbar.component.html'
 })
 export class NavbarComponent implements OnInit {
-    constructor(private _keycloak:KeycloakService, private _router:Router, private _element: ElementRef) {
+    constructor(private _keycloak: KeycloakService, private _element: ElementRef) {
 
     }
 
@@ -17,23 +16,12 @@ export class NavbarComponent implements OnInit {
         $(this._element.nativeElement).find('.dropdown-toggle').dropdown();
     }
 
-    get username():String {
+    get username(): String {
         return this._keycloak.username;
     }
 
     logout(event:Event):void {
         event.preventDefault();
         this._keycloak.logout();
-    }
-
-    isActive(link:HTMLAnchorElement):boolean {
-        if (link == null)
-            return false;
-
-        let linkAttribute = link.attributes.getNamedItem("routerLink");
-        if (linkAttribute == null)
-            return false;
-
-        return linkAttribute.value == this._router.url;
     }
 }


### PR DESCRIPTION
Navbar is being redrawn on certain pages. I'm not sure about the reason. Angular change detector runs `isLinkActive` method many times and completely unnecessarily. I changed that to use Angular way of detecting if link is active. It seems to reduce redrawing at least for certain pages. But the main issue still needs to be fixed. (Unfortunately it might be something completely unrelated).


(Note: If we don't manage to merge before modules, I will rebase, this doesn't have to block modules)