### PR TITLE
Always update execution list when an execution is active

### DIFF
--- a/ui/src/main/webapp/src/app/executions/executions-monitoring.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-monitoring.component.ts
@@ -30,6 +30,7 @@ export abstract class ExecutionsMonitoringComponent extends AbstractComponent {
     }
 
     protected onExecutionEvent(event: ExecutionEvent) {
+
         if (this.isExecutionActive(event.execution)) {
             this.activeExecutionsMap.set(event.execution.id, event.execution);
             this.updateActiveExecutions();


### PR DESCRIPTION
I noticed that the list doesn't always update when running windup. This seems to fix it.