### PR TITLE
Simplify checkboxes component

### DIFF
--- a/ui/src/main/webapp/src/app/shared/checkboxes.component.html
+++ b/ui/src/main/webapp/src/app/shared/checkboxes.component.html
@@ -1,10 +1,12 @@
-<div *ngFor="let option of _options">
-    <label>
-        <input type="checkbox" [name]="groupName"
-               [value]="valueCallback(option)"
-               [checked]="shouldBeChecked(option)"
-               (change)="handleCheckboxChange(option, $event)"
-               />
-        {{labelCallback(option)}}
-    </label>
+<div class="checkboxes-component">
+    <div *ngFor="let option of options">
+        <label>
+            <input type="checkbox" [name]="groupName"
+                   [value]="valueCallback(option)"
+                   [checked]="shouldBeChecked(option)"
+                   (change)="handleCheckboxChange(option, $event)"
+                   />
+            {{labelCallback(option)}}
+        </label>
+    </div>
 </div>

--- a/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
+++ b/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
@@ -11,6 +11,11 @@ export type ItemType = any;
 })
 export class CheckboxesComponent
 {
+    private _options: ItemType[];
+
+    private component: CheckboxesComponent;
+    private rootElement;
+
     /**
      * The name of this checkboxes group.
      */
@@ -44,10 +49,10 @@ export class CheckboxesComponent
         if (!Array.isArray(options))
             throw new Error("Invalid @Input value for options: " + JSON.stringify(options));
     }
-    get options(): ItemType[]{
+
+    get options(): ItemType[] {
         return this._options;
     }
-    _options: ItemType[];
 
     /**
      * This can be either the values or a subset of options.
@@ -69,9 +74,6 @@ export class CheckboxesComponent
 
         return false;
     }
-
-    private component: CheckboxesComponent;
-    private rootElement;
 
     public constructor(element: ElementRef) {
         this.component = this;

--- a/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
+++ b/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
@@ -118,7 +118,7 @@ export class CheckboxesComponent
         if (!checked && index != -1)
             this.checkedOptions.splice(index, 1);
         else
-            this.checkedOptions.push(option);
+            this.checkedOptions.push(this.valueCallback(option));
         
         this.checkedOptionsChange.emit(this.checkedOptions);
     }

--- a/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
+++ b/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
@@ -1,9 +1,7 @@
 import {
-    Component, Input, ElementRef, Output, EventEmitter, ChangeDetectionStrategy
+    Component, Input, Output, EventEmitter, ChangeDetectionStrategy
 } from "@angular/core";
 import {isFunction} from "util";
-
-export type ItemType = any;
 
 @Component({
     templateUrl: './checkboxes.component.html',
@@ -12,15 +10,12 @@ export type ItemType = any;
 })
 export class CheckboxesComponent
 {
-    private _options: ItemType[];
-    private _checkedOptions: ItemType[];
+    private _options: any[];
+    private _checkedOptions: any[];
 
     private _equalsCallback: (a: any, b: any) => boolean = (a, b) => a === b;
     private _labelCallback: (a: any) => string = (a) => a;
     private _valueCallback: (a: any) => any = (a) => a;
-
-    private component: CheckboxesComponent;
-    private rootElement;
 
     /**
      * The name of this checkboxes group.
@@ -29,7 +24,7 @@ export class CheckboxesComponent
     groupName: string = "checkboxes";
 
     /**
-     * Callbacks
+     * Callback to get item value
      */
     @Input()
     public set valueCallback(callback: (item: any) => any) {
@@ -42,6 +37,9 @@ export class CheckboxesComponent
         return this._valueCallback;
     }
 
+    /**
+     * Callback to compare item from options and checked options
+     */
     @Input()
     public set equalsCallback(callback: (a: any, b: any) => boolean) {
         if (callback && isFunction(callback)) {
@@ -55,6 +53,9 @@ export class CheckboxesComponent
         return this._equalsCallback;
     }
 
+    /**
+     * Callback to get item label
+     */
     @Input()
     public set labelCallback(callback: (a: any) => string) {
         if (callback && isFunction(callback)) {
@@ -67,10 +68,10 @@ export class CheckboxesComponent
     }
 
     /**
-     * All available options.
+     * Set available options
      */
     @Input()
-    set options(options: ItemType[]) {
+    set options(options: any[]) {
         if (options && !Array.isArray(options)) {
             throw new Error("Invalid value for options. Expecting array, got: " + JSON.stringify(options));
         }
@@ -78,15 +79,15 @@ export class CheckboxesComponent
         this._options = options || [];
     }
 
-    get options(): ItemType[] {
+    get options(): any[] {
         return this._options;
     }
 
     /**
-     * This can be either the values or a subset of options.
+     * Array of checked options. Could be the same object as option, or object from valueCallback
      */
     @Input()
-    public set checkedOptions(checkedOptions: ItemType[]) {
+    public set checkedOptions(checkedOptions: any[]) {
         if (checkedOptions && !Array.isArray(checkedOptions)) {
             throw new Error("Invalid value for checkedOptions. Expecting array, got: " + JSON.stringify(checkedOptions));
         }
@@ -94,40 +95,31 @@ export class CheckboxesComponent
         this._checkedOptions = checkedOptions || [];
     }
 
-    public get checkedOptions() {
+    public get checkedOptions(): any[] {
         return this._checkedOptions;
     }
 
     @Output()
-    checkedOptionsChange = new EventEmitter<string[] | ItemType[]>();
+    checkedOptionsChange = new EventEmitter<any[]>();
 
-    shouldBeChecked(option: ItemType): boolean {
+    shouldBeChecked(option: any): boolean {
         console.log("shouldBeChecked() called.", option, this.checkedOptions);
 
         if (!this.checkedOptions)
             return false;
 
-        if ((<ItemType[]>this.checkedOptions).some(checkedOption => this.equalsCallback(option, checkedOption)))
-            return true;
-
-        return false;
+        return this.checkedOptions.some(checkedOption => this.equalsCallback(option, checkedOption));
     }
 
-    public constructor(element: ElementRef) {
-        this.component = this;
-        this.rootElement = element.nativeElement;
-    }
-
-    handleCheckboxChange(option: ItemType, $event)  {
+    handleCheckboxChange(option: any, $event)  {
         let checked = $event.target ? $event.target.checked : false;
         let index = this.checkedOptions.findIndex((checkedOption) => this.equalsCallback(checkedOption, option));
-        //console.log("Index: " + index);
 
-        //console.log("handleCheckboxChange() called", this.labelCallback(option), checked);
         if (!checked && index != -1)
             this.checkedOptions.splice(index, 1);
         else
             this.checkedOptions.push(option);
+        
         this.checkedOptionsChange.emit(this.checkedOptions);
     }
 }

--- a/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
+++ b/ui/src/main/webapp/src/app/shared/checkboxes.component.ts
@@ -1,6 +1,7 @@
 import {
     Component, Input, ElementRef, Output, EventEmitter, ChangeDetectionStrategy
 } from "@angular/core";
+import {isFunction} from "util";
 
 export type ItemType = any;
 
@@ -12,6 +13,11 @@ export type ItemType = any;
 export class CheckboxesComponent
 {
     private _options: ItemType[];
+    private _checkedOptions: ItemType[];
+
+    private _equalsCallback: (a: any, b: any) => boolean = (a, b) => a === b;
+    private _labelCallback: (a: any) => string = (a) => a;
+    private _valueCallback: (a: any) => any = (a) => a;
 
     private component: CheckboxesComponent;
     private rootElement;
@@ -26,28 +32,50 @@ export class CheckboxesComponent
      * Callbacks
      */
     @Input()
-    valueCallback: (item: any) => string
-        = app => { throw new Error("valueCallback not yet defined.") };
+    public set valueCallback(callback: (item: any) => any) {
+        if (callback && isFunction(callback)) {
+            this._valueCallback = callback;
+        }
+    }
+
+    public get valueCallback() {
+        return this._valueCallback;
+    }
 
     @Input()
-    labelCallback: (item: ItemType) => string;
+    public set equalsCallback(callback: (a: any, b: any) => boolean) {
+        if (callback && isFunction(callback)) {
+            this._equalsCallback = callback;
+        }
+        //         return this.valueCallback(item1) == this.valueCallback(item2);
+
+    }
+
+    public get equalsCallback() {
+        return this._equalsCallback;
+    }
 
     @Input()
-    equalsCallback: (item1: ItemType, item2: ItemType) => boolean = (item1, item2) => {
-        return this.valueCallback(item1) == this.valueCallback(item2);
-    };
+    public set labelCallback(callback: (a: any) => string) {
+        if (callback && isFunction(callback)) {
+            this._labelCallback = callback;
+        }
+    }
+
+    public get labelCallback() {
+        return this._labelCallback;
+    }
 
     /**
      * All available options.
      */
     @Input()
-    set options(options: ItemType[]){
-        this._options = options;
-        //console.log("set options()", options);
-        if (!options)
-            return; // May be loaded async.
-        if (!Array.isArray(options))
-            throw new Error("Invalid @Input value for options: " + JSON.stringify(options));
+    set options(options: ItemType[]) {
+        if (options && !Array.isArray(options)) {
+            throw new Error("Invalid value for options. Expecting array, got: " + JSON.stringify(options));
+        }
+
+        this._options = options || [];
     }
 
     get options(): ItemType[] {
@@ -58,10 +86,20 @@ export class CheckboxesComponent
      * This can be either the values or a subset of options.
      */
     @Input()
-    checkedOptions: ItemType[] = [];
+    public set checkedOptions(checkedOptions: ItemType[]) {
+        if (checkedOptions && !Array.isArray(checkedOptions)) {
+            throw new Error("Invalid value for checkedOptions. Expecting array, got: " + JSON.stringify(checkedOptions));
+        }
+
+        this._checkedOptions = checkedOptions || [];
+    }
+
+    public get checkedOptions() {
+        return this._checkedOptions;
+    }
 
     @Output()
-    checkedOptionsChange = new EventEmitter<ItemType[]>();
+    checkedOptionsChange = new EventEmitter<string[] | ItemType[]>();
 
     shouldBeChecked(option: ItemType): boolean {
         console.log("shouldBeChecked() called.", option, this.checkedOptions);

--- a/ui/src/main/webapp/tests/app/components/checkboxes.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/checkboxes.component.spec.ts
@@ -1,0 +1,329 @@
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {DebugElement, Component, ViewChild} from "@angular/core";
+import {By} from "@angular/platform-browser";
+import {RouterTestingModule} from "@angular/router/testing";
+import {CheckboxesComponent} from "../../../src/app/shared/checkboxes.component";
+
+let comp:    CheckboxesComponent;
+let fixture: ComponentFixture<CheckboxesComponent>;
+let de:      DebugElement;
+let el:      HTMLElement;
+
+let host:  ComponentFixture<CheckboxesComponentHost>;
+
+@Component({
+    template: `<wu-checkboxes [options]="options" [checkedOptions]="checkedOptions"></wu-checkboxes>`
+})
+class CheckboxesComponentHost {
+    public options = [];
+    public checkedOptions = [];
+
+    @ViewChild(CheckboxesComponent)
+    public checkBoxes;
+}
+
+describe('CheckboxesComponent', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ RouterTestingModule ],
+            declarations: [
+                CheckboxesComponent, CheckboxesComponentHost
+            ]
+        }).compileComponents();
+
+        host = TestBed.createComponent(CheckboxesComponentHost);
+
+        fixture = TestBed.createComponent(CheckboxesComponent);
+        comp = fixture.componentInstance;
+
+        de = fixture.debugElement.query(By.css('div.checkboxes-component'));
+        el = de.nativeElement;
+    });
+
+     describe('For simple values', () => {
+        let items = ['hello', 'world', '42', 'whatever'];
+
+        beforeEach(() => {
+            comp.options = items;
+        });
+
+        it('should display checkbox with label for each item', () => {
+            fixture.detectChanges();
+
+            let labels = fixture.debugElement.queryAll(By.css('label'));
+
+            expect(labels.length).toEqual(items.length);
+
+            let textValues = labels.map(el => el.nativeElement.textContent.trim());
+
+            items.forEach(item => {
+                expect(textValues).toContain(item);
+            })
+        });
+
+        // TODO: this test should be done differently
+        xit('should fire change event when item is selected', () => {
+            let mock = jasmine.createSpyObj('Spy', ['checkedOptionsChange']);
+
+            comp.checkedOptions = [];
+            comp.checkedOptionsChange = mock.checkedOptionsChange;
+
+            fixture.detectChanges();
+
+            clickOnItems(fixture, [ items[0] ]);
+
+            fixture.detectChanges();
+
+            expect(mock.checkedOptionsChange).toHaveBeenCalled();
+            expect(mock.checkedOptionsChange).toHaveBeenCalledWith([ items[0] ]);
+        });
+
+        it('should update checkedOptions when item is selected', () => {
+            comp.checkedOptions = [];
+            fixture.detectChanges();
+
+            clickOnItems(fixture, [ items[0] ]);
+
+            fixture.detectChanges();
+
+            expect(comp.checkedOptions.length).toBe(1);
+            expect(comp.checkedOptions).toContain(items[0]);
+        });
+
+         it('should update checkedOptions when selected item is unselected', () => {
+             comp.checkedOptions = [ items[0] ];
+             fixture.detectChanges();
+
+             clickOnItems(fixture, [ items[0] ]);
+
+             fixture.detectChanges();
+
+             expect(comp.checkedOptions.length).toBe(0);
+         });
+
+        it('should automatically select items based on checkedOptions', () => {
+            let expectedCheckedItems = ['hello', 'world'];
+            comp.checkedOptions = expectedCheckedItems;
+
+            fixture.detectChanges();
+
+            let labels = fixture.debugElement.queryAll(By.css('label'));
+
+            let checkboxItems = new Map<string, boolean>();
+
+            let checkboxValues = labels.map(element => {
+                checkboxItems.set(element.children[0].properties['value'], element.children[0].properties['checked']);
+
+                return {
+                    text: element.children[0].properties['value'],
+                    checked: element.children[0].properties['checked']
+                };
+            });
+
+            let selectedValues = checkboxValues.filter(item => item.checked);
+
+            expect(selectedValues.length).toBe(expectedCheckedItems.length);
+
+            expectedCheckedItems.forEach(checkedItem => {
+                expect(checkboxItems.get(checkedItem)).toBe(true);
+            })
+        });
+
+        // TODO: Find out how to test component with OnPush change detection
+        xit('should automatically update selection when checkedOptions changes', () => {
+            let initiallyCheckedItems = ['hello', 'world'];
+            comp.checkedOptions = initiallyCheckedItems;
+            fixture.detectChanges();
+
+            let newCheckedItems = ['42'];
+            comp.checkedOptions = newCheckedItems;
+            fixture.detectChanges();
+
+            let selectionMap = getSelectionMap(fixture);
+
+            let expectedUncheckedItems = items.filter(item => newCheckedItems.indexOf(item) === -1);
+
+            newCheckedItems.forEach(item => {
+                expect(selectionMap.get(item)).toBe(true);
+            });
+
+            expectedUncheckedItems.forEach(item => {
+                expect(selectionMap.get(item)).toBe(false);
+            });
+        });
+
+        xit('should automatically update displayed checkboxes when options changes', () => {
+            // first change detection for first value
+            fixture.detectChanges();
+
+            let newOptions = ['Orange', 'Apple'];
+
+            comp.options = newOptions;
+            // second change detection for updated value
+            fixture.changeDetectorRef.markForCheck();
+            fixture.changeDetectorRef.detectChanges();
+            fixture.detectChanges();
+
+            let labels = fixture.debugElement.queryAll(By.css('label'));
+            expect(labels.length).toEqual(newOptions.length);
+
+            let textValues = labels.map(el => el.nativeElement.textContent.trim());
+
+            newOptions.forEach(item => {
+                expect(textValues).toContain(item);
+            })
+        });
+    });
+
+    describe('For object values', () => {
+        let valueObjects = [
+            { value: 'Hello value' },
+            { value: 'World value' },
+            { value: 'Secret of the Universe' }
+        ];
+
+        let items = [
+            { id: 1, label: 'Hello', value: valueObjects[0] },
+            { id: 2, label: 'World', value: valueObjects[1] },
+            { id: 3, label: '42', value: valueObjects[2] }
+        ];
+
+        beforeEach(() => {
+            comp.options = items;
+        });
+
+        it('should use labelCallback function to get label', () => {
+            let mock = jasmine.createSpyObj('Spy', ['getLabel']);
+            mock.getLabel.and.callFake(item => item.label);
+            comp.labelCallback = mock.getLabel;
+
+            fixture.detectChanges();
+
+            let labels = fixture.debugElement.queryAll(By.css('label'));
+
+            expect(mock.getLabel).toHaveBeenCalledTimes(items.length);
+            expect(labels.length).toEqual(items.length);
+
+            let textValues = labels.map(el => el.nativeElement.textContent.trim());
+
+            items.forEach(item => {
+                expect(textValues).toContain(item.label);
+            });
+        });
+
+        describe('when using valueCallback function to get value', () => {
+            let mock;
+
+            beforeEach(() => {
+                mock = jasmine.createSpyObj('Spy', ['getValue']);
+                mock.getValue.and.callFake(item => item.value);
+                comp.valueCallback = mock.getValue;
+                comp.checkedOptions = [];
+            });
+
+            it('should return value when item is clicked', () => {
+                fixture.detectChanges();
+
+                clickOnItems(fixture, [ items[0].value ]);
+
+                fixture.detectChanges();
+
+                expect(comp.checkedOptions.length).toBe(1);
+                expect(comp.checkedOptions[0]).toBe(valueObjects[0]);
+            });
+        });
+
+        describe('when no comparator provided', () => {
+            let selectedItems;
+
+            beforeEach(() => {
+                selectedItems = [ items[0], Object.assign({}, items[1]) ];
+            });
+
+            // TODO: How should it behave when unknown object is in checkedOptions?
+            it('should use default object equality comparator', () => {
+                comp.labelCallback = (item) => item.label;
+                comp.checkedOptions = selectedItems;
+
+                fixture.detectChanges();
+
+                let allOptionsArray = getSelectionArray(fixture);
+                let selectedOptionsArray = allOptionsArray.filter(item => item.checked);
+
+                expect(selectedOptionsArray.length).toBe(1);
+                expect(selectedOptionsArray[0].value).toBe(items[0]);
+            });
+        });
+
+        describe('when custom comparator provided', () => {
+            let selectedItems;
+
+            beforeEach(() => {
+                comp.equalsCallback = (option: any, checkedOption: any) => option.id === checkedOption;
+                selectedItems = [ items[0].id ];
+            });
+
+            it('should properly identify selected objects', () => {
+                comp.labelCallback = (item) => item.label;
+                comp.checkedOptions = selectedItems;
+
+                fixture.detectChanges();
+
+                let allOptionsArray = getSelectionArray(fixture);
+                let selectedOptionsArray = allOptionsArray.filter(item => item.checked);
+
+                expect(selectedOptionsArray.length).toBe(1);
+                expect(selectedOptionsArray[0].value).toBe(items[0]);
+            });
+        });
+    });
+});
+
+function getSelectionArray(fixture: ComponentFixture<CheckboxesComponent>) {
+    let labels = fixture.debugElement.queryAll(By.css('label'));
+
+    return labels.map(element => {
+        return {
+            value: element.children[0].properties['value'],
+            checked: element.children[0].properties['checked']
+        };
+    });
+}
+
+function getSelectionMap(fixture: ComponentFixture<CheckboxesComponent>): Map<string, boolean> {
+    let labelElements = fixture.debugElement.queryAll(By.css('label'));
+
+    let checkboxItems = new Map<string, boolean>();
+
+    labelElements.forEach(element => {
+        checkboxItems.set(element.children[0].properties['value'], element.children[0].properties['checked']);
+    });
+
+    return checkboxItems;
+}
+
+function assertSelection(map: Map<any, boolean>, expectChecked: any[], expectNotChecked: any[]) {
+    expectChecked.forEach(item => {
+        expect(map.get(item)).toBe(true);
+    });
+
+    expectNotChecked.forEach(item => {
+        expect(map.get(item)).toBe(false);
+    });
+}
+
+function clickOnItems(fixture: ComponentFixture<CheckboxesComponent>, items: any[]) {
+    let labels = fixture.debugElement.queryAll(By.css('label'));
+
+    items.forEach(item => {
+        let firstItem = labels.find(element => element.children[0].properties['value'] === item);
+
+        if (!firstItem) {
+            throw new Error('Item not found in list' + JSON.stringify(item));
+        }
+
+        firstItem.children[0].nativeElement.click();
+
+        fixture.detectChanges();
+    });
+}


### PR DESCRIPTION
I wanted to simplify checkboxes component, but as I can see, @jsight has already done it in his PR https://github.com/windup/windup-web/pull/254 :)

Anyway, I added several things:
- Default values for callbacks (simplifies usage of component)
- Checks for input values 
- Tests
- Fixed returned items when valueCallback was used