### PR TITLE
Create ContextMenuLink component

### DIFF
--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -117,6 +117,7 @@ import {WizardLayoutComponent} from "./shared/layout/wizard-layout.component";
 import {ExecutionsLayoutComponent} from "./executions/executions-layout.component";
 import {NavbarSelectionComponent} from "./shared/navigation/navbar-selection.component";
 import {DatePipe} from "@angular/common";
+import {ContextMenuLinkComponent} from "./shared/navigation/context-menu-link.component";
 
 /**
  * Load all mapping data from the generated files.
@@ -218,7 +219,8 @@ initializeModelMappingData();
         StatusIconComponent,
         ApplicationListComponent,
         ProjectExecutionsComponent,
-        NavbarSelectionComponent
+        NavbarSelectionComponent,
+        ContextMenuLinkComponent
     ],
     providers: [
         appRoutingProviders,

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu-link.component.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu-link.component.ts
@@ -1,0 +1,48 @@
+import {Component, Input, ChangeDetectionStrategy} from "@angular/core";
+import {ContextMenuItemInterface} from "./context-menu-item.class";
+
+/**
+ * This would ideally be directive which would apply (click) or [routerLink] to existing element
+ * (And wouldn't force it to be <a> tag)
+ *
+ * But Angular currently cannot dynamically apply directives from directives.
+ * See:
+ *  https://github.com/angular/angular/issues/8785
+ *  http://stackoverflow.com/questions/37148080/use-angular2-directive-in-host-of-another-directive
+ *  http://stackoverflow.com/questions/39563547/how-to-instantiate-and-apply-directives-programmatically
+ *
+ * It cannot even replace existing code by component template:
+ *  https://github.com/angular/angular/issues/3866
+ *
+ * So the only option is to use component as container and use <ng-content>
+ *
+ */
+@Component({
+    template: `
+            <a *ngIf="item.action" (click)="click(item)"><ng-content></ng-content></a>
+            <a [routerLink]="getLink(item)"><ng-content></ng-content></a>`,
+    selector: '[wu-context-menu-link]',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    styles: [
+        `a:focus { text-decoration: none; }`
+    ]
+})
+export class ContextMenuLinkComponent {
+    @Input()
+    item: ContextMenuItemInterface;
+
+    click(item: ContextMenuItemInterface) {
+        if (item.action) {
+            item.action();
+        }
+    }
+
+    getLink(item: ContextMenuItemInterface) {
+        if (typeof item.link === 'function') {
+            return item.link();
+        } else {
+            return item.link;
+        }
+    }
+
+}

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
@@ -1,10 +1,8 @@
 <div class="nav-pf-vertical nav-pf-vertical-with-sub-menus nav-pf-persistent-secondary">
     <ul class="list-group">
-        <li class="list-group-item" *ngFor="let item of enabledItems">
-            <a (click)="click(item)">
-                <span class="fa" ngClass="{{item.icon}}" data-toggle="tooltip" title="" [attr.data-original-title]="item.label"></span>
-                <span class="list-group-item-value">{{item.label}}</span>
-            </a>
+        <li class="list-group-item" *ngFor="let item of enabledItems" wu-context-menu-link [item]="item">
+            <span class="fa" ngClass="{{item.icon}}" data-toggle="tooltip" title="" [attr.data-original-title]="item.label"></span>
+            <span class="list-group-item-value">{{item.label}}</span>
         </li>
     </ul>
 </div>

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.ts
@@ -1,6 +1,5 @@
 import {Component, Input, ChangeDetectionStrategy} from "@angular/core";
 import {ContextMenuItemInterface} from "./context-menu-item.class";
-import {Router} from "@angular/router";
 
 @Component({
     selector: 'wu-context-menu',
@@ -12,9 +11,6 @@ export class ContextMenuComponent {
     protected _menuItems: ContextMenuItemInterface[] = [];
     protected enabledItems: ContextMenuItemInterface[] = [];
 
-    constructor(private _router: Router) {
-    }
-
     @Input()
     public set menuItems(items: ContextMenuItemInterface[]) {
         if (!items) {
@@ -23,27 +19,5 @@ export class ContextMenuComponent {
 
         this._menuItems = items;
         this.enabledItems = this._menuItems.filter(item => item.isEnabled);
-    }
-
-    click(item: ContextMenuItemInterface) {
-        if (item.action) {
-            item.action();
-        } else {
-            let link = this.getLink(item);
-
-            if (item.data) {
-                this._router.navigate([link, item.data]);
-            } else {
-                this._router.navigate([link]);
-            }
-        }
-    }
-
-    getLink(item: ContextMenuItemInterface) {
-        if (typeof item.link === 'function') {
-            return item.link();
-        } else {
-            return item.link;
-        }
     }
 }


### PR DESCRIPTION
Currently items in ContextMenu don't have any real link, they have click action which triggers either routing or some action.
Having actual link on items is more user friendly, since it provides option to use 'wheel click'.
User can click with mouse wheel or use ctrl-click and open link in new tab. Also link can be copied.

ContextMenuLink component will handle click actions when defined, or provide [routerLink] with URL, if item has some.


<s>Right now I'm fighting with some angular issues which I would like to resolve first. I would ideally want to use directive which would apply angular default `[routerLink]` but this doesn't work :(  I created [StackOverflow post](http://stackoverflow.com/questions/42696413/angular-custom-routerlink-directive)   so let's see if anyone could help with that...</s>

I found a solution. Not a nice one, but working one :)  `wu-context-menu-link` attribute must be applied to parent element of `<a>` tag.