### PR TITLE
618 delete application

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/model/RegisteredApplication.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/RegisteredApplication.java
@@ -69,7 +69,7 @@ public class RegisteredApplication implements Serializable
     @Column(length = 2048)
     private String reportIndexPath;
 
-    @ManyToOne(optional = false)
+    @ManyToOne
     private MigrationProject migrationProject;
 
     @OneToOne(fetch = FetchType.LAZY)
@@ -82,6 +82,9 @@ public class RegisteredApplication implements Serializable
     @Column(columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     @Temporal(TemporalType.TIMESTAMP)
     private Calendar lastModified;
+
+    @Column
+    private boolean isDeleted = false;
 
     public RegisteredApplication()
     {
@@ -265,6 +268,21 @@ public class RegisteredApplication implements Serializable
     public Calendar getLastModified()
     {
         return lastModified;
+    }
+
+    /**
+     * Checks if application is deleted
+     */
+    public boolean isDeleted()
+    {
+        return isDeleted;
+    }
+
+    /**
+     * Sets application deleted status
+     */
+    public void setDeleted(boolean deleted) {
+        isDeleted = deleted;
     }
 
     @Override

--- a/ui/src/main/webapp/src/app/registered-application/application-list.component.html
+++ b/ui/src/main/webapp/src/app/registered-application/application-list.component.html
@@ -4,7 +4,7 @@
     <div class="header-bar">
         <h2>Project {{project?.title || "loading..."}}</h2>
         <div class="search-and-create">
-            <wu-search (searchValueChange)="updateSearch($event)"></wu-search>
+            <wu-search [(searchValue)]="searchText" (searchValueChange)="updateSearch()"></wu-search>
             <div class="button-container">
                 <button (click)="registerApplication()" class="btn btn-primary" type="button">Register Application</button>
             </div>


### PR DESCRIPTION
Taiga task 618 - deleting application was causing FK Constraint violations.

Now application entity is deleted if it is not used in any AnalysisContext. If it is used in AnalysisContext, flag `isDeleted` is set to `true`.This  "partially deleted" entity is kept in database to enable listing it in older reports.