### PR TITLE
Fix migration issues table

### DIFF
--- a/ui/src/main/webapp/src/app/components/app.component.ts
+++ b/ui/src/main/webapp/src/app/components/app.component.ts
@@ -1,6 +1,7 @@
 import {Component} from "@angular/core";
-import {Router, NavigationEnd} from "@angular/router";
+import {Router, NavigationEnd, ActivatedRouteSnapshot, ActivatedRoute} from "@angular/router";
 import {RouteHistoryService} from "../core/routing/route-history.service";
+import {RouteFlattenerService} from "../core/routing/route-flattener.service";
 
 @Component({
     selector: 'windup-app',
@@ -14,9 +15,17 @@ export class AppComponent {
      *
      * When extension is fixed, this can be safely removed
      */
-    constructor(private router: Router, private routeHistoryService: RouteHistoryService) {
+    constructor(
+        private router: Router,
+        private routeHistoryService: RouteHistoryService,
+        private routeFlattener: RouteFlattenerService,
+        private activatedRoute: ActivatedRoute
+    ) {
         router.events
             .filter(event => event instanceof NavigationEnd)
-            .subscribe((event: NavigationEnd) => routeHistoryService.addNavigationEvent(event));
+            .subscribe((event: NavigationEnd) => {
+                this.routeHistoryService.addNavigationEvent(event);
+                this.routeFlattener.onNewRouteActivated(activatedRoute.snapshot);
+            });
     }
 }

--- a/ui/src/main/webapp/src/app/core/routing/route-flattener.service.ts
+++ b/ui/src/main/webapp/src/app/core/routing/route-flattener.service.ts
@@ -1,5 +1,6 @@
 import {ActivatedRouteSnapshot, UrlSegment, Params, Data, Route} from "@angular/router";
 import {Type, Injectable} from "@angular/core";
+import {Subject, ReplaySubject} from "rxjs";
 
 /**
  * This service is used to get ActivatedRouteSnapshot-like object with flattened data and parameters
@@ -18,6 +19,13 @@ import {Type, Injectable} from "@angular/core";
  */
 @Injectable()
 export class RouteFlattenerService {
+    protected flatRouteLoaded = new ReplaySubject<FlattenedRouteData>(1);
+    public OnFlatRouteLoaded = this.flatRouteLoaded.asObservable();
+
+    public onNewRouteActivated(route: ActivatedRouteSnapshot) {
+        let flatRoute = this.getFlattenedRouteData(route);
+        this.flatRouteLoaded.next(flatRoute);
+    }
 
     public getFlattenedRouteData(route: ActivatedRouteSnapshot): FlattenedRouteData {
         let downLevel = this.getActivatedRouteSnapshotWithChildren(route);

--- a/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
+++ b/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
@@ -73,7 +73,8 @@ export class MigrationIssuesTableComponent extends RoutedComponent implements On
     ngOnInit(): void {
         this.sortedIssues = this.migrationIssues;
 
-        this.addSubscription(this.flatRouteLoaded.subscribe(flatRouteData => {
+        this.addSubscription(this._routeFlattener.OnFlatRouteLoaded.subscribe(flatRouteData => {
+            console.log('flat route loaded');
             this.executionId = parseInt(flatRouteData.params['executionId']);
         }));
     }

--- a/ui/src/main/webapp/src/app/shared/routed.component.ts
+++ b/ui/src/main/webapp/src/app/shared/routed.component.ts
@@ -1,12 +1,11 @@
-import {Router, ActivatedRoute, NavigationEnd} from "@angular/router";
-import {Subject} from "rxjs";
-
+import {Router, ActivatedRoute} from "@angular/router";
+import {ReplaySubject} from "rxjs";
 import {AbstractComponent} from "./AbstractComponent";
 import {RouteFlattenerService, FlattenedRouteData} from "../core/routing/route-flattener.service";
 
 
 export abstract class RoutedComponent extends AbstractComponent {
-    protected flatRouteLoaded = new Subject<FlattenedRouteData>();
+    protected flatRouteLoaded = new ReplaySubject<FlattenedRouteData>(1);
 
     constructor(
         protected _router: Router,
@@ -14,11 +13,6 @@ export abstract class RoutedComponent extends AbstractComponent {
         protected _routeFlattener: RouteFlattenerService
     ) {
         super();
-
-        this.addSubscription(this._router.events.filter(event => event instanceof NavigationEnd).subscribe(_ => {
-            let flatRouteData = this._routeFlattener.getFlattenedRouteData(this._activatedRoute.snapshot);
-
-            this.flatRouteLoaded.next(flatRouteData);
-        }));
+        this._routeFlattener.OnFlatRouteLoaded.subscribe(flatRoute => this.flatRouteLoaded.next(flatRoute));
     }
 }

--- a/ui/src/main/webapp/tests/app/components/reports/application-index/application-index.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/reports/application-index/application-index.component.spec.ts
@@ -94,7 +94,7 @@ describe('ApplicationIndexComponent', () => {
     });
 
     describe('when navigate to non-existing report id', () => {
-        beforeEach( async( inject( [AggregatedStatisticsService, Router], (aggregatedStatsService: any) => {
+        beforeEach( async( inject( [AggregatedStatisticsService, Router, RouteFlattenerService], (aggregatedStatsService: any, router: any, flattener: any) => {
            
             aggregatedStatsService.getAggregatedCategories.and.returnValue(
                 new Observable<any>(observer => {
@@ -134,6 +134,7 @@ describe('ApplicationIndexComponent', () => {
             activeRouteMock.testParams = { executionId: 0 };
             fixture.detectChanges();
             RouterMock.navigationEnd();
+            flattener.onNewRouteActivated(<any>activeRouteMock.snapshot);
         })));
 
         it('should navigate to homepage', async(inject([Router], (router: Router) => {

--- a/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues-table.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues-table.component.spec.ts
@@ -22,6 +22,7 @@ let el:      HTMLElement;
 describe('MigrationissuesTableComponent', () => {
     let migrationIssues: ProblemSummary[];
     let activatedRouteMock: ActivatedRouteMock;
+    let routeFlattener: RouteFlattenerService = new RouteFlattenerService();
 
     beforeEach(() => {
         activatedRouteMock = new ActivatedRouteMock();
@@ -39,7 +40,10 @@ describe('MigrationissuesTableComponent', () => {
                     provide: Router,
                     useValue: RouterMock
                 },
-                RouteFlattenerService,
+                {
+                    provide: RouteFlattenerService,
+                    useValue: routeFlattener
+                },
                 MockBackend,
                 BaseRequestOptions,
                 {
@@ -103,6 +107,7 @@ describe('MigrationissuesTableComponent', () => {
         comp.migrationIssues = migrationIssues;
         fixture.detectChanges();
         RouterMock.navigationEnd();
+        routeFlattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
     });
 
     it('should display migration issues', () => {

--- a/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues.component.spec.ts
@@ -96,7 +96,9 @@ describe('MigrationissuesComponent', () => {
     });
 
     describe('when navigate to non-existing report id', () => {
-        beforeEach(async(inject([MigrationIssuesService, Router], (migrationIssuesService: any) => {
+        beforeEach(async(inject([MigrationIssuesService, Router, RouteFlattenerService],
+                (migrationIssuesService: any, router, flattener: RouteFlattenerService) => {
+
             migrationIssuesService.getAggregatedIssues.and.returnValue(
                 new Observable<any>(observer => {
                     observer.error({error: 'Report not found'});
@@ -107,6 +109,8 @@ describe('MigrationissuesComponent', () => {
             activatedRouteMock.testParams = {executionId: 0};
             fixture.detectChanges();
             RouterMock.navigationEnd();
+
+            flattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
         })));
 
         it('should navigate to homepage', async(inject([Router], (router: Router) => {
@@ -122,7 +126,7 @@ describe('MigrationissuesComponent', () => {
     describe('when navigate to correct report id', () => {
         let migrationIssuesServiceSpy;
 
-        beforeEach(async(inject([MigrationIssuesService], (migrationIssuesService: any) => {
+        beforeEach(async(inject([MigrationIssuesService, RouteFlattenerService], (migrationIssuesService: any, flattener: any) => {
             migrationIssuesServiceSpy = migrationIssuesService;
             migrationIssuesService.getAggregatedIssues.and.returnValue(
                 new Observable<any>(observer => {
@@ -134,6 +138,7 @@ describe('MigrationissuesComponent', () => {
             activatedRouteMock.testParams = {executionId: 1};
             fixture.detectChanges(); // init
             RouterMock.navigationEnd(); // resolve route data
+            flattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
             fixture.detectChanges(); // load changes
         })));
 
@@ -157,7 +162,7 @@ describe('MigrationissuesComponent', () => {
     });
 
     describe('when navigate to report without any issues', () => {
-        beforeEach(async(inject([MigrationIssuesService], (migrationIssuesService: any) => {
+        beforeEach(async(inject([MigrationIssuesService, RouteFlattenerService], (migrationIssuesService: any, flattener: any) => {
             migrationIssuesService.getAggregatedIssues.and.returnValue(
                 new Observable<any>(observer => {
                     let value = {
@@ -172,6 +177,7 @@ describe('MigrationissuesComponent', () => {
             activatedRouteMock.testParams = {executionId: 1};
             fixture.detectChanges(); // init
             RouterMock.navigationEnd(); // resolve route data
+            flattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
             fixture.detectChanges(); // load changes
         })));
 


### PR DESCRIPTION
Taiga task #516 - Clicking on individual issue in issues report returns unhelpful error.
 https://tree.taiga.io/project/rdruss-jboss-migration-windup-v3/task/616

 Actual problem was caused by multiple components subscribing to router
navigationEnd event and consuming that event. Solution is to subscribe
only in AppComponent and provide data to other components by using
shared service - RouteFlattenerService in this case.

Also ReplaySubject rather than Subject must be used - if component
subscribes after event was trigger, it wouldn't get any data.
ReplaySubject(1) will hold data to 1 step back and provide current
 data to components subscribing later then event actually happened.