### PR TITLE
Revert "Fix migration issues table"

### DIFF
--- a/ui/src/main/webapp/src/app/components/app.component.ts
+++ b/ui/src/main/webapp/src/app/components/app.component.ts
@@ -1,7 +1,6 @@
 import {Component} from "@angular/core";
-import {Router, NavigationEnd, ActivatedRouteSnapshot, ActivatedRoute} from "@angular/router";
+import {Router, NavigationEnd} from "@angular/router";
 import {RouteHistoryService} from "../core/routing/route-history.service";
-import {RouteFlattenerService} from "../core/routing/route-flattener.service";
 
 @Component({
     selector: 'windup-app',
@@ -15,17 +14,9 @@ export class AppComponent {
      *
      * When extension is fixed, this can be safely removed
      */
-    constructor(
-        private router: Router,
-        private routeHistoryService: RouteHistoryService,
-        private routeFlattener: RouteFlattenerService,
-        private activatedRoute: ActivatedRoute
-    ) {
+    constructor(private router: Router, private routeHistoryService: RouteHistoryService) {
         router.events
             .filter(event => event instanceof NavigationEnd)
-            .subscribe((event: NavigationEnd) => {
-                this.routeHistoryService.addNavigationEvent(event);
-                this.routeFlattener.onNewRouteActivated(activatedRoute.snapshot);
-            });
+            .subscribe((event: NavigationEnd) => routeHistoryService.addNavigationEvent(event));
     }
 }

--- a/ui/src/main/webapp/src/app/core/routing/route-flattener.service.ts
+++ b/ui/src/main/webapp/src/app/core/routing/route-flattener.service.ts
@@ -1,6 +1,5 @@
 import {ActivatedRouteSnapshot, UrlSegment, Params, Data, Route} from "@angular/router";
 import {Type, Injectable} from "@angular/core";
-import {Subject, ReplaySubject} from "rxjs";
 
 /**
  * This service is used to get ActivatedRouteSnapshot-like object with flattened data and parameters
@@ -19,13 +18,6 @@ import {Subject, ReplaySubject} from "rxjs";
  */
 @Injectable()
 export class RouteFlattenerService {
-    protected flatRouteLoaded = new ReplaySubject<FlattenedRouteData>(1);
-    public OnFlatRouteLoaded = this.flatRouteLoaded.asObservable();
-
-    public onNewRouteActivated(route: ActivatedRouteSnapshot) {
-        let flatRoute = this.getFlattenedRouteData(route);
-        this.flatRouteLoaded.next(flatRoute);
-    }
 
     public getFlattenedRouteData(route: ActivatedRouteSnapshot): FlattenedRouteData {
         let downLevel = this.getActivatedRouteSnapshotWithChildren(route);

--- a/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
+++ b/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
@@ -73,8 +73,7 @@ export class MigrationIssuesTableComponent extends RoutedComponent implements On
     ngOnInit(): void {
         this.sortedIssues = this.migrationIssues;
 
-        this.addSubscription(this._routeFlattener.OnFlatRouteLoaded.subscribe(flatRouteData => {
-            console.log('flat route loaded');
+        this.addSubscription(this.flatRouteLoaded.subscribe(flatRouteData => {
             this.executionId = parseInt(flatRouteData.params['executionId']);
         }));
     }

--- a/ui/src/main/webapp/src/app/shared/routed.component.ts
+++ b/ui/src/main/webapp/src/app/shared/routed.component.ts
@@ -1,11 +1,12 @@
-import {Router, ActivatedRoute} from "@angular/router";
-import {ReplaySubject} from "rxjs";
+import {Router, ActivatedRoute, NavigationEnd} from "@angular/router";
+import {Subject} from "rxjs";
+
 import {AbstractComponent} from "./AbstractComponent";
 import {RouteFlattenerService, FlattenedRouteData} from "../core/routing/route-flattener.service";
 
 
 export abstract class RoutedComponent extends AbstractComponent {
-    protected flatRouteLoaded = new ReplaySubject<FlattenedRouteData>(1);
+    protected flatRouteLoaded = new Subject<FlattenedRouteData>();
 
     constructor(
         protected _router: Router,
@@ -13,6 +14,11 @@ export abstract class RoutedComponent extends AbstractComponent {
         protected _routeFlattener: RouteFlattenerService
     ) {
         super();
-        this._routeFlattener.OnFlatRouteLoaded.subscribe(flatRoute => this.flatRouteLoaded.next(flatRoute));
+
+        this.addSubscription(this._router.events.filter(event => event instanceof NavigationEnd).subscribe(_ => {
+            let flatRouteData = this._routeFlattener.getFlattenedRouteData(this._activatedRoute.snapshot);
+
+            this.flatRouteLoaded.next(flatRouteData);
+        }));
     }
 }

--- a/ui/src/main/webapp/tests/app/components/reports/application-index/application-index.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/reports/application-index/application-index.component.spec.ts
@@ -94,7 +94,7 @@ describe('ApplicationIndexComponent', () => {
     });
 
     describe('when navigate to non-existing report id', () => {
-        beforeEach( async( inject( [AggregatedStatisticsService, Router, RouteFlattenerService], (aggregatedStatsService: any, router: any, flattener: any) => {
+        beforeEach( async( inject( [AggregatedStatisticsService, Router], (aggregatedStatsService: any) => {
            
             aggregatedStatsService.getAggregatedCategories.and.returnValue(
                 new Observable<any>(observer => {
@@ -134,7 +134,6 @@ describe('ApplicationIndexComponent', () => {
             activeRouteMock.testParams = { executionId: 0 };
             fixture.detectChanges();
             RouterMock.navigationEnd();
-            flattener.onNewRouteActivated(<any>activeRouteMock.snapshot);
         })));
 
         it('should navigate to homepage', async(inject([Router], (router: Router) => {

--- a/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues-table.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues-table.component.spec.ts
@@ -22,7 +22,6 @@ let el:      HTMLElement;
 describe('MigrationissuesTableComponent', () => {
     let migrationIssues: ProblemSummary[];
     let activatedRouteMock: ActivatedRouteMock;
-    let routeFlattener: RouteFlattenerService = new RouteFlattenerService();
 
     beforeEach(() => {
         activatedRouteMock = new ActivatedRouteMock();
@@ -40,10 +39,7 @@ describe('MigrationissuesTableComponent', () => {
                     provide: Router,
                     useValue: RouterMock
                 },
-                {
-                    provide: RouteFlattenerService,
-                    useValue: routeFlattener
-                },
+                RouteFlattenerService,
                 MockBackend,
                 BaseRequestOptions,
                 {
@@ -107,7 +103,6 @@ describe('MigrationissuesTableComponent', () => {
         comp.migrationIssues = migrationIssues;
         fixture.detectChanges();
         RouterMock.navigationEnd();
-        routeFlattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
     });
 
     it('should display migration issues', () => {

--- a/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/reports/migration-issues/migration-issues.component.spec.ts
@@ -96,9 +96,7 @@ describe('MigrationissuesComponent', () => {
     });
 
     describe('when navigate to non-existing report id', () => {
-        beforeEach(async(inject([MigrationIssuesService, Router, RouteFlattenerService],
-                (migrationIssuesService: any, router, flattener: RouteFlattenerService) => {
-
+        beforeEach(async(inject([MigrationIssuesService, Router], (migrationIssuesService: any) => {
             migrationIssuesService.getAggregatedIssues.and.returnValue(
                 new Observable<any>(observer => {
                     observer.error({error: 'Report not found'});
@@ -109,8 +107,6 @@ describe('MigrationissuesComponent', () => {
             activatedRouteMock.testParams = {executionId: 0};
             fixture.detectChanges();
             RouterMock.navigationEnd();
-
-            flattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
         })));
 
         it('should navigate to homepage', async(inject([Router], (router: Router) => {
@@ -126,7 +122,7 @@ describe('MigrationissuesComponent', () => {
     describe('when navigate to correct report id', () => {
         let migrationIssuesServiceSpy;
 
-        beforeEach(async(inject([MigrationIssuesService, RouteFlattenerService], (migrationIssuesService: any, flattener: any) => {
+        beforeEach(async(inject([MigrationIssuesService], (migrationIssuesService: any) => {
             migrationIssuesServiceSpy = migrationIssuesService;
             migrationIssuesService.getAggregatedIssues.and.returnValue(
                 new Observable<any>(observer => {
@@ -138,7 +134,6 @@ describe('MigrationissuesComponent', () => {
             activatedRouteMock.testParams = {executionId: 1};
             fixture.detectChanges(); // init
             RouterMock.navigationEnd(); // resolve route data
-            flattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
             fixture.detectChanges(); // load changes
         })));
 
@@ -162,7 +157,7 @@ describe('MigrationissuesComponent', () => {
     });
 
     describe('when navigate to report without any issues', () => {
-        beforeEach(async(inject([MigrationIssuesService, RouteFlattenerService], (migrationIssuesService: any, flattener: any) => {
+        beforeEach(async(inject([MigrationIssuesService], (migrationIssuesService: any) => {
             migrationIssuesService.getAggregatedIssues.and.returnValue(
                 new Observable<any>(observer => {
                     let value = {
@@ -177,7 +172,6 @@ describe('MigrationissuesComponent', () => {
             activatedRouteMock.testParams = {executionId: 1};
             fixture.detectChanges(); // init
             RouterMock.navigationEnd(); // resolve route data
-            flattener.onNewRouteActivated(<any>activatedRouteMock.snapshot);
             fixture.detectChanges(); // load changes
         })));
 


### PR DESCRIPTION
Reverts windup/windup-web#274

There is an issue with `ReplaySubject` - it will trigger event for initial navigation. But that one doesn't have required data available. Using `Subject` is not a valid solution either, because components subscribing later won't get any data.

I need to think it through little bit more. 