### PR TITLE
Fix production Angular build

### DIFF
--- a/ui/src/main/webapp/config/webpack.common.js
+++ b/ui/src/main/webapp/config/webpack.common.js
@@ -1,9 +1,7 @@
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var ProvidePlugin = webpack.ProvidePlugin;
 var ContextReplacementPlugin = webpack.ContextReplacementPlugin;
-var DedupePlugin = webpack.optimize.DedupePlugin;
 var CommonsChunkPlugin = webpack.optimize.CommonsChunkPlugin;
 var helpers = require('./helpers');
 
@@ -35,7 +33,7 @@ module.exports = {
             },
             {
                 test: /\.css$/,
-                exclude: helpers.root('src', 'app'),
+                exclude: [helpers.root('src', 'app'), helpers.root('node_modules', '@swimlane')],
                 loader: ExtractTextPlugin.extract({ fallback: 'style-loader', loader: ['css-loader?sourceMap'], publicPath: '../' })
             },
             {
@@ -47,7 +45,7 @@ module.exports = {
             },
             {
                 test: /\.css$/,
-                include: helpers.root('src', 'app'),
+                include: [helpers.root('src', 'app'), helpers.root('node_modules', '@swimlane')],
                 loader: 'raw-loader'
             },
             // All the sh*t for jQuery and other global plugins


### PR DESCRIPTION
The extracttextloader should not be used for Angular CSS. However, the ngx-charts dependency was being
loaded by it. This change makes these css files be loaded by the raw-loader, which appears to work.