### PR TITLE
Fix active execution monitoring

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -14,7 +14,7 @@ import {AnalysisContext, Package, MigrationPath, AdvancedOption, RulesPath, Pack
 import {RouteHistoryService} from "../core/routing/route-history.service";
 import {Subscription} from "rxjs";
 import {RouteFlattenerService} from "../core/routing/route-flattener.service";
-import {WindupService} from "../services/windup.service";
+import {WindupExecutionService} from "../services/windup-execution.service";
 import {NotificationService} from "../core/notification/notification.service";
 import {utils} from "../shared/utils";
 import {RegisteredApplicationService} from "../registered-application/registered-application.service";
@@ -68,7 +68,7 @@ export class AnalysisContextFormComponent extends FormComponent
                 private _packageRegistryService: PackageRegistryService,
                 private _routeHistoryService: RouteHistoryService,
                 private _routeFlattener: RouteFlattenerService,
-                private _windupService: WindupService,
+                private _windupExecutionService: WindupExecutionService,
                 private _notificationService: NotificationService,
                 private _registeredApplicationService: RegisteredApplicationService
     ) {
@@ -243,7 +243,7 @@ export class AnalysisContextFormComponent extends FormComponent
 
     onSuccess(analysisContext: AnalysisContext) {
         if (this.action === Action.SaveAndRun) {
-            this._windupService.executeWindupWithAnalysisContext(analysisContext.id)
+            this._windupExecutionService.execute(analysisContext, this.project)
                 .subscribe(execution => {
                     this._notificationService.success('Windup execution has started');
                     this._router.navigate([`/projects/${this.project.id}`]);

--- a/ui/src/main/webapp/src/app/executions/project-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/project-executions.component.ts
@@ -6,7 +6,7 @@ import {WindupExecutionService} from "../services/windup-execution.service";
 import {ExecutionsMonitoringComponent} from "./executions-monitoring.component";
 import {MigrationProject} from "windup-services";
 import {WindupService} from "../services/windup.service";
-import {ExecutionUpdatedEvent, ExecutionEvent} from "../core/events/windup-event";
+import {ExecutionUpdatedEvent, ExecutionEvent, NewExecutionStartedEvent} from "../core/events/windup-event";
 
 @Component({
     template: '<wu-executions-list [executions]="executions" [activeExecutions]="activeExecutions"></wu-executions-list>'
@@ -29,7 +29,9 @@ export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent im
             this.refreshExecutionList();
         });
 
-        this.addSubscription(this._eventBus.onEvent.filter(event => event.isTypeOf(ExecutionUpdatedEvent))
+        this.addSubscription(this._eventBus.onEvent
+            .filter(event => event.isTypeOf(ExecutionEvent))
+            .filter((event: ExecutionEvent) => event.migrationProject.id === this.project.id)
             .subscribe((event: ExecutionEvent) => this.onExecutionEvent(event)));
     }
 


### PR DESCRIPTION
Update AnalysisContextForm - use the right service and method to start
execution. WindupExecutionService.execute methods triggers execution,
fires proper event and watches for changes.

Use ReplaySubject(3) in EventBusService. Components registering for
events after navigation wouldn't get any if Subject was used. 3 events
back seems to be reasonable size of history for this purpose.