### PR TITLE
Improve cache

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/migration-path.service.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/migration-path.service.ts
@@ -5,6 +5,7 @@ import {Constants} from "../constants";
 import {MigrationPath} from "windup-services";
 import {AbstractService} from "../shared/abtract.service";
 import {Observable} from "rxjs";
+import {Cached} from "../shared/cache.service";
 
 @Injectable()
 export class MigrationPathService extends AbstractService {
@@ -14,6 +15,7 @@ export class MigrationPathService extends AbstractService {
         super();
     }
 
+    @Cached({section: 'migrationPath', immutable: true})
     getAll(): Observable<MigrationPath[]> {
         return this._http.get(Constants.REST_BASE + this.GET_ALL_URL,)
             .map(res => <MigrationPath[]> res.json())

--- a/ui/src/main/webapp/src/app/configuration/configuration-options.service.ts
+++ b/ui/src/main/webapp/src/app/configuration/configuration-options.service.ts
@@ -7,6 +7,7 @@ import {ConfigurationOption} from "../model/configuration-option.model";
 import {Observable} from "rxjs/Observable";
 import {ValidationResult} from "../model/validation-result.model";
 import {AdvancedOption} from "windup-services";
+import {Cached} from "../shared/cache.service";
 
 @Injectable()
 export class ConfigurationOptionsService extends AbstractService {
@@ -25,6 +26,7 @@ export class ConfigurationOptionsService extends AbstractService {
             .catch(this.handleError);
     }
 
+    @Cached({section: 'configurationOptions', immutable: true})
     getAll(): Observable<ConfigurationOption[]> {
         return this._http.get(Constants.REST_BASE + this.GET_CONFIGURATION_OPTIONS_URL)
             .map(res => <ConfigurationOption[]> res.json())

--- a/ui/src/main/webapp/src/app/configuration/configuration.service.ts
+++ b/ui/src/main/webapp/src/app/configuration/configuration.service.ts
@@ -5,6 +5,7 @@ import {Observable} from 'rxjs/Observable';
 import {Constants} from "../constants";
 import {Configuration, RulesPath} from "windup-services";
 import {AbstractService} from "../shared/abtract.service";
+import {Cached} from "../shared/cache.service";
 
 @Injectable()
 export class ConfigurationService extends AbstractService {
@@ -24,6 +25,7 @@ export class ConfigurationService extends AbstractService {
             .catch(this.handleError);
     }
 
+    @Cached({section: 'configuration', immutable: true})
     get(): Observable<Configuration> {
         return this._http.get(Constants.REST_BASE + this.GET_URL)
             .map(res => <Configuration> res.json())
@@ -32,6 +34,7 @@ export class ConfigurationService extends AbstractService {
 
     private GET_CUSTOM_RULESETS_URL = "/configuration/custom-rulesets";
 
+    @Cached({section: 'configuration', immutable: true})
     getCustomRulesetPaths(): Observable<RulesPath[]> {
         return this._http.get(Constants.REST_BASE + this.GET_CUSTOM_RULESETS_URL)
             .map(res => <RulesPath[]> res.json())

--- a/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
+++ b/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
@@ -14,7 +14,7 @@ import {
 import {MigrationProject} from "windup-services";
 import {PackageMetadata} from "windup-services";
 import {SchedulerService} from "../shared/scheduler.service";
-import {Subject} from "rxjs";
+import {ReplaySubject, Subject} from "rxjs";
 import {Cached} from "../shared/cache.service";
 
 @Injectable()
@@ -243,7 +243,8 @@ export class RegisteredApplicationService extends AbstractService {
     }
 
     waitUntilPackagesAreResolved(application: RegisteredApplication): Observable<PackageMetadata> {
-        let subject = new Subject<PackageMetadata>();
+        // ReplaySubject must be used because data might be cached and resolved right away
+        let subject = new ReplaySubject<PackageMetadata>(1);
 
         let closure = () => {
             this.getPackageMetadata(application).subscribe(packageMetadata => {

--- a/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
+++ b/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
@@ -217,16 +217,23 @@ export class RegisteredApplicationService extends AbstractService {
     }
 
     /**
-     * Method
-     * @param metadata
-     * @returns {PackageMetadata|boolean}
+     * Checks if PackageMetadata scanStatus is complete.
+     * If it is, PackageMetadata object can be treated as immutable and cached
+     *
+     * @param metadata {PackageMetadata}
+     * @returns {boolean}
      */
     static arePackagesLoaded = (metadata: PackageMetadata) => {
         return metadata && metadata.scanStatus === "COMPLETE";
     };
 
-    //@Cached({section: 'application', immutable: true, expiration: {minutes: 5}})
-    @Cached('application', null, true, RegisteredApplicationService.arePackagesLoaded)
+    /**
+     * Gets package metadata
+     *
+     * @param application {RegisteredApplication}
+     * @returns {Observable<PackageMetadata>}
+     */
+    @Cached({section: 'application', immutable: true, cacheItemCallback: RegisteredApplicationService.arePackagesLoaded})
     getPackageMetadata(application: RegisteredApplication): Observable<PackageMetadata> {
         let url = Constants.REST_BASE + RegisteredApplicationService.PACKAGES_URL.replace("{appId}", application.id.toString());
 

--- a/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
+++ b/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
@@ -216,6 +216,17 @@ export class RegisteredApplicationService extends AbstractService {
             .catch(this.handleError);
     }
 
+    /**
+     * Method
+     * @param metadata
+     * @returns {PackageMetadata|boolean}
+     */
+    static arePackagesLoaded = (metadata: PackageMetadata) => {
+        return metadata && metadata.scanStatus === "COMPLETE";
+    };
+
+    //@Cached({section: 'application', immutable: true, expiration: {minutes: 5}})
+    @Cached('application', null, true, RegisteredApplicationService.arePackagesLoaded)
     getPackageMetadata(application: RegisteredApplication): Observable<PackageMetadata> {
         let url = Constants.REST_BASE + RegisteredApplicationService.PACKAGES_URL.replace("{appId}", application.id.toString());
 

--- a/ui/src/main/webapp/src/app/shared/cache.service.ts
+++ b/ui/src/main/webapp/src/app/shared/cache.service.ts
@@ -125,13 +125,28 @@ interface CacheExpiration {
 /**
  * Caches function call result
  *
+ * @param configuration {CacheConfiguration}
+ */
+export function Cached(configuration?: CacheConfiguration);
+/**
+ * Caches function call result
+ *
  * @param section {string} Cache section name
  * @param expiration {CacheExpiration} Expiration time (default is 5 min.)
  * @param immutable {boolean} If object is immutable, its cache never expires
  * @param cacheItemCallback {Function} Callback which specifies if item can be cached.
  */
-export function Cached(section?: string, expiration?: CacheExpiration, immutable: boolean = false, cacheItemCallback?: Function) {
-    if (section === null || section === undefined) {
+export function Cached(section?: string, expiration?: CacheExpiration, immutable?: boolean, cacheItemCallback?: Function);
+export function Cached(section?, expiration?: CacheExpiration, immutable: boolean = false, cacheItemCallback?: Function) {
+    if (typeof section === 'object') {
+        let configuration = Object.assign({}, {
+            immutable: false
+        }, section);
+
+        expiration = configuration.expiration;
+        immutable = configuration.immutable;
+        cacheItemCallback = configuration.cacheItemCallback;
+    } else if (section === null || section === undefined) {
         section = 'global';
     }
 
@@ -200,3 +215,10 @@ function getCacheKey(functionName: string, args: any[]) {
 
 // I hope this will be sufficient for having single instance
 export const CacheServiceInstance = new CacheService();
+
+export interface CacheConfiguration {
+    section?: string;
+    immutable?: boolean;
+    expiration?: CacheExpiration;
+    cacheItemCallback?: (any) => boolean;
+}

--- a/ui/src/main/webapp/src/app/shared/cache.service.ts
+++ b/ui/src/main/webapp/src/app/shared/cache.service.ts
@@ -209,7 +209,7 @@ function isObservable(obj: any|Observable<any>) {
 }
 
 function getCacheKey(functionName: string, args: any[]) {
-    let commaSeparatedArgs = args.join(', ');
+    let commaSeparatedArgs = args.map(arg => JSON.stringify(arg)).join(', ');
 
     return functionName + '(' + commaSeparatedArgs + ')';
 }

--- a/ui/src/main/webapp/tests/app/services/cache/cache.decorator.spec.ts
+++ b/ui/src/main/webapp/tests/app/services/cache/cache.decorator.spec.ts
@@ -42,6 +42,15 @@ class MockClass {
     public world(value: number) {
         return value;
     }
+
+
+    public arbitraryParameterCalledTimes = 0;
+
+    @Cached()
+    public arbitraryParameter(object: any) {
+        this.arbitraryParameterCalledTimes++;
+        return object;
+    }
 }
 
 class MockCacheSection extends CacheSection {
@@ -223,6 +232,51 @@ describe('@Cached decorator', () => {
 
                 expect(sectionSection.countItems()).toBe(1);
             });
+        });
+    });
+
+    describe('Passing different function parameters', () => {
+        beforeEach(() => {
+            instance.arbitraryParameterCalledTimes = 0;
+        });
+
+        let functionCallTemplate = (parameter, anotherParameter, countCallsFirst = 1, countCallsSecond = 2) => {
+            let result = instance.arbitraryParameter(parameter);
+            let cachedResult = instance.arbitraryParameter(parameter);
+
+            expect(instance.arbitraryParameterCalledTimes).toBe(countCallsFirst);
+            expect(cachedResult).toBe(result);
+            expect(cachedResult).toBe(parameter);
+
+            for (let i = 0; i < 2; i++) {
+                let result = instance.arbitraryParameter(anotherParameter);
+
+                expect(instance.arbitraryParameterCalledTimes).toBe(countCallsSecond);
+                expect(result).toBe(anotherParameter);
+            }
+        };
+
+        it('should work for numeric parameter', () => {
+            functionCallTemplate(7, 42);
+        });
+
+        it('should work for string parameter', () => {
+            functionCallTemplate('hello', 'world');
+        });
+
+        it('should work for object parameter', () => {
+            let firstObject = { title: 'hello' };
+            let secondObject = { title: 'world' };
+            let thirdObject = { title: 'hello' };
+
+            functionCallTemplate(firstObject, secondObject);
+
+            let result = instance.arbitraryParameter(firstObject);
+            let cachedResult = instance.arbitraryParameter(thirdObject);
+            // first object and third object has the same signature => they should have the same cache key
+            expect(instance.arbitraryParameterCalledTimes).toBe(2);
+            expect(result).toBe(cachedResult);
+            expect(result).toBe(firstObject);
         });
     });
 });

--- a/ui/src/main/webapp/tests/app/services/cache/cache.decorator.spec.ts
+++ b/ui/src/main/webapp/tests/app/services/cache/cache.decorator.spec.ts
@@ -1,12 +1,16 @@
 import {Cached, CacheSection, CacheServiceInstance} from "../../../../src/app/shared/cache.service";
+import {Observable} from "rxjs";
 
 let cacheServiceInstance = CacheServiceInstance;
 let sectionSection = cacheServiceInstance.getSection('section');
 let globalSection = cacheServiceInstance.getSection('global');
 
 class MockClass {
+    public fooCalledTimes = 0;
+
     @Cached()
     public foo(id: number) {
+        this.fooCalledTimes++;
         return id;
     }
 
@@ -20,9 +24,23 @@ class MockClass {
         return 'world';
     }
 
+    public greetCalledTimes = 0;
+
     @Cached('section', {minutes: 10, seconds: 10}, false)
     public greet() {
+        let value = this.greetCalledTimes === 0 ? 7 : 77;
+        this.greetCalledTimes++;
 
+        return Observable.of(value);
+    }
+
+    static CacheItemCallback = (value: number) => {
+        return value > 42;
+    };
+
+    @Cached({section: 'section', immutable: true, expiration: {seconds: 1}, cacheItemCallback: MockClass.CacheItemCallback})
+    public world(value: number) {
+        return value;
     }
 }
 
@@ -40,23 +58,17 @@ class MockCacheSection extends CacheSection {
     }
 }
 
-/**
- * TODO: Temporarily commented out
- * I'm afraid I' don't have the same instance of CacheServiceInstance as Cached decorator has
- */
-xdescribe('@Cached decorator', () => {
+describe('@Cached decorator', () => {
     let instance = new MockClass();
-    let cacheSectionSection = new MockCacheSection(sectionSection);
-    let cacheSectionGlobal = new MockCacheSection(globalSection);
+    let mockCacheSectionSection = new MockCacheSection(sectionSection);
+    let mockCacheSectionGlobal = new MockCacheSection(globalSection);
 
     describe('Empty decorator without parameter', () => {
         let key = 'foo(42)';
         let value = 42;
 
         beforeEach(() => {
-            spyOn(instance, 'foo');
             instance.foo(value);
-            console.log(sectionSection);
         });
 
         it('should add item into "global" cache section after first call', () => {
@@ -68,29 +80,35 @@ xdescribe('@Cached decorator', () => {
         });
 
         it('should store proper value for given item', () => {
-            expect(globalSection.getItem(key)).toBe(value);
+            expect(globalSection.getItem(key).value).toBe(value);
         });
 
         it('should use default configuration for item', () => {
-            let item = cacheSectionGlobal.map.get(key);
+            let item = mockCacheSectionGlobal.map.get(key);
             expect(item.immutable).toBe(false);
-            expect(item.expires.getTime() - item.expires.getTime()).toBe(5 * 60 * 1000);
+            expect(item.expires.getTime() - item.created.getTime()).toBe(5 * 60 * 1000);
         });
 
         it('should no longer call method after having item in cache', () => {
+            // Cannot use spies here - they probably think method got called even though it did not
+            //let originalMethod = instance.foo.bind(instance);
+            //spyOn(instance, 'foo').and.callFake((value) => originalMethod(value));
+
+            instance.fooCalledTimes = 0;
+
             for (let i = 0; i < 4; i++) {
                 let result = instance.foo(value);
                 expect(result).toBe(value);
             }
 
-            expect(instance.foo).toHaveBeenCalledTimes(1);
+            expect(instance.fooCalledTimes).toBe(0);
         });
 
         it('should call method for different item', () => {
+            instance.fooCalledTimes = 0;
             instance.foo(500);
 
-            expect(instance.foo).toHaveBeenCalled();
-            expect(instance.foo).toHaveBeenCalledWith(500);
+            expect(instance.fooCalledTimes).toBe(1);
         });
     });
 
@@ -112,12 +130,12 @@ xdescribe('@Cached decorator', () => {
     describe('Decorator with all parameters', () => {
         beforeEach(() => {
             instance.hello();
-            instance.greet();
+            instance.greet().subscribe(_ => {}); // needs to be subscribed, otherwise Observable.do is not executed
         });
 
         it('should properly set them in cache item', () => {
-            let key = 'hello';
-            let item = cacheSectionSection.map.get(key);
+            let key = 'hello()';
+            let item = mockCacheSectionSection.map.get(key);
 
             let interval = item.expires.getTime() - item.created.getTime();
             let oneSecondInMs = 1000;
@@ -126,15 +144,85 @@ xdescribe('@Cached decorator', () => {
             expect(interval).toBe(oneSecondInMs);
         });
 
-        it('shoud properly set immutable parameter', () => {
-            let key = 'greet';
-            let item = cacheSectionSection.map.get(key);
+        it('should properly set immutable parameter', () => {
+            let key = 'greet()';
+            let item = mockCacheSectionSection.map.get(key);
 
             let interval = item.expires.getTime() - item.created.getTime();
             let expectedInterval = 10 * 60 * 1000 + 10 * 1000;
 
             expect(item.immutable).toBe(false);
             expect(interval).toBe(expectedInterval);
+        });
+
+        it('should return cached value as observable for observables', () => {
+            expect(instance.greet().subscribe).toBeDefined();
+            instance.greet().subscribe(value => {
+                expect(value).toBe(7);
+            });
+        });
+
+        it('should call function again, when value is out of cache', () => {
+            instance.greetCalledTimes = 0;
+
+            sectionSection.clear(); // clear cache, first call should go to function
+
+            for (let i = 0; i < 2; i++) {
+                // first call should return 7 and store it in cache
+                // second call should get it from cache
+                instance.greet().subscribe(value => {
+                    expect(value).toBe(7);
+                });
+            }
+
+            sectionSection.clear(); // cache should be cleared
+            instance.greet().subscribe(value => {
+                expect(value).toBe(77); // and function should be called again, this time returning 77
+            })
+        });
+    });
+
+    describe('Decorator with object syntax', () => {
+        let key;
+
+        beforeEach(() => {
+            sectionSection.clear();
+
+            key = 'world(120)';
+            instance.world(120);
+        });
+
+        it('should properly set immutable property', () => {
+            let item = mockCacheSectionSection.map.get(key);
+
+            expect(item.immutable).toBe(true);
+        });
+
+        it('should properly set expiration time', () => {
+            let item = mockCacheSectionSection.map.get(key);
+
+            let interval = item.expires.getTime() - item.created.getTime();
+            let oneSecondInMs = 1000;
+
+            expect(interval).toBe(oneSecondInMs);
+        });
+
+        describe('cacheItemCallback', () => {
+            beforeEach(() => {
+                sectionSection.clear();
+            });
+
+            it('should not cache items for which callback returns false', () => {
+                instance.world(42);
+
+                expect(sectionSection.countItems()).toBe(0);
+            });
+
+            it('should cache items for which callback returns true', () => {
+                instance.world(420);
+
+                expect(sectionSection.countItems()).toBe(1);
+            });
         });
     });
 });


### PR DESCRIPTION
Add `cacheItemCallback` to `@Cached` decorator

Callback is used to determine if item can be cached. Result from function call is passed to callback and if it returns true, it is cached. Otherwise not.

It is useful for situations when certain object can be cached when it is in some specific state (for example `PackageMetadata` can be cached when `scanStatus` is `"COMPLETE"`).