### PR TITLE
Added an application list as the default report page.

### DIFF
--- a/ui/src/main/webapp/css/windup-web.css
+++ b/ui/src/main/webapp/css/windup-web.css
@@ -112,7 +112,7 @@ td {
     font-size: 12px;
 }
 
-a[target='_blank']::before {
+.external-link::before {
     content: '\F2D2';
     font: normal normal normal 14px/1 FontAwesome;
     font-size: 12px;

--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -120,6 +120,7 @@ import {DatePipe} from "@angular/common";
 import {ApplicationLevelLayoutComponent} from "./reports/application-level-layout.component";
 import {SelectApplicationsComponent} from "./analysis-context/select-applications.component";
 import {ContextMenuLinkComponent} from "./shared/navigation/context-menu-link.component";
+import {ExecutionApplicationListComponent} from "./reports/execution-application-list/execution-application-list.component";
 import {SourceResolve} from "./reports/source/source.resolve";
 
 /**
@@ -225,7 +226,8 @@ initializeModelMappingData();
         NavbarSelectionComponent,
         SelectApplicationsComponent,
         ContextMenuLinkComponent,
-        ApplicationLevelLayoutComponent
+        ApplicationLevelLayoutComponent,
+        ExecutionApplicationListComponent
     ],
     providers: [
         appRoutingProviders,

--- a/ui/src/main/webapp/src/app/app.routing.ts
+++ b/ui/src/main/webapp/src/app/app.routing.ts
@@ -31,9 +31,11 @@ import {ProjectExecutionsComponent} from "./executions/project-executions.compon
 import {WizardLayoutComponent} from "./shared/layout/wizard-layout.component";
 import {ExecutionsLayoutComponent} from "./executions/executions-layout.component";
 import {ApplicationLevelLayoutComponent} from "./reports/application-level-layout.component";
+import {ExecutionApplicationListComponent} from "./reports/execution-application-list/execution-application-list.component";
 
 export const executionLevelRoutes: Routes = [
-    {path: '', component: ExecutionDetailComponent, data: {displayName: 'Execution Info'}},
+    {path: '', component: ExecutionApplicationListComponent, data: {displayName: 'Applications'}},
+    {path: 'execution-details', component: ExecutionDetailComponent, data: {displayName: 'Execution Info'}},
     {path: 'dependencies-report', component: DependenciesReportComponent, data: {displayName: 'Dependency Report'}},
     {path: 'technology-report', component: TechnologiesReportComponent, data: {displayName: 'Technology Report'}},
     {path: 'migration-issues',

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -24,7 +24,7 @@
                 <li><a [routerLink]="['./application-details']" i18n="report">Application Details</a></li>
                 <li><a [routerLink]="['./migration-issues']" i18n="report">Issues</a></li>
                 <li *ngIf="execution?.analysisContext?.generateStaticReports">
-                    <a class="link" target="_blank" href="{{formatStaticReportUrl(execution)}}">Static Reports</a>
+                    <a class="link external-link" target="_blank" href="{{formatStaticReportUrl(execution)}}">Static Reports</a>
                 </li>
                 <li *ngIf="!hideUnfinishedFeatures"><a [routerLink]="['./technology-report']" i18n="report">Technologies</a></li>
                 <li *ngIf="!hideUnfinishedFeatures"><a [routerLink]="['./dependencies']" i18n="report">Dependencies</a></li>

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.scss
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.scss
@@ -25,3 +25,5 @@ dt {
     white-space: nowrap;
   }
 }
+
+

--- a/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit, OnDestroy} from "@angular/core";
 import {ActivatedRoute, Router} from "@angular/router";
 
 import {RouteLinkProviderService} from "../core/routing/route-link-provider-service";
-import {ReportMenuItem} from "../shared/navigation/context-menu-item.class";
+import {ContextMenuItem, ReportMenuItem} from "../shared/navigation/context-menu-item.class";
 import {WINDUP_WEB} from "../app.module";
 import {ProjectExecutionsComponent} from "./project-executions.component";
 import {WindupExecution} from "windup-services";
@@ -13,6 +13,7 @@ import {ProjectLayoutComponent} from "../project/project-layout.component";
 import {MigrationProjectService} from "../project/migration-project.service";
 import {DatePipe} from "@angular/common";
 import {RouteFlattenerService} from "../core/routing/route-flattener.service";
+import {WindupExecutionService} from "../services/windup-execution.service";
 
 @Component({
     templateUrl: './executions-layout.component.html',
@@ -88,14 +89,13 @@ export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements
 
     protected createContextMenuItems() {
         this.menuItems = [
-            {
-                label: 'View Project',
-                link: this._routeLinkProviderService.getRouteForComponent(ProjectExecutionsComponent, {
-                    projectId: this.project.id
-                }),
-                icon: 'fa-tachometer',
-                isEnabled: true
-            },
+            new ReportMenuItem(
+                'Application List',
+                'fa-list',
+                this.project,
+                this.execution,
+                ''
+            ),
             new ReportMenuItem(
                 'Dashboard',
                 'fa-book',
@@ -117,6 +117,16 @@ export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements
                 this.execution,
                 'migration-issues'
             ),
+            new ContextMenuItem(
+                'Static Reports',
+                'fa-external-link',
+                true,
+                WindupExecutionService.formatStaticReportUrl(this.execution),
+                null,
+                null,
+                '_blank',
+                true
+            )
         ];
 
         if (!WINDUP_WEB.config.hideUnfinishedFeatures) {

--- a/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
@@ -87,6 +87,16 @@ export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements
         this._router.navigate(this.getExecutionRoute(execution));
     };
 
+    get staticReportsAvailable():boolean {
+        if (!this.execution)
+            return false;
+
+        if (!this.execution.analysisContext)
+            return false;
+
+        return this.execution.analysisContext.generateStaticReports;
+    }
+
     protected createContextMenuItems() {
         this.menuItems = [
             new ReportMenuItem(
@@ -119,8 +129,8 @@ export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements
             ),
             new ContextMenuItem(
                 'Static Reports',
-                'fa-external-link',
-                true,
+                'fa-window-restore',
+                this.staticReportsAvailable,
                 WindupExecutionService.formatStaticReportUrl(this.execution),
                 null,
                 null,

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -18,7 +18,7 @@
     </thead>
     <tbody>
     <tr *ngFor="let execution of sortedExecutions" [class]="getClass(execution)" class="execution-row">
-        <td><a [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">{{execution.id}}</a></td>
+        <td><a [routerLink]="['/projects', execution.projectId, 'reports', execution.id, 'execution-details']">{{execution.id}}</a></td>
         <td><a [routerLink]="['/projects', execution.projectId]">{{getProject(execution.projectId)?.title}}</a></td>
         <td><wu-status-icon [status]="execution.state"></wu-status-icon>{{execution.state}}</td>
         <td>{{execution.timeStarted | date: 'short'}}</td>
@@ -27,7 +27,10 @@
         <td *ngIf="!execution.timeCompleted"></td>
         <td>
             <a class="link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" i18n="button">Cancel</a>
-            <a class="link" *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports" target="_blank" href="{{formatStaticReportUrl(execution)}}"> View Static Report </a>
+            <a
+                    class="link"
+                    *ngIf="execution.state == 'COMPLETED'"
+                    [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">View Reports</a>
         </td>
     </tr>
     </tbody>

--- a/ui/src/main/webapp/src/app/project/project-layout.component.ts
+++ b/ui/src/main/webapp/src/app/project/project-layout.component.ts
@@ -80,12 +80,6 @@ export class ProjectLayoutComponent extends RoutedComponent implements OnInit, O
                 icon: 'fa-cubes',
                 isEnabled: true
             },
-            /*{
-                label: 'Executions',
-                link: this._routeLinkProviderService.getRouteForComponent(ProjectExecutionsComponent, { projectId: this.project.id }),
-                icon: 'fa-flask',
-                isEnabled: true
-            },*/
             {
                 label: 'New Execution',
                 link: this._routeLinkProviderService.getRouteForComponent(AnalysisContextFormComponent, { projectId: this.project.id }),

--- a/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.html
+++ b/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.html
@@ -1,0 +1,30 @@
+<div *ngIf="false">
+    <h2 i18n="Application List Page Loading|A message to indicate that the application list data is still loading">
+        Loading execution data
+    </h2>
+</div>
+<div>
+    <div class="header-bar">
+        <h2 i18n="Heading|Application List">Applications</h2>
+        <div class="search">
+            <wu-search [(searchValue)]="searchText" (searchValueChange)="updateSearch()"></wu-search>
+        </div>
+    </div>
+
+    <table class="table table-bordered table-hover">
+        <thead wu-sortable-table
+               [(sortedData)]="sortedApplications" [data]="filteredApplications"
+               [initialSortBy]="initialSort"
+               [tableHeaders]="[
+                    { title: 'Application', isSortable: true, sortBy: 'fileName' }
+               ]">
+        </thead>
+        <tbody>
+            <tr *ngFor="let app of sortedApplications">
+                <td>
+                    <a [routerLink]="['/projects', projectID, 'reports', execID, 'applications', app.id]">{{app.fileName}}</a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.html
+++ b/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.html
@@ -16,13 +16,26 @@
                [(sortedData)]="sortedApplications" [data]="filteredApplications"
                [initialSortBy]="initialSort"
                [tableHeaders]="[
-                    { title: 'Application', isSortable: true, sortBy: 'fileName' }
+                    { title: 'Application', isSortable: true, sortBy: 'fileName' },
+                    { title: 'Tags', isSortable: false, sortBy: 'fileName' },
+                    { title: 'Points', isSortable: true, sortBy: 'fileName' }
                ]">
         </thead>
         <tbody>
             <tr *ngFor="let app of sortedApplications">
                 <td>
                     <a [routerLink]="['/projects', projectID, 'reports', execID, 'applications', app.id]">{{app.fileName}}</a>
+                </td>
+                <td>
+                    <span *ngIf="tagsByApplication.get(app.id) == null">
+                        Loading...
+                    </span>
+                    <span *ngIf="tagsByApplication.get(app.id) != null">
+                        <wu-technology-tag *ngFor="let tag of tagsByApplication.get(app.id)" [tag]="tag"></wu-technology-tag>
+                    </span>
+                </td>
+                <td>
+                    {{pointsByApplication.get(app.id) != null ? pointsByApplication.get(app.id) : 'Loading...' }}
                 </td>
             </tr>
         </tbody>

--- a/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.ts
+++ b/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.ts
@@ -1,12 +1,17 @@
 import {Component, OnDestroy, OnInit} from "@angular/core";
 import {ActivatedRoute, Router} from "@angular/router";
 
-import {FilterApplication, WindupExecution} from "windup-services";
+import {FilterApplication, ProjectTraversalReducedDTO, WindupExecution} from "windup-services";
 import {NotificationService} from "../../core/notification/notification.service";
 import {RoutedComponent} from "../../shared/routed.component";
 import {RouteFlattenerService} from "../../core/routing/route-flattener.service";
 import {WindupService} from "../../services/windup.service";
 import {OrderDirection} from "../../shared/sort/sorting.service";
+import {
+    ApplicationDetailsFullDTO, ApplicationDetailsService,
+    ProjectTraversalFullDTO, TagFullDTO
+} from "../application-details/application-details.service";
+import {utils} from "../../shared/utils";
 
 @Component({
     templateUrl: './execution-application-list.component.html',
@@ -25,12 +30,17 @@ export class ExecutionApplicationListComponent extends RoutedComponent implement
     sortedApplications: FilterApplication[] = [];
     searchText: string;
 
+    applicationDetailsDTO:ApplicationDetailsFullDTO;
+    pointsByApplication:Map<number, number> = new Map<number, number>();
+    tagsByApplication:Map<number, {name: string, level: string}[]> = new Map<number, {name: string, level: string}[]>();
+
     constructor(
         _activatedRoute: ActivatedRoute,
         _routeFlattener: RouteFlattenerService,
         _router: Router,
         private _windupService: WindupService,
         private _notificationService: NotificationService,
+        private _applicationDetailsService:ApplicationDetailsService,
     ) {
         super(_router, _activatedRoute, _routeFlattener);
     }
@@ -53,6 +63,14 @@ export class ExecutionApplicationListComponent extends RoutedComponent implement
         this.filteredApplications = execution.filterApplications;
         this.sortedApplications = execution.filterApplications;
         this.updateSearch();
+
+        this._applicationDetailsService.getApplicationDetailsData(this.execID).subscribe(
+            applicationDetailsDto => {
+                this.applicationDetailsDTO = applicationDetailsDto;
+                this.flattenReportData();
+            },
+            error => this._notificationService.error(utils.getErrorMessage(error))
+        );
     }
 
     ngOnDestroy() {
@@ -64,5 +82,78 @@ export class ExecutionApplicationListComponent extends RoutedComponent implement
         } else {
             this.filteredApplications = this.execution.filterApplications;
         }
+    }
+
+    private flattenReportData() {
+        this.applicationDetailsDTO.traversals.forEach(traversal => {
+            // 1. Get the Filter Application
+            let filterApplication = this.getFilterApplication(traversal);
+            console.log("Found app: ", filterApplication);
+
+            if (!filterApplication)
+                return;
+
+            this.pointsByApplication.set(filterApplication.id, 0);
+            this.tagsByApplication.set(filterApplication.id, []);
+            // 2. Traverse and add up the points
+            this.flattenReportDataForTraversal(filterApplication, traversal);
+        });
+
+        this.tagsByApplication.forEach((value, index, map) => {
+            this.tagsByApplication.set(index, value.sort((a, b) => {
+                if (a.level != b.level) {
+                    if (a.level == "IMPORTANT")
+                        return -1;
+                    else if (b.level == "IMPORTANT")
+                        return 1;
+
+                    // These should be the only two cases, but if for some reason there is an unknown tag,
+                    // just use name comparisong below.
+                }
+
+                return a.name.localeCompare(b.name);
+            }));
+        });
+    }
+
+    private flattenReportDataForTraversal(filterApplication:FilterApplication, traversal:ProjectTraversalFullDTO) {
+        let addPointsToMap = (points:number) => {
+            let existingPoints = this.pointsByApplication.get(filterApplication.id);
+            if (!existingPoints)
+                this.pointsByApplication.set(filterApplication.id, points);
+            else
+                this.pointsByApplication.set(filterApplication.id, existingPoints + points);
+        };
+
+        let addTag = (tag:TagFullDTO) => {
+            // TODO/FIXME: This is a hack (same hack as in windup core - in application_list.ftl)
+            if (tag.nameString == "Decompiled Java File")
+                return;
+
+            let existingTags = this.tagsByApplication.get(filterApplication.id);
+            if (existingTags.find(existingTag => existingTag.name == tag.nameString))
+                return;
+
+            existingTags.push({name: tag.nameString, level: tag.levelString});
+        };
+
+        // Just make sure that we always at least zero it out.
+        addPointsToMap(0);
+
+        traversal.files.forEach(file => {
+            file.tags.forEach(tag => addTag(tag));
+
+            file.hints.forEach(hint => addPointsToMap(hint.effort));
+            file.classifications.forEach(classification => addPointsToMap(classification.effort));
+        });
+        traversal.children.forEach(childTraversal => this.flattenReportDataForTraversal(filterApplication, childTraversal));
+    }
+
+    private getFilterApplication(traversal:ProjectTraversalFullDTO):FilterApplication {
+        if (!this.filteredApplications)
+            return null;
+        console.log(" finding for: " + traversal.canonicalFilename + " among: ", this.filteredApplications);
+
+        return this.filteredApplications.find(app => app.fileName == traversal.canonicalFilename);
     }
 }

--- a/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.ts
+++ b/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.ts
@@ -1,0 +1,68 @@
+import {Component, OnDestroy, OnInit} from "@angular/core";
+import {ActivatedRoute, Router} from "@angular/router";
+
+import {FilterApplication, WindupExecution} from "windup-services";
+import {NotificationService} from "../../core/notification/notification.service";
+import {RoutedComponent} from "../../shared/routed.component";
+import {RouteFlattenerService} from "../../core/routing/route-flattener.service";
+import {WindupService} from "../../services/windup.service";
+import {OrderDirection} from "../../shared/sort/sorting.service";
+
+@Component({
+    templateUrl: './execution-application-list.component.html',
+    styleUrls: [
+        '../../../../css/tables.scss'
+    ]
+})
+export class ExecutionApplicationListComponent extends RoutedComponent implements OnInit, OnDestroy
+{
+    private projectID:number;
+    private execID:number;
+
+    initialSort = {property: 'fileName', direction: OrderDirection.ASC};
+    execution:WindupExecution;
+    filteredApplications: FilterApplication[] = [];
+    sortedApplications: FilterApplication[] = [];
+    searchText: string;
+
+    constructor(
+        _activatedRoute: ActivatedRoute,
+        _routeFlattener: RouteFlattenerService,
+        _router: Router,
+        private _windupService: WindupService,
+        private _notificationService: NotificationService,
+    ) {
+        super(_router, _activatedRoute, _routeFlattener);
+    }
+
+    ngOnInit(): any {
+        this.addSubscription(this.flatRouteLoaded.subscribe(flatRouteData => {
+            let executionId = parseInt(flatRouteData.params['executionId']);
+            this.execID = executionId;
+
+            this._windupService.getExecution(executionId)
+                .subscribe(execution => {
+                    this.loadExecution(execution);
+                });
+        }));
+    }
+
+    loadExecution(execution: WindupExecution) {
+        this.projectID = execution.projectId;
+        this.execution = execution;
+        this.filteredApplications = execution.filterApplications;
+        this.sortedApplications = execution.filterApplications;
+        this.updateSearch();
+    }
+
+    ngOnDestroy() {
+    }
+
+    updateSearch() {
+        if (this.searchText && this.searchText.length > 0) {
+            this.filteredApplications = this.execution.filterApplications.filter(app => app.fileName.search(new RegExp(this.searchText, 'i')) !== -1);
+        } else {
+            this.filteredApplications = this.execution.filterApplications;
+        }
+    }
+}

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu-item.class.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu-item.class.ts
@@ -18,14 +18,25 @@ export class ContextMenuItem implements ContextMenuItemInterface {
     protected _isEnabled: boolean | Function;
     protected _action?: Function;
     protected _data?: any;
+    protected _target?: string;
+    protected _absolute?: boolean;
 
-    constructor(label: string, icon: string, isEnabled?: boolean | Function, link?: string, action?:Function, data?: any) {
+    constructor(label: string,
+                icon: string,
+                isEnabled?: boolean | Function,
+                link?: string, action?:Function,
+                data?: any,
+                target?: string,
+                absolute?: boolean)
+    {
         this._label = label;
         this._link = link;
         this._icon = icon;
         this._isEnabled = isEnabled;
         this._action = action;
         this._data = data;
+        this._target = target;
+        this._absolute = (typeof absolute == "undefined") ? false : absolute;
     }
 
     get label(): string {
@@ -53,6 +64,18 @@ export class ContextMenuItem implements ContextMenuItemInterface {
 
     get data():any {
         return this._data;
+    }
+
+    get target():string {
+        return this._target;
+    }
+
+    /**
+     * Indicates that this is an absolute HTML link, rather than a link that should
+     * go through Angular's routing system.
+     */
+    get absolute():boolean {
+        return this._absolute;
     }
 }
 

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu-link.component.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu-link.component.ts
@@ -20,7 +20,8 @@ import {ContextMenuItemInterface} from "./context-menu-item.class";
 @Component({
     template: `
             <a *ngIf="item.action" (click)="click(item)"><ng-content></ng-content></a>
-            <a [routerLink]="getLink(item)"><ng-content></ng-content></a>`,
+            <a *ngIf="!item.absolute" [routerLink]="getLink(item)"><ng-content select="[router-mode]"></ng-content></a>
+            <a *ngIf="item.absolute" [href]="item.link" [target]="item.target"><ng-content select="[absolute-mode]"></ng-content></a>`,
     selector: '[wu-context-menu-link]',
     changeDetection: ChangeDetectionStrategy.OnPush,
     styles: [

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
@@ -1,8 +1,11 @@
 <div class="nav-pf-vertical nav-pf-vertical-with-sub-menus nav-pf-persistent-secondary">
     <ul class="list-group">
         <li class="list-group-item" *ngFor="let item of enabledItems" wu-context-menu-link [item]="item">
-            <span class="fa" ngClass="{{item.icon}}" data-toggle="tooltip" title="" [attr.data-original-title]="item.label"></span>
-            <span class="list-group-item-value">{{item.label}}</span>
+            <span class="fa" ngClass="{{item.icon}}" data-toggle="tooltip" title="" [attr.data-original-title]="item.label" router-mode></span>
+            <span class="list-group-item-value" router-mode>{{item.label}}</span>
+
+            <span class="fa" ngClass="{{item.icon}}" data-toggle="tooltip" title="" [attr.data-original-title]="item.label" absolute-mode></span>
+            <span class="list-group-item-value" absolute-mode>{{item.label}}</span>
         </li>
     </ul>
 </div>

--- a/ui/src/main/webapp/src/app/shared/sort/sorting.service.ts
+++ b/ui/src/main/webapp/src/app/shared/sort/sorting.service.ts
@@ -44,6 +44,9 @@ export class SortingService<T> {
     }
 
     protected comparatorCallback(a: any, b: any): number  {
+        if (typeof a == "string" && typeof b == "string")
+            return a.localeCompare(b);
+
         if (a < b) {
             return -1;
         }

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -125,8 +125,8 @@ describe('ExecutionsListComponent', () => {
             let stateText = state.textContent ? state.textContent.trim() : "";
 
             if (stateText == "COMPLETED") {
-                expect(el.children[COL_ACTIONS].children.length).toBe(0);
-                expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('');
+                expect(el.children[COL_ACTIONS].children.length).toBe(1);
+                expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('View Reports');
             } else {
                 expect(el.children[COL_ACTIONS].children.length).toBe(0);
                 expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('');


### PR DESCRIPTION
This page will supersede the execution details as the default page for executions.
Clicking on the leftmost column in the execution list will still take you to execution
details.


This still needs points, tags, and other details.