### PR TITLE
Remove excessive logging

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -124,7 +124,6 @@ export class AnalysisContextFormComponent extends FormComponent
     }
 
     private initializeAnalysisContext() {
-        console.log("initializeAnalysisContext(), this.analysisContext: ", this.analysisContext);
         let analysisContext = this.analysisContext;
 
         if (analysisContext == null) {
@@ -228,8 +227,6 @@ export class AnalysisContextFormComponent extends FormComponent
         // Store the Analysis Context
         let update = this.analysisContext.id != null;
         let service = update ? this._analysisContextService.update : this._analysisContextService.create;
-
-        console.log(`Updating/creating analysis context #${this.analysisContext.id}, migrPath: ${this.analysisContext.migrationPath.id}`);
         let contextObservable: Observable<AnalysisContext> = service.call(this._analysisContextService, this.analysisContext, this.project);
 
         contextObservable.subscribe(

--- a/ui/src/main/webapp/src/app/analysis-context/custom-rule-selection.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/custom-rule-selection.component.ts
@@ -50,7 +50,7 @@ export class CustomRuleSelectionComponent implements OnInit {
             rulesPaths => {
                 this.rulesPaths = rulesPaths;
             },
-            err => { console.log(err) }
+            err => { console.error(err) }
         );
     }
 

--- a/ui/src/main/webapp/src/app/components/in-viewport.directive.ts
+++ b/ui/src/main/webapp/src/app/components/in-viewport.directive.ts
@@ -50,8 +50,6 @@ export class InViewport implements OnInit, OnDestroy {
         let boundingRectangle = this._element.nativeElement.getBoundingClientRect();
         let elementTop = $(this._element.nativeElement).offset().top;
         let elementBottom = elementTop + boundingRectangle.height;
-        //console.log("Element: ", this._element.nativeElement);
-        //console.log("Element top,bottom: ", elementTop, elementBottom);
 
         let inView = false;
         if (elementTop > InViewport.currentPosition.top && elementTop < InViewport.currentPosition.bottom)
@@ -59,7 +57,6 @@ export class InViewport implements OnInit, OnDestroy {
         else if (elementBottom > InViewport.currentPosition.top && elementBottom < InViewport.currentPosition.bottom)
             inView = true;
 
-        //console.log("returning inView: ", inView, this._element.nativeElement);
         this.inViewport.emit(inView);
     }
 }

--- a/ui/src/main/webapp/src/app/components/login.component.ts
+++ b/ui/src/main/webapp/src/app/components/login.component.ts
@@ -11,7 +11,6 @@ export class LoginComponent implements OnInit {
 
     ngOnInit(): void {
         this._keyCloakService.isLoggedIn().subscribe((isLoggedIn) => {
-            console.log('is logged in?', isLoggedIn);
             if (isLoggedIn) {
                 this._router.navigate(['']);
             }

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.ts
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.ts
@@ -114,7 +114,7 @@ export class ConfigurationComponent implements OnInit {
                 this.configuration = configuration;
                 this.loadProviders();
             },
-            error => console.log("Error: " + error)
+            error => console.error("Error: " + error)
         )
     }
 

--- a/ui/src/main/webapp/src/app/core/authentication/keycloak.service.ts
+++ b/ui/src/main/webapp/src/app/core/authentication/keycloak.service.ts
@@ -50,7 +50,6 @@ export class KeycloakService {
                     resolve(auth);
                 })
                 .error((failure) => {
-                    //console.log('transform promise error', failure);
                     error(failure)
                 });
         });
@@ -71,16 +70,14 @@ export class KeycloakService {
 
     protected onLoginSuccess(isLoggedIn) {
         if (!isLoggedIn) {
-            console.log('Login success, not logged in');
+            console.warn('Login success, not logged in');
             this._router.navigate(['/login']);
         } else {
-            //console.log('login success, logged in');
             this.auth.loggedIn = true;
             this.auth.authz = this.keyCloak;
             this.auth.logoutUrl =  this.keyCloak.authServerUrl + "/realms/windup/tokens/logout?redirect_uri=" + Constants.AUTH_REDIRECT_URL;
 
             this.keyCloak.onAuthLogout = function () {
-                console.log("Logout event received!");
                 this.logout();
             };
             this.keyCloak.onAuthRefreshError = function () {
@@ -111,7 +108,6 @@ export class KeycloakService {
     }
 
     logout() {
-        console.log('Keycloak logging out.');
         this.auth.authz.logout();
         this.auth.loggedIn = false;
         this.auth.authz = null;

--- a/ui/src/main/webapp/src/app/core/authentication/windup.http.service.ts
+++ b/ui/src/main/webapp/src/app/core/authentication/windup.http.service.ts
@@ -24,7 +24,7 @@ export class WindupHttpService extends Http {
                     observer.complete();
                 },
                 error => {
-                    console.log("Need a token, but no token is available, not setting bearer token.");
+                    console.warn("Need a token, but no token is available, not setting bearer token.");
                     observer.error(error);
                 }
             )

--- a/ui/src/main/webapp/src/app/core/events/event-bus.service.ts
+++ b/ui/src/main/webapp/src/app/core/events/event-bus.service.ts
@@ -14,7 +14,6 @@ export class EventBusService {
     }
 
     public fireEvent(event: WindupEvent) {
-        console.log('Firing event: ', event);
         this.eventSubscribers.next(event);
     }
 }

--- a/ui/src/main/webapp/src/app/project/migration-project-form.component.ts
+++ b/ui/src/main/webapp/src/app/project/migration-project-form.component.ts
@@ -58,13 +58,11 @@ export class MigrationProjectFormComponent extends FormComponent implements OnIn
 
     save() {
         if (this.editMode) {
-            console.log("Updating migration project: " + this.model.title);
             this._migrationProjectService.update(this.model).subscribe(
                 migrationProject => this.navigateOnSuccess(migrationProject),
                 error => this.handleError(<any> error)
             );
         } else {
-            console.log("Creating migration project: " + this.model.title);
             this._migrationProjectService.create(this.model).subscribe(
                 migrationProject => this.navigateOnSuccess(migrationProject),
                 error => this.handleError(<any> error)

--- a/ui/src/main/webapp/src/app/project/project-list.component.ts
+++ b/ui/src/main/webapp/src/app/project/project-list.component.ts
@@ -84,7 +84,6 @@ export class ProjectListComponent implements OnInit {
     viewProject(event: Event, project:MigrationProject) {
         event.stopPropagation();
 
-        console.log(JSON.stringify(project));
         this._router.navigate(['/projects', project.id]);
         return false;
     }

--- a/ui/src/main/webapp/src/app/registered-application/register-application-form.component.ts
+++ b/ui/src/main/webapp/src/app/registered-application/register-application-form.component.ts
@@ -95,7 +95,6 @@ export class RegisterApplicationFormComponent extends FormComponent implements O
 
             let uploadUrl = Constants.REST_BASE + RegisteredApplicationService.UPLOAD_URL;
             uploadUrl = uploadUrl.replace("{projectId}", this.project.id.toString());
-            console.log("URL: " + uploadUrl);
 
             this.multipartUploader.setOptions({
                 url: uploadUrl,
@@ -120,8 +119,6 @@ export class RegisterApplicationFormComponent extends FormComponent implements O
     }
 
     private registerPath() {
-        console.log("Registering path: " + this.fileInputPath);
-
         if (this.isDirWithApps) {
             this._registeredApplicationService.registerApplicationInDirectoryByPath(this.project, this.fileInputPath)
                 .subscribe(
@@ -174,7 +171,6 @@ export class RegisterApplicationFormComponent extends FormComponent implements O
     }
 
     private changeMode(mode: RegistrationType) {
-        console.log("Changing mode to: " + mode);
         this.mode = mode;
     }
 }

--- a/ui/src/main/webapp/src/app/reports/dependencies/dependencies-graph.component.ts
+++ b/ui/src/main/webapp/src/app/reports/dependencies/dependencies-graph.component.ts
@@ -83,7 +83,6 @@ export class DependenciesGraphComponent implements OnInit, OnChanges {
 
 
     private initVisualisation() {
-        console.log("initVisualisation()");
         this.svg = d3.select('svg#dependenciesGraph');
         this.zoomingGroup = d3.select("svg #zoomingGroup");
         this.myEdges = this.svg.selectAll(".myEdge");
@@ -129,7 +128,6 @@ export class DependenciesGraphComponent implements OnInit, OnChanges {
 
 
     private processNewDependenciesData(depsData: DependenciesData): void {
-        console.log("processNewDependenciesData()");
         this.jsonData = depsData;
 
         // Adjust the height according to count of nodes. If this doesn't work, we could watch the Y positions difference of top and bottom nodes (before zooming).
@@ -148,7 +146,6 @@ export class DependenciesGraphComponent implements OnInit, OnChanges {
      * Main rendering function.
      */
     private render(jsonData) {
-        //console.warn("render()")
         // Edges
         this.zoomingGroup.selectAll(".myEdge")
             .data(jsonData.links)
@@ -159,10 +156,8 @@ export class DependenciesGraphComponent implements OnInit, OnChanges {
         // Nodes
         this.myGroups =  this.zoomingGroup.selectAll(".myGroup")
             .data(jsonData.nodes, (d) => d.id)
-                //.each((x) => console.log("Updating: ", x.id, x.state))
                 .classed("small", (d) => d.state == "small")
             .enter()
-                //.each((d) => (console.log("Entering: ", d.id, d.state)))
                 // Initially centered
                 //.each(function(d){ d.x = this.center.x + DependenciesGraphComponent.displacement(); d.y = this.center.y + DependenciesGraphComponent.displacement();})
                 .append("g")
@@ -173,7 +168,7 @@ export class DependenciesGraphComponent implements OnInit, OnChanges {
                     .on("end", () => this.dragEnded())
                 )
             ;
-        this.myGroups.exit().each((x) => console.log("Exiting: ", x)).remove();
+        this.myGroups.exit().remove();
         this.myGroups
             .attr("class", (d) => "myGroup node" + d.id + " type" + d.type + " suffix_" + (d.data ? d.data.fileSuffix : "none"))
             //.classed("isKnown", (d) => -1 === ["jar", "war", "ear"].indexOf(substringAfterLast(d.name, ".")))

--- a/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
+++ b/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
@@ -138,7 +138,6 @@ export class MigrationIssuesTableComponent extends RoutedComponent implements On
 
     navigateToSource(file:any) {
         let fileModel = <FileModel>this._graphJsonToModelService.fromJSON(file, FileModel);
-        console.log("File clicked: " + fileModel.vertexId);
         ///projects/32057/groups/32058/reports/32121/source/32121
         let newPath = `source/${fileModel.vertexId}`;
         this._router.navigate([newPath], { relativeTo: this._activatedRoute });

--- a/ui/src/main/webapp/src/app/reports/pretty-path.pipe.ts
+++ b/ui/src/main/webapp/src/app/reports/pretty-path.pipe.ts
@@ -20,7 +20,7 @@ export class PrettyPathPipe implements PipeTransform {
     transform(file: PersistedTraversalChildFileModel):string {
         this.prettyPath = file.filePath;
         if (!file.filePath)
-            console.log("NO file path? " + file);
+            console.warn("NO file path? " + file);
 
         if (file.filePath.toLowerCase().endsWith(".java")) {
             file.fileModel.subscribe(

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report.component.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report.component.ts
@@ -45,7 +45,6 @@ export class TechnologiesReportComponent implements OnInit {
                 mergedStats.fileTypes = this.mergeFileTypesToOne(<any>mergedStats.fileTypes, ['class', 'java'], 'Java');
                 mergedStats.fileTypes = this.calculateFileTypeUsagePercentage(mergedStats.fileTypes);
                 this.filteredTechnologiesStats = mergedStats;
-                console.log(this.filteredTechnologiesStats);
             },
             error => {
                 this._notificationService.error(utils.getErrorMessage(error));
@@ -121,8 +120,6 @@ TODO: Fix this
                 return technologiesStats[property];
             });
         });
-
-        console.log(propertiesArray);
 
         forkJoin(propertiesArray)
             .subscribe((projectTechnologiesArray: TechnologyKeyValuePairModel[][]) => {

--- a/ui/src/main/webapp/src/app/services/graph/cache.ts
+++ b/ui/src/main/webapp/src/app/services/graph/cache.ts
@@ -40,11 +40,9 @@ export class StaticCache
     /// A Map object iterates its elements in insertion order — a for...of loop returns an array of [key, value] for each iteration.
     /// However that seems not to work. Trying with forEach.
     static deleteOldest(howMany: number): void {
-        //console.debug("Deleting oldest " + howMany + " of " + this.cachedData.size);
         let iterKeys = this.cachedData.keys();
         let item: IteratorResult<string>;
         while (howMany-- > 0 && (item = iterKeys.next(), !item.done)){
-            //console.debug("    Deleting: " + item.value);
             this.cachedData.delete(item.value); // Deleting while iterating should be ok in JS.
         }
     }

--- a/ui/src/main/webapp/src/app/services/graph/graph-adjacency.decorator.ts
+++ b/ui/src/main/webapp/src/app/services/graph/graph-adjacency.decorator.ts
@@ -32,8 +32,6 @@ export function GraphAdjacency (
             return;
 
         descriptor.get = function () {
-            //console.log(`* get() v#${this.vertexId} ${name} ${direction} ${returnArray ? "array" : "single"} ${kind}`);
-
             let verticesLabel = (direction === "IN") ? "vertices_in" : "vertices_out";
 
             // Data is empty, just return null (or an empty array)
@@ -58,7 +56,6 @@ export function GraphAdjacency (
             let httpService: Http = this.http;
             let returnArray_ = returnArray; // Otherwise returnArray sticks with it's first value for all calls.
             function fetcher(url: string): Observable<any> {
-                //console.debug("    Fetching URL: " + url);///
                 return httpService.get(url).map((response: Response) => {
                     if (!response)
                         return console.error("Fetching URL returned null: " + url), null;
@@ -105,16 +102,14 @@ export function GraphAdjacency (
                         // Store the in/out vertexes.
                         edgeModel[direction === "IN" ? "_out" : "_in"] = model;
                         edgeModel[direction === "IN" ? "_in"  : "_out"] = this; /// This should be the "this" of the getter, i.e. original vertex.
-                        //console.log("Incidence edge model: " + edgeModel + " in: " + edgeModel._in + " out: " + edgeModel._out);
+
                         return edgeModel;
                     });
                 break;
                 // @InVertex/@OutVertex: getter called on edge model; it only has _in and _out reference (no need for specfic name).
                 case "IN_V":
-                    //console.log("This _in: " + this._in);
                     return Observable.of(this._in);
                 case "OUT_V":
-                    //console.log("This _out: " + this._out);
                     return Observable.of(this._out);
             }
 

--- a/ui/src/main/webapp/src/app/services/graph/graph-json-to-model.service.ts
+++ b/ui/src/main/webapp/src/app/services/graph/graph-json-to-model.service.ts
@@ -174,16 +174,12 @@ export function sortClassesBySpeciality(classes: Array<AnyClass>) : Array<AnyCla
 {
     let classesLevels: AnyClass[][] = [];
     for (let i = 0; i < classes.length; i++){
-        console.log("Next class");
         let clazz = classes[i], parent;
         let proto = Object.getPrototypeOf(new (<typeof Object>clazz)()); // The only way to get to the actual function.
         let protoOrig = proto;
         for (var depth = 0; ; depth++){
-            //console.log(`  Proto: ${proto}`);
-            console.log(`  Depth: ${depth} Proto: ${proto.constructor.name}`);
             parent = Object.getPrototypeOf(proto);
             if (!parent) {
-                console.log("No parent, break;")
                 break;
             }
             proto = parent;

--- a/ui/src/main/webapp/src/app/shared/cache.service.ts
+++ b/ui/src/main/webapp/src/app/shared/cache.service.ts
@@ -145,12 +145,10 @@ export function Cached(section?: string, expiration?: CacheExpiration, immutable
             let cacheKey = getCacheKey(propertyKey, args);
 
             if (!cacheSection.hasItem(cacheKey)) {
-                console.log('Cache miss', cacheKey);
                 let result: any|Observable<any> = originalMethod.apply(this, args);
 
                 if (isObservable(result)) {
                     return result.do(function(jsonResult) {
-                        console.log('Cache emplacement', jsonResult);
                         cacheSection.setItem(cacheKey, jsonResult, immutable, expiration);
                     });
                 } else {
@@ -159,7 +157,6 @@ export function Cached(section?: string, expiration?: CacheExpiration, immutable
                 }
             }
 
-            console.log('cache hit', cacheKey);
             return new Observable<any>(function(observer) {
                 observer.next(cacheSection.getItem(cacheKey));
                 observer.complete();

--- a/ui/src/main/webapp/src/app/shared/confirm-deactivate.guard.ts
+++ b/ui/src/main/webapp/src/app/shared/confirm-deactivate.guard.ts
@@ -5,7 +5,6 @@ import {Observable} from "rxjs/Observable";
 export class ConfirmDeactivateGuard implements CanDeactivate<IsDirty> {
 
     canDeactivate(target: IsDirty, route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean>|Promise<boolean>|boolean {
-        console.log("Can deactivate with target: " + target + " dirty? " + target.dirty);
         if(target.dirty) {
             return window.confirm('Leaving the form will revert any changes. Do you want to continue?');
         }

--- a/ui/src/main/webapp/src/app/shared/form.component.ts
+++ b/ui/src/main/webapp/src/app/shared/form.component.ts
@@ -27,7 +27,7 @@ export class FormComponent {
             this.errorMessages.push("Server call failed.");
         } else if (error.parameterViolations) {
             error.parameterViolations.forEach(violation => {
-                console.log("Violation: " + JSON.stringify(violation));
+                console.warn("Violation: " + JSON.stringify(violation));
                 this.errorMessages.push(violation.message);
             });
         } else {

--- a/ui/src/main/webapp/src/app/shared/popover.component.ts
+++ b/ui/src/main/webapp/src/app/shared/popover.component.ts
@@ -22,7 +22,6 @@ export class PopoverComponent implements AfterViewInit {
     popoverElement:ElementRef;
 
     ngAfterViewInit() {
-        console.log("Popover element: " + this.popoverElement.nativeElement);
         (<any>$(this.popoverElement.nativeElement)).popover();
     }
 }

--- a/ui/src/main/webapp/src/app/shared/sort/sortable-table.component.ts
+++ b/ui/src/main/webapp/src/app/shared/sort/sortable-table.component.ts
@@ -91,7 +91,6 @@ export class SortableTableComponent {
     protected sortData() {
         this.sortedData = this._sortingService.sort(this._originalData);
         this.sortedDataChange.emit(this.sortedData);
-        console.log(this.sortedData);
     }
 }
 

--- a/ui/src/main/webapp/tests/app/components/shared/sortable-table.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/shared/sortable-table.component.spec.ts
@@ -276,7 +276,6 @@ function assertIndicatorIsCorrect(fixture: ComponentFixture<SortableTableCompone
     let sortingIndicators = fixture.debugElement.queryAll(By.css('i'));
 
     sortingIndicators.forEach((indicator, idx) => {
-        console.log(indicator.classes);
         expect(indicator.classes['fa']).toBe(true);
 
         if (idx === index) {

--- a/ui/src/main/webapp/tests/app/generated-ts-files.spec.ts
+++ b/ui/src/main/webapp/tests/app/generated-ts-files.spec.ts
@@ -17,7 +17,6 @@ describe('Generated TS Files', () => {
     it ('filemodels - fromJSON()', () => {
         let http = <Http>{
             get(url:string) {
-                console.log("Should call get to: " + url + " now");
                 return Observable.create(function(observer) {
                     let value: any = [ TestGraphData.TEST_FILE_MODELS[0] ];
                     observer.next(value);
@@ -30,7 +29,6 @@ describe('Generated TS Files', () => {
         expect(modelObject).toBeDefined();
         expect(modelObject.vertexId).toEqual(16640);
         let model = <FileModel> modelObject;
-        console.log("Returned model: " + model);
 
         expect(model.fileName).toEqual("NonXAResource.class");
         model.parentFile.toPromise()

--- a/ui/src/main/webapp/tests/app/mocks/activated-route.mock.ts
+++ b/ui/src/main/webapp/tests/app/mocks/activated-route.mock.ts
@@ -24,7 +24,6 @@ export class ActivatedRouteMock {
     private _testData: {};
     get testData() { return this._testData; }
     set testData(data: {}) {
-        console.log('TestData set: ', data);
         this._testData = data;
         this.dataSubject.next(data);
     }

--- a/ui/src/main/webapp/tests/app/registeredapplication.service.spec.ts
+++ b/ui/src/main/webapp/tests/app/registeredapplication.service.spec.ts
@@ -102,7 +102,6 @@ describe("Registered Application Service Test", () => {
         let subject = new Subject<PackageMetadata>();
 
         let getPackageMetadata = () => {
-            console.log('getPackageMetadata called');
 
             count++;
 

--- a/ui/src/main/webapp/tests/app/services/cache/cache.decorator.spec.ts
+++ b/ui/src/main/webapp/tests/app/services/cache/cache.decorator.spec.ts
@@ -56,7 +56,6 @@ xdescribe('@Cached decorator', () => {
         beforeEach(() => {
             spyOn(instance, 'foo');
             instance.foo(value);
-            console.log(sectionSection);
         });
 
         it('should add item into "global" cache section after first call', () => {

--- a/ui/src/main/webapp/tests/app/services/graph-cache-service.spec.ts
+++ b/ui/src/main/webapp/tests/app/services/graph-cache-service.spec.ts
@@ -2,7 +2,6 @@ import {StaticCache} from "../../../src/app/services/graph/cache";
 
 describe("Cache service", () => {
     beforeEach(() => {
-        console.log("-------------------- Cache service -------------------- ");
         StaticCache.clear();
     });
 
@@ -13,7 +12,6 @@ describe("Cache service", () => {
         expect(StaticCache.cachedData.size).toEqual(0);
 
         // Add 1st
-        console.log("Caching foo ");
         StaticCache.add("foo", "bar");
         expect(StaticCache.cachedData.size).toEqual(1);
         expect(StaticCache.getOrFetch("foo", noopFetcher)).toEqual("bar");
@@ -24,14 +22,12 @@ describe("Cache service", () => {
         expect(StaticCache.getOrFetch("foo", noopFetcher)).toEqual("anotherBar");
 
         // Add 2nd
-        console.log("Caching foo2");
         StaticCache.add("foo2", "baz2");
         expect(StaticCache.cachedData.size).toEqual(2);
         expect(StaticCache.get("foo2")).toEqual("baz2");
         expect(StaticCache.get("foo")).toEqual("anotherBar");
 
         // Going over the limit - should remove "foo"
-        console.log("Caching foo3");
         StaticCache.add("foo3", "baz3");
         expect(StaticCache.cachedData.size).toEqual(2);
         expect(StaticCache.getOrFetch("foo3", noopFetcher)).toEqual("baz3");
@@ -40,7 +36,6 @@ describe("Cache service", () => {
         expect(StaticCache.get("foo2")).toEqual("baz2");
 
         // Going over the limit - should remove "foo2"
-        console.log("Caching foo4");
         StaticCache.add("foo4", "baz4");
         expect(StaticCache.cachedData.size).toEqual(2);
         expect(StaticCache.getOrFetch("foo3", noopFetcher)).toEqual("baz3");

--- a/ui/src/main/webapp/tests/app/unmarshaller.spec.ts
+++ b/ui/src/main/webapp/tests/app/unmarshaller.spec.ts
@@ -23,7 +23,6 @@ describe('Unmarshaller tests', () => {
     let http: any;
 
     beforeEach(() => {
-        console.log("-------------------- Unmarshaller test -------------------- ");
         StaticCache.clear();
 
         http = jasmine.createSpyObj('Http', [
@@ -54,7 +53,6 @@ describe('Unmarshaller tests', () => {
         expect(modelObject).toBeDefined();
         expect(modelObject.vertexId).toEqual(456);
         let model = <TestGeneratorModel> modelObject;
-        console.log("Returned model: " + model);
 
         expect(model.name).toEqual("Blake Ross");
     });
@@ -72,7 +70,6 @@ describe('Unmarshaller tests', () => {
         expect(modelObject).toBeDefined();
         expect(modelObject.vertexId).toEqual(456);
         let model = <TestGeneratorModel> modelObject;
-        console.log("Returned model: " + model);
 
         expect(model.setInPropsTest).toBeDefined("Should be defined");
         expect(model.setInPropsTest.length).toEqual(3);
@@ -97,7 +94,6 @@ describe('Unmarshaller tests', () => {
 
     it ('unmarshaller test - fromJSON() - shuttles', async(() => {
         http.get.and.callFake((url: string) => {
-                console.log("Called Http.get for: " + url);
                 return Observable.create(function(observer) {
                     let value: any = {
                         json: function () {
@@ -125,7 +121,6 @@ describe('Unmarshaller tests', () => {
 
     it ('unmarshaller test - fromJSON() - fighter', async(() => {
         http.get.and.callFake((url:string) => {
-                console.log("Called Http.get for: " + url);
                 return Observable.create(function(observer) {
                     let value: any = {
                         json: function () {


### PR DESCRIPTION
It is OK to use `console.log` for quick debugging while development,
but I think we should remove it when feature is finished. We had
quite a lot of logging in code and console became quite messy.

I removed most of  `console.log` statements and kept there only `warn` or
`error` ones, because these signal something wrong is going on and
should not get triggered in common use.