### PR TITLE
Save analysis context - simpler solution

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
@@ -1,6 +1,7 @@
 package org.jboss.windup.web.services.model;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -85,6 +86,8 @@ public class AnalysisContext implements Serializable
         this.includePackages = new HashSet<>();
         this.excludePackages = new HashSet<>();
         this.applications = new HashSet<>();
+        this.advancedOptions = new ArrayList<>();
+        this.rulesPaths = new HashSet<>();
     }
 
     public AnalysisContext(MigrationProject project)
@@ -271,6 +274,21 @@ public class AnalysisContext implements Serializable
         }
 
         this.getApplications().remove(application);
+    }
+
+    public AnalysisContext clone()
+    {
+        AnalysisContext clone = new AnalysisContext(this.migrationProject);
+
+        clone.applications.addAll(this.getApplications());
+        clone.generateStaticReports = this.generateStaticReports;
+        clone.migrationPath = this.migrationPath;
+        clone.advancedOptions.addAll(this.advancedOptions);
+        clone.rulesPaths.addAll(this.rulesPaths);
+        clone.includePackages.addAll(this.includePackages);
+        clone.excludePackages.addAll(this.excludePackages);
+
+        return clone;
     }
 
     @Override

--- a/services/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
@@ -14,6 +14,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -84,6 +85,9 @@ public class MigrationProject implements Serializable
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "project", cascade = CascadeType.REMOVE)
     @Fetch(FetchMode.SELECT)
     private Set<WindupExecution> executions;
+
+    @OneToOne
+    private AnalysisContext defaultAnalysisContext;
 
     public MigrationProject()
     {
@@ -234,6 +238,39 @@ public class MigrationProject implements Serializable
     public void removeExecution(WindupExecution execution)
     {
         this.executions.remove(execution);
+    }
+
+    /**
+     * Gets default analysis context
+     */
+    @JsonIgnore
+    public AnalysisContext getDefaultAnalysisContext()
+    {
+        return defaultAnalysisContext;
+    }
+
+    /**
+     * Gets id of default analysis context
+     */
+    @JsonProperty
+    public Long getDefaultAnalysisContextId()
+    {
+        Long id = null;
+
+        if (this.defaultAnalysisContext != null) {
+            id = this.defaultAnalysisContext.getId();
+        }
+
+        return id;
+    }
+
+    /**
+     * Sets new default analysis context
+     */
+    @JsonIgnore
+    public void setDefaultAnalysisContext(AnalysisContext defaultAnalysisContext)
+    {
+        this.defaultAnalysisContext = defaultAnalysisContext;
     }
 
     @Override

--- a/services/src/main/java/org/jboss/windup/web/services/rest/AnalysisContextEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/AnalysisContextEndpoint.java
@@ -26,16 +26,16 @@ public interface AnalysisContextEndpoint
     AnalysisContext get(@PathParam("id") Long id);
 
     /**
-     * This is fallback solution when no default analysis context exists for project
+     * Saves default analysis context for project
      *
-     * (Should not really happen)
+     * Each project should have default context by default,
+     * so it should update it.
+     *
+     * But in very rare situation, it creates new default context,
+     * if project doesn't have any (that should never happen)
      *
      */
-    @POST
-    @Path("migrationProjects/{projectId}")
-    AnalysisContext create(@Valid AnalysisContext analysisContext, @PathParam("projectId") Long projectId);
-
     @PUT
-    @Path("{id}")
-    AnalysisContext update(@PathParam("id") Long id, @Valid AnalysisContext analysisContext);
+    @Path("migrationProjects/{projectId}")
+    AnalysisContext saveAsProjectDefault(@Valid AnalysisContext analysisContext, @PathParam("projectId") Long projectId);
 }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/AnalysisContextEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/AnalysisContextEndpoint.java
@@ -25,6 +25,12 @@ public interface AnalysisContextEndpoint
     @Path("{id}")
     AnalysisContext get(@PathParam("id") Long id);
 
+    /**
+     * This is fallback solution when no default analysis context exists for project
+     *
+     * (Should not really happen)
+     *
+     */
     @POST
     @Path("migrationProjects/{projectId}")
     AnalysisContext create(@Valid AnalysisContext analysisContext, @PathParam("projectId") Long projectId);

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpoint.java
@@ -32,8 +32,8 @@ public interface WindupEndpoint
      * Initiates a Windup execution for a particular AnalysisContext.
      */
     @POST
-    @Path("execute-with-context")
-    WindupExecution executeWithContext(AnalysisContext context);
+    @Path("execute-project-with-context/{projectId}")
+    WindupExecution executeProjectWithContext(AnalysisContext context, @PathParam("projectId") Long projectId);
 
     @GET
     @Path("executions")

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpoint.java
@@ -1,5 +1,6 @@
 package org.jboss.windup.web.services.rest;
 
+import org.jboss.windup.web.services.model.AnalysisContext;
 import org.jboss.windup.web.services.model.WindupExecution;
 
 import javax.ws.rs.Consumes;
@@ -32,7 +33,7 @@ public interface WindupEndpoint
      */
     @POST
     @Path("execute-with-context")
-    WindupExecution executeWithContext(Long contextID);
+    WindupExecution executeWithContext(AnalysisContext context);
 
     @GET
     @Path("executions")

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -58,9 +58,13 @@ public class WindupEndpointImpl implements WindupEndpoint
      * @see org.jboss.windup.web.services.messaging.ExecutorMDB
      */
     @Override
-    public WindupExecution executeWithContext(Long contextId)
+    public WindupExecution executeWithContext(AnalysisContext originalContext)
     {
-        AnalysisContext originalContext = this.analysisContextService.get(contextId);
+        if (originalContext == null)
+        {
+            throw new BadRequestException("AnalysisContext must be provided");
+        }
+
 
         if (originalContext.getApplications().size() == 0)
         {

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -60,12 +60,16 @@ public class WindupEndpointImpl implements WindupEndpoint
     @Override
     public WindupExecution executeWithContext(Long contextId)
     {
-        AnalysisContext analysisContext = this.analysisContextService.get(contextId);
+        AnalysisContext originalContext = this.analysisContextService.get(contextId);
 
-        if (analysisContext.getApplications().size() == 0)
+        if (originalContext.getApplications().size() == 0)
         {
             throw new BadRequestException("Cannot execute windup without selected applications");
         }
+
+        // make clone of analysis context and use it for execution
+        AnalysisContext analysisContext = originalContext.clone();
+        this.entityManager.persist(analysisContext);
 
         for (RegisteredApplication application : analysisContext.getApplications())
         {

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -81,7 +81,7 @@ public class WindupEndpointImpl implements WindupEndpoint
         MigrationProject project = this.migrationProjectService.getMigrationProject(projectId);
         analysisContext.setMigrationProject(project); // ensure project is correctly set
 
-        this.entityManager.persist(analysisContext);
+        analysisContext = this.analysisContextService.create(analysisContext);
 
         for (RegisteredApplication application : analysisContext.getApplications())
         {

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -26,6 +26,7 @@ import org.jboss.windup.web.services.model.RegisteredApplication;
 import org.jboss.windup.web.services.model.WindupExecution;
 import org.jboss.windup.web.services.service.AnalysisContextService;
 import org.jboss.windup.web.services.service.ConfigurationService;
+import org.jboss.windup.web.services.service.MigrationProjectService;
 
 @Stateless
 public class WindupEndpointImpl implements WindupEndpoint
@@ -45,6 +46,9 @@ public class WindupEndpointImpl implements WindupEndpoint
     private AnalysisContextService analysisContextService;
 
     @Inject
+    private MigrationProjectService migrationProjectService;
+
+    @Inject
     private JMSContext messaging;
 
     @Inject
@@ -58,7 +62,7 @@ public class WindupEndpointImpl implements WindupEndpoint
      * @see org.jboss.windup.web.services.messaging.ExecutorMDB
      */
     @Override
-    public WindupExecution executeWithContext(AnalysisContext originalContext)
+    public WindupExecution executeProjectWithContext(AnalysisContext originalContext, Long projectId)
     {
         if (originalContext == null)
         {
@@ -73,6 +77,10 @@ public class WindupEndpointImpl implements WindupEndpoint
 
         // make clone of analysis context and use it for execution
         AnalysisContext analysisContext = originalContext.clone();
+
+        MigrationProject project = this.migrationProjectService.getMigrationProject(projectId);
+        analysisContext.setMigrationProject(project); // ensure project is correctly set
+
         this.entityManager.persist(analysisContext);
 
         for (RegisteredApplication application : analysisContext.getApplications())

--- a/services/src/main/java/org/jboss/windup/web/services/service/AnalysisContextService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/AnalysisContextService.java
@@ -61,6 +61,7 @@ public class AnalysisContextService
      */
     public AnalysisContext create(AnalysisContext analysisContext)
     {
+        analysisContext.setId(null); // creating new instance, should not have id
         this.ensureSystemRulesPathsPresent(analysisContext);
         this.loadPackagesToAnalysisContext(analysisContext);
         entityManager.persist(analysisContext);
@@ -98,15 +99,16 @@ public class AnalysisContextService
     /**
      * Updates an existing instance.
      */
-    public AnalysisContext update(AnalysisContext analysisContext)
+    public AnalysisContext update(Long analysisContextId, AnalysisContext analysisContext)
     {
-        AnalysisContext original = this.get(analysisContext.getId());
+        AnalysisContext original = this.get(analysisContextId);
 
         if (this.contextHasExecutions(original))
         {
             throw new BadRequestException("Cannot update context used for executions");
         }
 
+        analysisContext.setId(analysisContextId); // make sure user doesn't provide invalid id
         this.ensureSystemRulesPathsPresent(analysisContext);
         this.loadPackagesToAnalysisContext(analysisContext);
         analysisContext.setMigrationProject(original.getMigrationProject());

--- a/services/src/main/java/org/jboss/windup/web/services/service/MigrationProjectService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/MigrationProjectService.java
@@ -28,6 +28,9 @@ public class MigrationProjectService
     @FromFurnace
     private WebPathUtil webPathUtil;
 
+    @Inject
+    private AnalysisContextService analysisContextService;
+
     /**
      * Gets migration project
      */
@@ -72,7 +75,10 @@ public class MigrationProjectService
         }
 
         project.setId(null); // creating new project, should not have id set
+        this.entityManager.persist(project); // get id for analysis context
 
+        AnalysisContext analysisContext = this.analysisContextService.createDefaultAnalysisContext(project);
+        project.setDefaultAnalysisContext(analysisContext);
         this.entityManager.persist(project);
 
         return project;

--- a/services/src/test/java/org/jboss/windup/web/services/data/DataProvider.java
+++ b/services/src/test/java/org/jboss/windup/web/services/data/DataProvider.java
@@ -90,7 +90,7 @@ public class DataProvider
 
         analysisContext.getRulesPaths().add(getTestRulesPath());
 
-        return this.analysisContextEndpoint.update(analysisContext.getId(), analysisContext);
+        return this.analysisContextEndpoint.saveAsProjectDefault(analysisContext, project.getId());
     }
 
     private RulesPath getTestRulesPath()

--- a/services/src/test/java/org/jboss/windup/web/services/data/DataProvider.java
+++ b/services/src/test/java/org/jboss/windup/web/services/data/DataProvider.java
@@ -13,6 +13,8 @@ import org.jboss.windup.web.services.rest.ConfigurationEndpoint;
 import org.jboss.windup.web.services.rest.ConfigurationEndpointTest;
 import org.jboss.windup.web.services.rest.MigrationProjectEndpoint;
 import org.jboss.windup.web.services.rest.MigrationProjectRegisteredApplicationsEndpoint;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericEntity;
@@ -66,10 +68,20 @@ public class DataProvider
         return this.migrationProjectEndpoint.createMigrationProject(migrationProject);
     }
 
-    public AnalysisContext getAnalysisContext(MigrationProject project)
+    protected Long getProjectAnalysisContextId(MigrationProject project) throws JSONException
     {
-        AnalysisContext analysisContext = new AnalysisContext(project);
-        analysisContext = this.analysisContextEndpoint.create(analysisContext, project.getId());
+        Response response = target.path("/migrationProjects/get/" + project.getId()).request().get();
+        response.bufferEntity();
+        String stringResponse = response.readEntity(String.class);
+        JSONObject json = new JSONObject(stringResponse);
+
+        return json.getLong("defaultAnalysisContextId");
+    }
+
+    public AnalysisContext getAnalysisContext(MigrationProject project) throws JSONException
+    {
+        Long contextId = this.getProjectAnalysisContextId(project);
+        AnalysisContext analysisContext = this.analysisContextEndpoint.get(contextId);
 
         if (analysisContext.getRulesPaths() == null)
         {

--- a/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
+++ b/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
@@ -11,7 +11,11 @@ import org.jboss.windup.web.services.model.RegisteredApplication;
 import org.jboss.windup.web.services.model.WindupExecution;
 import org.jboss.windup.web.services.rest.AnalysisContextEndpoint;
 import org.jboss.windup.web.services.rest.WindupEndpoint;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Assert;
+
+import javax.ws.rs.core.Response;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>

--- a/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
+++ b/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
@@ -46,7 +46,7 @@ public class WindupExecutionUtil
             RegisteredApplication application = dataProvider.getApplication(project, sampleIS, "sample-tiny.war");
 
             context.addApplication(application);
-            this.analysisContextEndpoint.update(context.getId(), context);
+            this.analysisContextEndpoint.saveAsProjectDefault(context, project.getId());
         }
 
         System.out.println("Setup Graph test, registered application and ready to start Windup analysis...");

--- a/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
+++ b/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
@@ -51,7 +51,7 @@ public class WindupExecutionUtil
 
         System.out.println("Setup Graph test, registered application and ready to start Windup analysis...");
 
-        WindupExecution initialExecution = this.windupEndpoint.executeWithContext(context.getId());
+        WindupExecution initialExecution = this.windupEndpoint.executeWithContext(context);
 
         WindupExecution status = this.windupEndpoint.getExecution(initialExecution.getId());
         long beginTime = System.currentTimeMillis();

--- a/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
+++ b/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
@@ -51,7 +51,7 @@ public class WindupExecutionUtil
 
         System.out.println("Setup Graph test, registered application and ready to start Windup analysis...");
 
-        WindupExecution initialExecution = this.windupEndpoint.executeWithContext(context);
+        WindupExecution initialExecution = this.windupEndpoint.executeProjectWithContext(context, project.getId());
 
         WindupExecution status = this.windupEndpoint.getExecution(initialExecution.getId());
         long beginTime = System.currentTimeMillis();

--- a/services/src/test/java/org/jboss/windup/web/services/rest/AnalysisContextEndpointTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/AnalysisContextEndpointTest.java
@@ -67,7 +67,7 @@ public class AnalysisContextEndpointTest extends AbstractTest
 
         analysisContext.setRulesPaths(configurationEndpoint.getConfiguration().getRulesPaths());
 
-        analysisContext = analysisContextEndpoint.update(analysisContext.getId(), analysisContext);
+        analysisContext = analysisContextEndpoint.saveAsProjectDefault(analysisContext, project.getId());
 
         AnalysisContext loaded = analysisContextEndpoint.get(analysisContext.getId());
 

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -230,15 +230,7 @@ export class AnalysisContextFormComponent extends FormComponent
     }
 
     onSubmit() {
-        let observable = this._analysisContextService.update(this.analysisContext);
-
-        // Store the Analysis Context
-        if (this.analysisContext.id === 0 || this.analysisContext.id === null) {
-            console.warn("AnalysisContext for project not loaded - should never happen");
-            observable = this._analysisContextService.create(this.analysisContext, this.project);
-        }
-
-        observable.subscribe(
+        this._analysisContextService.saveAsDefault(this.analysisContext, this.project).subscribe(
             updatedContext => {
                 this._dirty = false;
                 this.onSuccess(updatedContext);

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context.service.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context.service.ts
@@ -5,7 +5,7 @@ import {Constants} from "../constants";
 import {AnalysisContext} from "windup-services";
 import {AbstractService} from "../shared/abtract.service";
 import {MigrationProject} from "windup-services";
-import {Cached} from "../shared/cache.service";
+import {Cached, CacheSection, CacheService} from "../shared/cache.service";
 
 /**
  * Analysis context, AKA execution configuration, is tied 1:1 to executions.
@@ -18,8 +18,11 @@ export class AnalysisContextService extends AbstractService {
     private ANALYSIS_CONTEXT_URL = "/analysis-context/{id}";
     private CREATE_URL = "/analysis-context/migrationProjects/{projectId}";
 
-    constructor (private _http: Http) {
+    private _cache: CacheSection;
+
+    constructor (private _http: Http, private _cacheService: CacheService) {
         super();
+        this._cache = _cacheService.getSection('analysisContext');
     }
 
     create(analysisContext: AnalysisContext, project: MigrationProject) {
@@ -43,6 +46,10 @@ export class AnalysisContextService extends AbstractService {
 
         return this._http.put(url, body, this.JSON_OPTIONS)
             .map(res => <AnalysisContext> res.json())
+            .do((context: AnalysisContext) => {
+                let key = 'get(' + context.id + ')';
+                this._cache.removeItem(key);
+            })
             .catch(this.handleError);
     }
 

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context.service.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context.service.ts
@@ -6,6 +6,7 @@ import {AnalysisContext} from "windup-services";
 import {AbstractService} from "../shared/abtract.service";
 import {MigrationProject} from "windup-services";
 import {Cached, CacheSection, CacheService} from "../shared/cache.service";
+import {Observable} from "rxjs";
 
 /**
  * Analysis context, AKA execution configuration, is tied 1:1 to executions.
@@ -25,28 +26,21 @@ export class AnalysisContextService extends AbstractService {
         this._cache = _cacheService.getSection('analysisContext');
     }
 
-    create(analysisContext: AnalysisContext, project: MigrationProject) {
+    /**
+     * Saves analysis context as project default context
+     *
+     * @param analysisContext {AnalysisContext}
+     * @param project {MigrationProject}
+     * @returns {Observable<AnalysisContext>}
+     */
+    saveAsDefault(analysisContext: AnalysisContext, project: MigrationProject): Observable<AnalysisContext> {
         let body = JSON.stringify(analysisContext);
         let url = Constants.REST_BASE + this.CREATE_URL.replace('{projectId}', project.id.toString());
-
-        return this._http.post(url, body, this.JSON_OPTIONS)
-            .map(res => <AnalysisContext> res.json())
-            .catch(this.handleError);
-    }
-
-    /**
-     * Updating an analysis context only makes sense for those used as project default, i.e. those without an execution related to it.
-     * Also, there should be only one such context.
-     *
-     * TODO: Throw if trying to update a context of a past execution.
-     */
-    update(analysisContext: AnalysisContext) {
-        let body = JSON.stringify(analysisContext);
-        let url = Constants.REST_BASE + this.ANALYSIS_CONTEXT_URL.replace("{id}", analysisContext.id.toString());
 
         return this._http.put(url, body, this.JSON_OPTIONS)
             .map(res => <AnalysisContext> res.json())
             .do((context: AnalysisContext) => {
+                // invalidate cache for just updated context
                 let key = 'get(' + context.id + ')';
                 this._cache.removeItem(key);
             })

--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -123,6 +123,7 @@ import {ContextMenuLinkComponent} from "./shared/navigation/context-menu-link.co
 import {ExecutionApplicationListComponent} from "./reports/execution-application-list/execution-application-list.component";
 import {SourceResolve} from "./reports/source/source.resolve";
 import {ExecutionResolve} from "./executions/execution.resolve";
+import {CacheService, CacheServiceInstance} from "./shared/cache.service";
 
 /**
  * Load all mapping data from the generated files.
@@ -286,6 +287,10 @@ initializeModelMappingData();
             provide: GraphJSONToModelService,
             useFactory: createGraphJSONToModelService,
             deps: [Http]
+        },
+        {
+          provide: CacheService,
+          useValue: CacheServiceInstance
         },
         AggregatedStatisticsService,
         DatePipe

--- a/ui/src/main/webapp/src/app/services/windup-execution.service.ts
+++ b/ui/src/main/webapp/src/app/services/windup-execution.service.ts
@@ -26,7 +26,7 @@ export class WindupExecutionService extends AbstractService {
     }
 
     public execute(analysisContext: AnalysisContext, project: MigrationProject): Observable<WindupExecution> {
-        return this._windupService.executeWindupWithAnalysisContext(analysisContext.id)
+        return this._windupService.executeWindupWithAnalysisContext(analysisContext)
             .do(execution => {
                 this._eventBus.fireEvent(new NewExecutionStartedEvent(execution, project, this));
                 this.watchExecutionUpdates(execution, project)

--- a/ui/src/main/webapp/src/app/services/windup-execution.service.ts
+++ b/ui/src/main/webapp/src/app/services/windup-execution.service.ts
@@ -26,7 +26,7 @@ export class WindupExecutionService extends AbstractService {
     }
 
     public execute(analysisContext: AnalysisContext, project: MigrationProject): Observable<WindupExecution> {
-        return this._windupService.executeWindupWithAnalysisContext(analysisContext)
+        return this._windupService.executeWindupWithAnalysisContext(analysisContext, project)
             .do(execution => {
                 this._eventBus.fireEvent(new NewExecutionStartedEvent(execution, project, this));
                 this.watchExecutionUpdates(execution, project)

--- a/ui/src/main/webapp/src/app/services/windup.service.ts
+++ b/ui/src/main/webapp/src/app/services/windup.service.ts
@@ -3,13 +3,13 @@ import {Http} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 
 import {Constants} from "../constants";
-import {AnalysisContext, WindupExecution} from "windup-services";
+import {AnalysisContext, MigrationProject, WindupExecution} from "windup-services";
 import {AbstractService} from "../shared/abtract.service";
 import {Cached, CacheServiceInstance} from "../shared/cache.service";
 
 @Injectable()
 export class WindupService extends AbstractService {
-    private EXECUTE_WITH_CONTEXT_PATH = "/windup/execute-with-context";
+    private EXECUTE_WITH_CONTEXT_PATH = Constants.REST_BASE + "/windup/execute-project-with-context/{projectId}";
     private EXECUTIONS_PATH = '/windup/executions';
     private PROJECT_EXECUTIONS_PATH = '/windup/by-project/{projectId}';
 
@@ -40,10 +40,12 @@ export class WindupService extends AbstractService {
             .catch(this.handleError);
     }
 
-    public executeWindupWithAnalysisContext(context: AnalysisContext): Observable<WindupExecution> {
+    public executeWindupWithAnalysisContext(context: AnalysisContext, project: MigrationProject): Observable<WindupExecution> {
+        let url = this.EXECUTE_WITH_CONTEXT_PATH.replace('{projectId}', project.id.toString());
+
         let body = JSON.stringify(context);
 
-        return this._http.post(Constants.REST_BASE + this.EXECUTE_WITH_CONTEXT_PATH, body, this.JSON_OPTIONS)
+        return this._http.post(url, body, this.JSON_OPTIONS)
             .map(res => <WindupExecution> res.json())
             .do(res => {
                 CacheServiceInstance.getSection('execution').clear();

--- a/ui/src/main/webapp/src/app/services/windup.service.ts
+++ b/ui/src/main/webapp/src/app/services/windup.service.ts
@@ -3,7 +3,7 @@ import {Http} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 
 import {Constants} from "../constants";
-import {WindupExecution} from "windup-services";
+import {AnalysisContext, WindupExecution} from "windup-services";
 import {AbstractService} from "../shared/abtract.service";
 import {Cached, CacheServiceInstance} from "../shared/cache.service";
 
@@ -29,7 +29,7 @@ export class WindupService extends AbstractService {
 
     static cacheExecutionList = (executions: WindupExecution[]): boolean => {
         return executions.find(execution => !WindupService.cacheExecution(execution)) == null;
-    }
+    };
 
     @Cached({section: 'execution', immutable: true, cacheItemCallback: WindupService.cacheExecution})
     public getExecution(executionID:number):Observable<WindupExecution> {
@@ -40,9 +40,8 @@ export class WindupService extends AbstractService {
             .catch(this.handleError);
     }
 
-    public executeWindupWithAnalysisContext(contextId: number): Observable<WindupExecution> {
-        let body = JSON.stringify(contextId);
-
+    public executeWindupWithAnalysisContext(context: AnalysisContext): Observable<WindupExecution> {
+        let body = JSON.stringify(context);
 
         return this._http.post(Constants.REST_BASE + this.EXECUTE_WITH_CONTEXT_PATH, body, this.JSON_OPTIONS)
             .map(res => <WindupExecution> res.json())

--- a/ui/src/main/webapp/src/app/shared/cache.service.ts
+++ b/ui/src/main/webapp/src/app/shared/cache.service.ts
@@ -46,6 +46,12 @@ export class CacheSection {
         return item.data;
     }
 
+    public removeItem(key: string) {
+        if (this.dataMap.has(key)) {
+            this.dataMap.delete(key);
+        }
+    }
+
     /**
      * Sets cache item
      *


### PR DESCRIPTION
Each project should have defaultAnalysisContext. This context is used
for configuration. It is never used for execution. Execution creates
a clone of that AnalysisContext.

There is fallback solution if defaultAnalysisContext doesn't exist on
 MigrationProject (even though this should never happen!). Also
 analysisContext should never be updated, when it is used for execution.