### PR TITLE
Application Dashboard report: fixing table column header s/Category/E…

### DIFF
--- a/ui/src/main/webapp/src/app/reports/application-index/application-index.component.html
+++ b/ui/src/main/webapp/src/app/reports/application-index/application-index.component.html
@@ -154,7 +154,7 @@
                     <caption>Mandatory Incidents by Type</caption>
                     <thead>
                         <tr>
-                            <th>Category</th>
+                            <th>Effort Level</th>
                             <th>Incidents</th>
                             <th>Story Points</th>
                         </tr>


### PR DESCRIPTION
…ffortLevel/

I noticed that there is a copy/paste error in Mandatory incidents by type table where column Category should be Effort Level