### PR TITLE
T712-Executions page: change 'Executions' to 'Analysis'

### DIFF
--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -1,13 +1,13 @@
 <wu-active-executions-progressbar [activeExecutions]="activeExecutions"></wu-active-executions-progressbar>
 
-<h2 i18n="heading|executions list">Executions</h2>
+<h2 i18n="heading|executions list">Analysis</h2>
 <table class="table table-bordered table-hover table-mobile executions-list-table">
     <thead wu-sortable-table
         [(sortedData)]="sortedExecutions"
         [data]="executions"
         [initialSortBy]="initialSort"
         [tableHeaders]="[
-            { title: 'Execution', isSortable: true, sortBy: 'id' },
+            { title: 'Analysis', isSortable: true, sortBy: 'id' },
             { title: 'Project', isSortable: true, sortBy: sortByProjectCallback },
             { title: 'State', isSortable: true, sortBy: 'state' },
             { title: 'Date Started', isSortable: true, sortBy: 'timeStarted' },


### PR DESCRIPTION
Replaced  'Executions' to 'Analysis' in component:

- heading h2
- table header

All the ids where "executions" is used have not been changed (e.g. "activeExecutions", "sortedExecutions").