### PR TITLE
T765_718_720-Executions Page: fix state bug and renamings

### DIFF
--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -125,6 +125,7 @@ import {SourceResolve} from "./reports/source/source.resolve";
 import {ExecutionResolve} from "./executions/execution.resolve";
 import {CacheService, CacheServiceInstance} from "./shared/cache.service";
 import {ProjectNameNotExistsValidator} from "./shared/validators/project-name-not-exists.validator";
+import {PrettyExecutionStatus} from "./shared/pretty-execution-state.pipe";
 
 /**
  * Load all mapping data from the generated files.
@@ -229,7 +230,8 @@ initializeModelMappingData();
         SelectApplicationsComponent,
         ContextMenuLinkComponent,
         ApplicationLevelLayoutComponent,
-        ExecutionApplicationListComponent
+        ExecutionApplicationListComponent,
+        PrettyExecutionStatus
     ],
     providers: [
         appRoutingProviders,

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -10,23 +10,23 @@
             { title: 'Analysis', isSortable: true, sortBy: 'id' },
             { title: 'Status', isSortable: true, sortBy: 'state' },
             { title: 'Date Started', isSortable: true, sortBy: 'timeStarted' },
-            { title: 'Duration', isSortable: true, sortBy: sortByDurationCallback },
             { title: 'Actions', isSortable: false }
         ]">
     </thead>
     <tbody>
     <tr *ngFor="let execution of sortedExecutions" [class]="getClass(execution)" class="execution-row">
         <td><a [routerLink]="['/projects', execution.projectId, 'reports', execution.id, 'execution-details']">{{execution.id}}</a></td>
-        <td><wu-status-icon [status]="execution.state"></wu-status-icon>{{execution.state}}</td>
+        <td><wu-status-icon [status]="execution.state"></wu-status-icon>{{humanReadableLabel(execution)}} {{execution.state == 'COMPLETED' || execution.state == 'FAILED' ? "in " + (execution.timeCompleted - execution.timeStarted | wuDuration) : ""}}</td>
         <td>{{execution.timeStarted | date: 'short'}}</td>
-        <td *ngIf="execution.timeCompleted">{{ execution.timeCompleted - execution.timeStarted | wuDuration }}</td>
-        <td *ngIf="!execution.timeCompleted"></td>
         <td>
             <a class="link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" i18n="button">Cancel</a>
+            <!-- left for when dynamic report will be linked again
             <a
                     class="link"
                     *ngIf="execution.state == 'COMPLETED'"
                     [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">View Reports</a>
+            -->
+            <a *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports" class="link external-link" target="_blank" href="{{formatStaticReportUrl(execution)}}">Static Report</a>
         </td>
     </tr>
     </tbody>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -16,7 +16,7 @@
     <tbody>
     <tr *ngFor="let execution of sortedExecutions" [class]="getClass(execution)" class="execution-row">
         <td><a [routerLink]="['/projects', execution.projectId, 'reports', execution.id, 'execution-details']">{{execution.id}}</a></td>
-        <td><wu-status-icon [status]="execution.state"></wu-status-icon>{{humanReadableLabel(execution)}} {{execution.state == 'COMPLETED' || execution.state == 'FAILED' ? "in " + (execution.timeCompleted - execution.timeStarted | wuDuration) : ""}}</td>
+        <td><wu-status-icon [status]="execution.state"></wu-status-icon>{{execution.state | wuPrettyExecutionStatus}}<span *ngIf="execution.state == 'COMPLETED' || execution.state == 'FAILED'"> in {{(execution.timeCompleted - execution.timeStarted | wuDuration)}}</span></td>
         <td>{{execution.timeStarted | date: 'short'}}</td>
         <td>
             <a class="link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" i18n="button">Cancel</a>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.ts
@@ -105,8 +105,4 @@ export class ExecutionsListComponent implements OnInit {
         return WindupExecutionService.formatStaticReportUrl(execution);
     }
 
-    humanReadableLabel(execution: WindupExecution): string {
-        return utils.humanReadableLabel(execution.state);
-    }
-
 }

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.ts
@@ -105,4 +105,8 @@ export class ExecutionsListComponent implements OnInit {
         return WindupExecutionService.formatStaticReportUrl(execution);
     }
 
+    humanReadableLabel(execution: WindupExecution): string {
+        return utils.humanReadableLabel(execution.state);
+    }
+
 }

--- a/ui/src/main/webapp/src/app/executions/project-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/project-executions.component.ts
@@ -35,7 +35,7 @@ export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent im
             .filter((event: ExecutionEvent) => event.migrationProject.id === this.project.id)
             .subscribe((event: ExecutionEvent) => this.onExecutionEvent(event)));
 
-        this.runUpdate = Boolean(false);
+        this.runUpdate = false;
     }
 
     private refreshExecutionList() {
@@ -49,7 +49,7 @@ export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent im
         super.onExecutionEvent(event);
         if (!this.runUpdate || !(event.execution.state === 'STARTED')) {
             this.refreshExecutionList();
-            this.runUpdate = Boolean(true);
+            this.runUpdate = true;
         }
     }
 }

--- a/ui/src/main/webapp/src/app/executions/project-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/project-executions.component.ts
@@ -13,6 +13,7 @@ import {ExecutionUpdatedEvent, ExecutionEvent, NewExecutionStartedEvent} from ".
 })
 export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent implements OnInit {
     protected executions: WindupExecution[];
+    private runUpdate: boolean;
 
     constructor(
         private _activatedRoute: ActivatedRoute,
@@ -33,6 +34,8 @@ export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent im
             .filter(event => event.isTypeOf(ExecutionEvent))
             .filter((event: ExecutionEvent) => event.migrationProject.id === this.project.id)
             .subscribe((event: ExecutionEvent) => this.onExecutionEvent(event)));
+
+        this.runUpdate = Boolean(false);
     }
 
     private refreshExecutionList() {
@@ -44,8 +47,9 @@ export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent im
 
     protected onExecutionEvent(event: ExecutionEvent) {
         super.onExecutionEvent(event);
-        if (!this.isExecutionActive(event.execution)) {
+        if (!this.runUpdate || !(event.execution.state === 'STARTED')) {
             this.refreshExecutionList();
+            this.runUpdate = Boolean(true);
         }
     }
 }

--- a/ui/src/main/webapp/src/app/shared/pretty-execution-state.pipe.ts
+++ b/ui/src/main/webapp/src/app/shared/pretty-execution-state.pipe.ts
@@ -1,0 +1,26 @@
+import {Pipe, PipeTransform} from "@angular/core";
+import {ExecutionState} from "windup-services";
+
+@Pipe({
+    name: 'wuPrettyExecutionStatus'
+})
+
+export class PrettyExecutionStatus implements PipeTransform {
+
+    transform(state: ExecutionState): string {
+        switch (state) {
+            case "STARTED":
+                return 'In Progress';
+            case "QUEUED":
+                return 'Queued';
+            case "COMPLETED":
+                return 'Completed';
+            case "FAILED":
+                return 'Failed';
+            case "CANCELLED":
+                return 'Cancelled';
+            default:
+                return state;
+        }
+    }
+}

--- a/ui/src/main/webapp/src/app/shared/utils.ts
+++ b/ui/src/main/webapp/src/app/shared/utils.ts
@@ -1,5 +1,3 @@
-import {ExecutionState} from "windup-services";
-
 export function substringAfterLast(str, delimiter) {
     return str.substring(str.lastIndexOf(delimiter) + 1); // +1 trick for no occurence.
 }
@@ -18,23 +16,6 @@ export module utils {
             return error.error;
         } else {
             return 'Unknown error: ' + error;
-        }
-    }
-
-    export function humanReadableLabel(state: ExecutionState): string {
-        switch (state) {
-            case "STARTED":
-                return 'In Progress';
-            case "QUEUED":
-                return 'Queued';
-            case "COMPLETED":
-                return 'Completed';
-            case "FAILED":
-                return 'Failed';
-            case "CANCELLED":
-                return 'Cancelled';
-            default:
-                return state;
         }
     }
 

--- a/ui/src/main/webapp/src/app/shared/utils.ts
+++ b/ui/src/main/webapp/src/app/shared/utils.ts
@@ -1,4 +1,4 @@
-
+import {ExecutionState} from "windup-services";
 
 export function substringAfterLast(str, delimiter) {
     return str.substring(str.lastIndexOf(delimiter) + 1); // +1 trick for no occurence.
@@ -18,6 +18,23 @@ export module utils {
             return error.error;
         } else {
             return 'Unknown error: ' + error;
+        }
+    }
+
+    export function humanReadableLabel(state: ExecutionState): string {
+        switch (state) {
+            case "STARTED":
+                return 'In Progress';
+            case "QUEUED":
+                return 'Queued';
+            case "COMPLETED":
+                return 'Completed';
+            case "FAILED":
+                return 'Failed';
+            case "CANCELLED":
+                return 'Cancelled';
+            default:
+                return state;
         }
     }
 

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -16,7 +16,7 @@ import {SortableTableComponent} from "../../../../src/app/shared/sort/sortable-t
 import {SortIndicatorComponent} from "../../../../src/app/shared/sort/sort-indicator.component";
 import {StatusIconComponent} from "../../../../src/app/shared/status-icon.component";
 import {SchedulerService} from "../../../../src/app/shared/scheduler.service";
-import {utils} from "../../../../src/app/shared/utils";
+import {PrettyExecutionStatus} from "../../../../src/app/shared/pretty-execution-state.pipe";
 
 let comp:    ExecutionsListComponent;
 let fixture: ComponentFixture<ExecutionsListComponent>;
@@ -49,7 +49,8 @@ describe('ExecutionsListComponent', () => {
                 DurationPipe,
                 SortableTableComponent,
                 SortIndicatorComponent,
-                StatusIconComponent
+                StatusIconComponent,
+                PrettyExecutionStatus
             ],
             providers: [
                 SchedulerService,
@@ -159,7 +160,7 @@ describe('ExecutionsListComponent', () => {
 
                 expect(el.children.length).toEqual(COUNT_COLUMNS);
                 expect(el.children[COL_ID].textContent.trim()).toEqual(SORTED_EXECUTIONS_DATA[i].id.toString());
-                expect(el.children[COL_STATE].textContent.trim()).toContain(utils.humanReadableLabel(SORTED_EXECUTIONS_DATA[i].state));
+                expect(el.children[COL_STATE].textContent.trim()).toContain((new PrettyExecutionStatus().transform(SORTED_EXECUTIONS_DATA[i].state)));
             }
         });
     });

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -16,6 +16,7 @@ import {SortableTableComponent} from "../../../../src/app/shared/sort/sortable-t
 import {SortIndicatorComponent} from "../../../../src/app/shared/sort/sort-indicator.component";
 import {StatusIconComponent} from "../../../../src/app/shared/status-icon.component";
 import {SchedulerService} from "../../../../src/app/shared/scheduler.service";
+import {utils} from "../../../../src/app/shared/utils";
 
 let comp:    ExecutionsListComponent;
 let fixture: ComponentFixture<ExecutionsListComponent>;
@@ -27,10 +28,9 @@ let SORTED_EXECUTIONS_DATA = EXECUTIONS_DATA.slice().sort((a, b) => <any>b.timeS
 const COL_ID = 0;
 const COL_STATE = 1;
 const COL_DATE_STARTED = 2;
-const COL_DURATION = 3;
-const COL_ACTIONS = 4;
+const COL_ACTIONS = 3;
 
-const COUNT_COLUMNS = 5;
+const COUNT_COLUMNS = 4;
 
 let mockProjects = [
     { id: 1, title: 'Dummy project' }
@@ -97,7 +97,7 @@ describe('ExecutionsListComponent', () => {
     it('should display cancel link for QUEUED executions', () => {
         let rows = fixture.debugElement.queryAll(By.css('tbody tr'));
 
-        let queuedExecutions = rows.filter(row => row.nativeElement.children[COL_STATE].textContent.trim() === 'QUEUED');
+        let queuedExecutions = rows.filter(row => row.nativeElement.children[COL_STATE].textContent.trim() === 'Queued');
 
         expect(queuedExecutions.length).toBe(1);
 
@@ -113,7 +113,7 @@ describe('ExecutionsListComponent', () => {
     it('should not display cancel link for executions in other state', () => {
         let rows = fixture.debugElement.queryAll(By.css('tbody tr'));
 
-        let notQueuedExecutions = rows.filter(row => row.nativeElement.children[COL_STATE].textContent.trim() !== 'QUEUED');
+        let notQueuedExecutions = rows.filter(row => row.nativeElement.children[COL_STATE].textContent.trim() !== 'Queued');
 
         expect(notQueuedExecutions.length).toBe(4);
 
@@ -122,9 +122,9 @@ describe('ExecutionsListComponent', () => {
             let state = el.children[COL_STATE];
             let stateText = state.textContent ? state.textContent.trim() : "";
 
-            if (stateText == "COMPLETED") {
+            if (stateText == "Completed") {
                 expect(el.children[COL_ACTIONS].children.length).toBe(1);
-                expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('View Reports');
+                expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('Static Report');
             } else {
                 expect(el.children[COL_ACTIONS].children.length).toBe(0);
                 expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('');
@@ -148,7 +148,7 @@ describe('ExecutionsListComponent', () => {
 
             // NOTE: I'm not sure if this is not locale dependent
             let durationSeconds = Math.round(duration/1000);
-            expect(el.children[COL_DURATION].textContent).toEqual(durationSeconds + ' seconds');
+            expect(el.children[COL_STATE].textContent).toContain(durationSeconds + ' seconds');
         });
 
         it('should display data', () => {
@@ -159,7 +159,7 @@ describe('ExecutionsListComponent', () => {
 
                 expect(el.children.length).toEqual(COUNT_COLUMNS);
                 expect(el.children[COL_ID].textContent.trim()).toEqual(SORTED_EXECUTIONS_DATA[i].id.toString());
-                expect(el.children[COL_STATE].textContent.trim()).toEqual(SORTED_EXECUTIONS_DATA[i].state);
+                expect(el.children[COL_STATE].textContent.trim()).toContain(utils.humanReadableLabel(SORTED_EXECUTIONS_DATA[i].state));
             }
         });
     });


### PR DESCRIPTION
- Link to the Static Reports Instead of Dynamic Reports
- Combine duration with the "Status" column
- Fix state bugs adding "runUpdate" boolean variable to do the update only the first time the state changes from queued to started
- Change current word "STARTED" for state to "In Progress" adding a humanReadableLabel(state: ExecutionState) that translates state in labels in utils.ts and also changed all the label to not be "screamed" in capital letters

I had to wrap humanReadableLabel(state: ExecutionState) from utils.ts in executions-list.component.ts to make it usable in executions-list.component.html: is it right?
