### PR TITLE
T722_770 Execution Details Page: commented Reports tab and renaming

### DIFF
--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -1,8 +1,8 @@
 <div *ngIf="!execution">
-    <h2 i18n="Loading execution heading|Execution Page">Loading execution data</h2>
+    <h2 i18n="Loading analysis heading|Analysis Page">Loading analysis data</h2>
 </div>
 <div *ngIf="execution">
-    <h2 i18n="Heading|Execution Page">Execution details</h2>
+    <h2 i18n="Heading|Analysis Page">Analysis details</h2>
 
     <div *ngIf="execution.state === 'QUEUED' || execution.state === 'STARTED'">
         <wu-progress-bar
@@ -14,6 +14,7 @@
     </div>
 
     <wu-tab-container>
+<!--    commenting for when the reports will have to be linked again
         <wu-tab [tabTitle]="'Available Reports'">
             <div *ngIf="!displayReportLinks">
                 <div><wu-status-icon [status]="execution.state"></wu-status-icon>{{execution.state | wuPrettyExecutionStatus}}</div>
@@ -30,25 +31,26 @@
                 <li *ngIf="!hideUnfinishedFeatures"><a [routerLink]="['../dependencies']" i18n="report">Dependencies</a></li>
             </ul>
         </wu-tab>
-        <wu-tab [tabTitle]="'Execution Status'">
+-->
+        <wu-tab [tabTitle]="'Analysis Status'">
             <dl>
-                <dt i18n="Execution state">State</dt>
+                <dt i18n="Analysis state">State</dt>
                 <dd><wu-status-icon [status]="execution.state"></wu-status-icon>{{execution.state | wuPrettyExecutionStatus}}</dd>
-                <dt i18n="Execution start date">Started Date</dt>
+                <dt i18n="Analysis start date">Started Date</dt>
                 <dd>{{execution.timeStarted | date: 'short'}}</dd>
                 <ng-container *ngIf="execution.timeCompleted">
-                    <dt i18n="Execution completion date">Completed Date</dt>
+                    <dt i18n="Analysis completion date">Completed Date</dt>
                     <dd>{{execution.timeCompleted | date: 'short'}}</dd>
-                    <dt i18n="Execution duration">Duration</dt>
+                    <dt i18n="Analysis duration">Duration</dt>
                     <dd>{{ execution.timeCompleted - execution.timeStarted | wuDuration }}</dd>
                 </ng-container>
                 <ng-container *ngIf="!execution.timeCompleted">
-                    <dt i18n="Execution last modification">Last Modified Date</dt>
+                    <dt i18n="Analysis last modification">Last Modified Date</dt>
                     <dd>{{execution.lastModified | date: 'short'}}</dd>
                 </ng-container>
             </dl>
 
-            <h3 i18n="Execution configuration|Section">Configuration</h3>
+            <h3 i18n="Analysis configuration|Section">Configuration</h3>
 
             <h4 i18n="Migration Path">Migration path</h4>
             {{execution.analysisContext?.migrationPath?.name}}
@@ -58,22 +60,22 @@
                 <li *ngFor="let application of execution.filterApplications">{{application.fileName}}</li>
             </ul>
 
-            <h4 i18n="Rules used for execution">Rules</h4>
+            <h4 i18n="Rules used for analysis">Rules</h4>
             <ul>
                 <li *ngFor="let rulePath of execution.analysisContext.rulesPaths">{{rulePath.path}}</li>
             </ul>
 
-            <h4 i18n="Packages included for execution">Included packages</h4>
+            <h4 i18n="Packages included for analysis">Included packages</h4>
             <ul>
                 <li *ngFor="let package of execution.analysisContext.includePackages">{{package.fullName}}</li>
             </ul>
 
-            <h4 i18n="Packages excluded from execution">Excluded packages</h4>
+            <h4 i18n="Packages excluded from analysis">Excluded packages</h4>
             <ul>
                 <li *ngFor="let package of execution.analysisContext.excludePackages">{{package.fullName}}</li>
             </ul>
 
-            <h4 i18n="Advanced Options|Execution">Advanced options</h4>
+            <h4 i18n="Advanced Options|Analysis">Advanced options</h4>
             <wu-analysis-context-advanced-options
                 [(selectedOptions)]="execution.analysisContext.advancedOptions"
                 [isReadOnly]="true"

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -26,6 +26,9 @@
                 <span *ngIf="execution.state == 'COMPLETED' || execution.state == 'FAILED'">
                     in
                 </span>
+                <span *ngIf="execution.state == 'CANCELLED'">
+                    after
+                </span>
                 <span *ngIf="execution.timeCompleted">
                     {{(execution.timeCompleted - execution.timeStarted | wuDuration)}}
                 </span>

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -98,7 +98,7 @@ describe('ExecutionsListComponent', () => {
     it('should display cancel link for QUEUED executions', () => {
         let rows = fixture.debugElement.queryAll(By.css('tbody tr'));
 
-        let queuedExecutions = rows.filter(row => row.nativeElement.children[COL_STATE].textContent.trim() === 'Queued');
+        let queuedExecutions = rows.filter(row => row.nativeElement.children[COL_STATE].textContent.trim().startsWith('Queued'));
 
         expect(queuedExecutions.length).toBe(1);
 
@@ -114,7 +114,7 @@ describe('ExecutionsListComponent', () => {
     it('should not display cancel link for executions in other state', () => {
         let rows = fixture.debugElement.queryAll(By.css('tbody tr'));
 
-        let notQueuedExecutions = rows.filter(row => row.nativeElement.children[COL_STATE].textContent.trim() !== 'Queued');
+        let notQueuedExecutions = rows.filter(row => !row.nativeElement.children[COL_STATE].textContent.trim().startsWith('Queued'));
 
         expect(notQueuedExecutions.length).toBe(4);
 


### PR DESCRIPTION
- commented the "Available Reports" tab waiting for dynamic report to be available
- renamed all "Executions" in "Analysis"

After commit https://github.com/mrizzi/windup-web/commit/9b55e440c44871474f38e949b94cc22955140243
- added handling of "CANCELLED" state to executions-list.component.html 
- fix tests
