### PR TITLE
Autobackup and ruleentity cleanup

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/DataBackup.java
+++ b/services/src/main/java/org/jboss/windup/web/services/DataBackup.java
@@ -41,7 +41,7 @@ public class DataBackup
     @PersistenceContext
     private EntityManager entityManager;
 
-    @Schedule(hour = "5,11,17,23", minute = "10")
+    @Schedule(hour = "23/6", minute = "10")
     public void maintainBackups()
     {
         this.backupDatabase();

--- a/services/src/main/java/org/jboss/windup/web/services/DataBackup.java
+++ b/services/src/main/java/org/jboss/windup/web/services/DataBackup.java
@@ -1,0 +1,149 @@
+package org.jboss.windup.web.services;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.ejb.Schedule;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.windup.web.addons.websupport.WebPathUtil;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
+
+/**
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+@Singleton
+@Startup
+public class DataBackup
+{
+    public static final String BACKUP = "backup";
+    public static final Long MAX_AGE_DAYS = 3L;
+
+    private static Logger LOG = Logger.getLogger(DataBackup.class.getName());
+
+    @Inject
+    @FromFurnace
+    private WebPathUtil webPathUtil;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Schedule(hour = "5,11,17,23", minute = "10")
+    public void maintainBackups()
+    {
+        this.backupDatabase();
+        this.purgeOldBackups();
+    }
+
+    private void backupDatabase()
+    {
+        // NOTE, this probably only works on H2
+        Path backupFile = getBackupFile();
+        if (backupFile == null)
+            return;
+
+        String backupPath = backupFile.toAbsolutePath().toString();
+        try
+        {
+            String backupCommand = "BACKUP TO '" + backupPath + "';";
+            this.entityManager.createNativeQuery(backupCommand)
+                        .executeUpdate();
+            LOG.info("H2 database backed up to: " + backupPath);
+        }
+        catch (Exception e)
+        {
+            LOG.log(Level.WARNING, "Error creating hourly auto-backup to: " + backupPath + " due to: " + e.getMessage(), e);
+        }
+    }
+
+    private void purgeOldBackups()
+    {
+        Path backupDirectory = this.getBackupDirectory();
+        if (backupDirectory == null)
+            return;
+
+        try
+        {
+            Files.list(backupDirectory)
+                        .forEach(path -> {
+                            try
+                            {
+                                if (!Files.isRegularFile(path))
+                                    return;
+
+                                String filename = path.getFileName().toString();
+                                Matcher filenameMatcher = Pattern
+                                            .compile("BACKUP_(\\d\\d\\d\\d_\\d\\d_\\d\\d-\\d\\d\\d\\d).zip")
+                                            .matcher(filename);
+                                if (!filenameMatcher.matches())
+                                    return;
+
+                                String dateString = filenameMatcher.group(1);
+                                Date date = getDateFormat().parse(dateString);
+                                long age = System.currentTimeMillis() - date.getTime();
+                                long maxAge = MAX_AGE_DAYS * 24L * 60L * 60L * 1000L;
+                                if (age > maxAge)
+                                {
+                                    LOG.info("Purging old backup file: " + path);
+                                    FileUtils.deleteQuietly(path.toFile());
+                                }
+                            }
+                            catch (ParseException e)
+                            {
+                                LOG.warning("Unexpected file format in backup folder: " + path);
+                            }
+                        });
+        }
+        catch (IOException e)
+        {
+            LOG.warning("Error cleaning up backup folder (path: " + backupDirectory + "): " + e.getMessage());
+        }
+    }
+
+    private SimpleDateFormat getDateFormat()
+    {
+        return new SimpleDateFormat("yyyy_MM_dd-HHmm");
+    }
+
+    private Path getBackupFile()
+    {
+        Path directory = getBackupDirectory();
+        if (directory == null)
+            return null;
+
+        String dateFormatted = getDateFormat().format(new Date());
+        String filename = "BACKUP_" + dateFormatted + ".zip";
+        return directory.resolve(filename);
+    }
+
+    private Path getBackupDirectory()
+    {
+        Path windupDataPath = webPathUtil.getGlobalWindupDataPath();
+        Path backupDirectory = windupDataPath.resolve(BACKUP);
+
+        try
+        {
+            if (!Files.isDirectory(backupDirectory))
+                Files.createDirectories(backupDirectory);
+        }
+        catch (IOException e)
+        {
+            LOG.warning("Unable to create folder for backup data: " + e.getMessage());
+            return null;
+        }
+        return backupDirectory;
+    }
+}

--- a/services/src/main/java/org/jboss/windup/web/services/RuleDataLoader.java
+++ b/services/src/main/java/org/jboss/windup/web/services/RuleDataLoader.java
@@ -120,6 +120,12 @@ public class RuleDataLoader
 
                     String providerID = ruleProviderMetadata.getID();
                     String origin = ruleProviderMetadata.getOrigin();
+                    RuleProviderEntity.RuleProviderType ruleProviderType = getProviderType(origin);
+
+                    // Skip user provided rules that are
+                    if (rulesPath.getRulesPathType() == RulesPath.RulesPathType.USER_PROVIDED &&
+                            ruleProviderType == RuleProviderEntity.RuleProviderType.JAVA)
+                        continue;
 
                     RuleProviderEntity ruleProviderEntity = new RuleProviderEntity();
                     ruleProviderEntity.setProviderID(providerID);
@@ -140,7 +146,7 @@ public class RuleDataLoader
 
                     ruleProviderEntity.setPhase(phase);
 
-                    ruleProviderEntity.setRuleProviderType(getProviderType(origin));
+                    ruleProviderEntity.setRuleProviderType(ruleProviderType);
 
                     List<RuleEntity> ruleEntities = new ArrayList<>();
 

--- a/services/src/main/java/org/jboss/windup/web/services/RuleDataLoader.java
+++ b/services/src/main/java/org/jboss/windup/web/services/RuleDataLoader.java
@@ -16,13 +16,17 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import javax.annotation.Resource;
 import javax.ejb.Schedule;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.transaction.UserTransaction;
 
 import org.jboss.windup.config.RuleProvider;
 import org.jboss.windup.config.loader.RuleLoaderContext;
@@ -49,12 +53,16 @@ import org.ocpsoft.rewrite.config.Rule;
  */
 @Singleton
 @Startup
+@TransactionManagement(TransactionManagementType.BEAN)
 public class RuleDataLoader
 {
     private static Logger LOG = Logger.getLogger(RuleDataLoader.class.getName());
 
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Resource
+    private UserTransaction userTransaction;
 
     @Inject
     private ConfigurationService configurationService;
@@ -78,99 +86,119 @@ public class RuleDataLoader
     public void loadPeriodically()
     {
         reloadRuleData();
-        cleanupDanglingRows();
-        getCategories();
     }
 
     public void configurationUpdated(@Observes Configuration configuration)
     {
         LOG.info("Reloading rule data due to configuration update!");
         reloadRuleData();
-        getCategories();
     }
 
     public void reloadRuleData()
     {
-        LOG.info("Loading all rule data...");
-        Configuration webConfiguration = configurationService.getConfiguration();
-        if (webConfiguration.getRulesPaths() == null || webConfiguration.getRulesPaths().isEmpty())
-            return;
-
-        for (RulesPath rulesPath : webConfiguration.getRulesPaths())
+        LOG.info("Starting reload of rule data...");
+        try
         {
-            LOG.info("Purging existing rule data for: " + rulesPath);
-            // Delete the previous ones
-            entityManager
-                        .createNamedQuery(RuleProviderEntity.DELETE_BY_RULES_PATH)
-                        .setParameter(RuleProviderEntity.RULES_PATH_PARAM, rulesPath)
-                        .executeUpdate();
+            this.loadRules();
+        }
+        catch (Exception e)
+        {
+            LOG.log(Level.SEVERE, "Error loading rules due to: " + e.getMessage(), e);
+        }
+        this.getCategories();
+        this.cleanupDanglingRows();
+        LOG.info("Rule data reload complete!");
+    }
 
-            entityManager.createNamedQuery(RuleProviderEntity.DELETE_WITH_NULL_RULES_PATH).executeUpdate();
+    private void loadRules()
+    {
+        this.begin();
+        try
+        {
+            Configuration webConfiguration = configurationService.getConfiguration();
+            if (webConfiguration.getRulesPaths() == null || webConfiguration.getRulesPaths().isEmpty())
+                return;
 
-            rulesPath.setLoadError(null);
-            try
+            for (RulesPath rulesPath : webConfiguration.getRulesPaths())
             {
-                Path path = Paths.get(rulesPath.getPath());
-                RuleLoaderContext ruleLoaderContext = new RuleLoaderContext(Collections.singleton(path), null);
-                RuleProviderRegistry providerRegistry = ruleProviderService.loadRuleProviderRegistry(Collections.singleton(path));
+                LOG.info("Purging existing rule data for: " + rulesPath);
+                // Delete the previous ones
+                entityManager
+                            .createNamedQuery(RuleProviderEntity.DELETE_BY_RULES_PATH)
+                            .setParameter(RuleProviderEntity.RULES_PATH_PARAM, rulesPath)
+                            .executeUpdate();
 
-                for (RuleProvider provider : providerRegistry.getProviders())
+                entityManager.createNamedQuery(RuleProviderEntity.DELETE_WITH_NULL_RULES_PATH).executeUpdate();
+
+                rulesPath.setLoadError(null);
+                try
                 {
-                    RuleProviderMetadata ruleProviderMetadata = provider.getMetadata();
+                    Path path = Paths.get(rulesPath.getPath());
+                    RuleLoaderContext ruleLoaderContext = new RuleLoaderContext(Collections.singleton(path), null);
+                    RuleProviderRegistry providerRegistry = ruleProviderService.loadRuleProviderRegistry(Collections.singleton(path));
 
-                    String providerID = ruleProviderMetadata.getID();
-                    String origin = ruleProviderMetadata.getOrigin();
-                    RuleProviderEntity.RuleProviderType ruleProviderType = getProviderType(origin);
-
-                    // Skip user provided rules that are
-                    if (rulesPath.getRulesPathType() == RulesPath.RulesPathType.USER_PROVIDED &&
-                            ruleProviderType == RuleProviderEntity.RuleProviderType.JAVA)
-                        continue;
-
-                    RuleProviderEntity ruleProviderEntity = new RuleProviderEntity();
-                    ruleProviderEntity.setProviderID(providerID);
-                    ruleProviderEntity.setDateLoaded(new GregorianCalendar());
-                    ruleProviderEntity.setDescription(ruleProviderMetadata.getDescription());
-                    ruleProviderEntity.setOrigin(origin);
-                    ruleProviderEntity.setRulesPath(rulesPath);
-                    entityManager.persist(ruleProviderEntity);
-
-                    setFileMetaData(ruleProviderEntity);
-
-                    ruleProviderEntity.setSources(technologyReferencesToTechnologyList(ruleProviderMetadata.getSourceTechnologies()));
-                    ruleProviderEntity.setTargets(technologyReferencesToTechnologyList(ruleProviderMetadata.getTargetTechnologies()));
-
-                    String phase = MigrationRulesPhase.class.getSimpleName().toUpperCase();
-                    if (ruleProviderMetadata.getPhase() != null)
-                        phase = ruleProviderMetadata.getPhase().getSimpleName().toUpperCase();
-
-                    ruleProviderEntity.setPhase(phase);
-
-                    ruleProviderEntity.setRuleProviderType(ruleProviderType);
-
-                    List<RuleEntity> ruleEntities = new ArrayList<>();
-
-                    for (Rule rule : provider.getConfiguration(ruleLoaderContext).getRules())
+                    for (RuleProvider provider : providerRegistry.getProviders())
                     {
-                        String ruleID = rule.getId();
-                        String ruleString = this.ruleFormatterService.ruleToRuleContentsString(rule);
+                        RuleProviderMetadata ruleProviderMetadata = provider.getMetadata();
 
-                        RuleEntity ruleEntity = new RuleEntity();
-                        ruleEntity.setRuleID(ruleID);
-                        ruleEntity.setRuleContents(ruleString);
-                        ruleEntities.add(ruleEntity);
+                        String providerID = ruleProviderMetadata.getID();
+                        String origin = ruleProviderMetadata.getOrigin();
+                        RuleProviderEntity.RuleProviderType ruleProviderType = getProviderType(origin);
+
+                        // Skip user provided rules that are
+                        if (rulesPath.getRulesPathType() == RulesPath.RulesPathType.USER_PROVIDED &&
+                                    ruleProviderType == RuleProviderEntity.RuleProviderType.JAVA)
+                            continue;
+
+                        RuleProviderEntity ruleProviderEntity = new RuleProviderEntity();
+                        ruleProviderEntity.setProviderID(providerID);
+                        ruleProviderEntity.setDateLoaded(new GregorianCalendar());
+                        ruleProviderEntity.setDescription(ruleProviderMetadata.getDescription());
+                        ruleProviderEntity.setOrigin(origin);
+                        ruleProviderEntity.setRulesPath(rulesPath);
+                        entityManager.persist(ruleProviderEntity);
+
+                        setFileMetaData(ruleProviderEntity);
+
+                        ruleProviderEntity.setSources(technologyReferencesToTechnologyList(ruleProviderMetadata.getSourceTechnologies()));
+                        ruleProviderEntity.setTargets(technologyReferencesToTechnologyList(ruleProviderMetadata.getTargetTechnologies()));
+
+                        String phase = MigrationRulesPhase.class.getSimpleName().toUpperCase();
+                        if (ruleProviderMetadata.getPhase() != null)
+                            phase = ruleProviderMetadata.getPhase().getSimpleName().toUpperCase();
+
+                        ruleProviderEntity.setPhase(phase);
+
+                        ruleProviderEntity.setRuleProviderType(ruleProviderType);
+
+                        List<RuleEntity> ruleEntities = new ArrayList<>();
+
+                        for (Rule rule : provider.getConfiguration(ruleLoaderContext).getRules())
+                        {
+                            String ruleID = rule.getId();
+                            String ruleString = this.ruleFormatterService.ruleToRuleContentsString(rule);
+
+                            RuleEntity ruleEntity = new RuleEntity();
+                            ruleEntity.setRuleID(ruleID);
+                            ruleEntity.setRuleContents(ruleString);
+                            ruleEntities.add(ruleEntity);
+                        }
+
+                        ruleProviderEntity.setRules(ruleEntities);
+
+                        entityManager.persist(ruleProviderEntity);
                     }
-
-                    ruleProviderEntity.setRules(ruleEntities);
-
-                    entityManager.persist(ruleProviderEntity);
+                }
+                catch (Exception e)
+                {
+                    rulesPath.setLoadError("Failed to load rules due to: " + e.getMessage());
+                    LOG.log(Level.SEVERE, "Could not load rule information due to: " + e.getMessage(), e);
                 }
             }
-            catch (Exception e)
-            {
-                rulesPath.setLoadError("Failed to load rules due to: " + e.getMessage());
-                LOG.log(Level.SEVERE, "Could not load rule information due to: " + e.getMessage(), e);
-            }
+        }
+        finally
+        {
+            this.commit();
         }
     }
 
@@ -179,49 +207,63 @@ public class RuleDataLoader
      */
     private void cleanupDanglingRows()
     {
-        this.runSqlQuiet("delete from ruleproviderentity_ruleentity where ruleproviderentity_rule_provider_entity_id " +
-                "in (select rule_provider_entity_id from ruleproviderentity where RULESPATH_RULES_PATH_ID is null);");
-        this.runSqlQuiet("delete from ruleproviderentity_technology_source where " +
-                        "rule_provider_entity_id in (select rule_provider_entity_id from ruleproviderentity where RULESPATH_RULES_PATH_ID is null);");
-        this.runSqlQuiet("delete from ruleproviderentity_technology_target " +
-                        "where rule_provider_entity_id in (select rule_provider_entity_id from ruleproviderentity where RULESPATH_RULES_PATH_ID is null);");
-        this.runSqlQuiet("delete from ruleproviderentity where RULESPATH_RULES_PATH_ID is null;");
-        this.runSqlQuiet("delete from ruleentity re where re.rule_entity_id not in " +
-                "(select rules_rule_entity_id from ruleproviderentity_ruleentity);");
-    }
-
-    private void runSqlQuiet(String sql)
-    {
         try
         {
-            this.entityManager.createNativeQuery(sql).executeUpdate();
+            this.begin();
+            this.entityManager.createQuery("delete from RuleProviderEntity where rulesPath is null").executeUpdate();
+            this.commit();
+
+            this.begin();
+            for (RuleEntity ruleEntity : this.entityManager.createQuery("select re from RuleEntity re", RuleEntity.class).getResultList())
+            {
+                long ruleProviderCount = this.entityManager
+                            .createQuery("select count(rpe) from RuleProviderEntity rpe where :ruleEntity member of rpe.rules", Long.class)
+                            .setParameter("ruleEntity", ruleEntity)
+                            .getSingleResult();
+                if (ruleProviderCount == 0)
+                {
+                    this.entityManager.remove(ruleEntity);
+                }
+            }
         }
-        catch (Exception e)
+        catch (Throwable t)
         {
-            LOG.log(Level.WARNING, "Failed to execute sql due to: " + e.getMessage(), e);
+            LOG.warning("Rule provider data cleanup failed due to: " + t.getMessage());
+        }
+        finally
+        {
+            this.commit();
         }
     }
 
     private Collection<Category> getCategories()
     {
-        List<Category> existingCategoriesList = this.entityManager.createQuery("SELECT c FROM Category c", Category.class)
-                    .getResultList();
+        this.begin();
+        try
+        {
+            List<Category> existingCategoriesList = this.entityManager.createQuery("SELECT c FROM Category c", Category.class)
+                        .getResultList();
 
-        Set<String> existingCategoriesAsString = existingCategoriesList.stream()
-                    .map(Category::getName)
-                    .collect(Collectors.toSet());
+            Set<String> existingCategoriesAsString = existingCategoriesList.stream()
+                        .map(Category::getName)
+                        .collect(Collectors.toSet());
 
-        Map<String, Integer> categoriesWithPriority = this.issueCategoryProviderService.getCategoriesWithPriority();
+            Map<String, Integer> categoriesWithPriority = this.issueCategoryProviderService.getCategoriesWithPriority();
 
-        List<Category> categories = categoriesWithPriority
-                    .entrySet().stream()
-                    .filter(category -> !existingCategoriesAsString.contains(category.getKey()))
-                    .map(category -> new Category(category.getKey(), category.getValue()))
-                    .collect(Collectors.toList());
+            List<Category> categories = categoriesWithPriority
+                        .entrySet().stream()
+                        .filter(category -> !existingCategoriesAsString.contains(category.getKey()))
+                        .map(category -> new Category(category.getKey(), category.getValue()))
+                        .collect(Collectors.toList());
 
-        categories.forEach(category -> this.entityManager.persist(category));
+            categories.forEach(category -> this.entityManager.persist(category));
 
-        return categories;
+            return categories;
+        }
+        finally
+        {
+            this.commit();
+        }
     }
 
     private Set<Technology> technologyReferencesToTechnologyList(Collection<TechnologyReference> technologyReferences)
@@ -279,5 +321,29 @@ public class RuleDataLoader
             return RuleProviderEntity.RuleProviderType.GROOVY;
         else
             return RuleProviderEntity.RuleProviderType.JAVA;
+    }
+
+    private void begin()
+    {
+        try
+        {
+            this.userTransaction.begin();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void commit()
+    {
+        try
+        {
+            this.userTransaction.commit();
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/services/src/main/java/org/jboss/windup/web/services/model/RuleProviderEntity.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/RuleProviderEntity.java
@@ -43,13 +43,17 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
     @NamedQuery(name = RuleProviderEntity.DELETE_ALL, query = "delete from RuleProviderEntity"),
     @NamedQuery(
             name = RuleProviderEntity.DELETE_BY_RULES_PATH,
-            query = "delete from RuleProviderEntity rpe where rpe.rulesPath = :" + RuleProviderEntity.RULES_PATH_PARAM)
+            query = "delete from RuleProviderEntity rpe where rpe.rulesPath = :" + RuleProviderEntity.RULES_PATH_PARAM),
+    @NamedQuery(
+            name = RuleProviderEntity.DELETE_WITH_NULL_RULES_PATH,
+            query = "delete from RuleProviderEntity rpe where rpe.rulesPath is null")
 })
 public class RuleProviderEntity implements Serializable
 {
     public static final String FIND_ALL = "RuleProviderEntity.findAll";
     public static final String DELETE_ALL = "RuleProviderEntity.deleteAll";
     public static final String DELETE_BY_RULES_PATH = "RuleProviderEntity.deleteByRulesPath";
+    public static final String DELETE_WITH_NULL_RULES_PATH = "RuleProviderEntity.deleteNullPath";
     public static final String RULES_PATH_PARAM = "rulesPath";
 
     public static final String RULE_PROVIDER_ENTITY_ID = "rule_provider_entity_id";
@@ -99,7 +103,7 @@ public class RuleProviderEntity implements Serializable
     @JoinTable(name = "ruleproviderentity_technology_target", joinColumns = @JoinColumn(name = RULE_PROVIDER_ENTITY_ID, referencedColumnName = RULE_PROVIDER_ENTITY_ID), inverseJoinColumns = @JoinColumn(name = Technology.TECHNOLOGY_ID, referencedColumnName = Technology.TECHNOLOGY_ID))
     private Set<Technology> targets;
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn(name = RuleEntity.RULE_SEQUENCE)
     private List<RuleEntity> rules;
 

--- a/services/src/main/java/org/jboss/windup/web/services/model/RuleProviderEntity.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/RuleProviderEntity.java
@@ -103,7 +103,7 @@ public class RuleProviderEntity implements Serializable
     @JoinTable(name = "ruleproviderentity_technology_target", joinColumns = @JoinColumn(name = RULE_PROVIDER_ENTITY_ID, referencedColumnName = RULE_PROVIDER_ENTITY_ID), inverseJoinColumns = @JoinColumn(name = Technology.TECHNOLOGY_ID, referencedColumnName = Technology.TECHNOLOGY_ID))
     private Set<Technology> targets;
 
-    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @OrderColumn(name = RuleEntity.RULE_SEQUENCE)
     private List<RuleEntity> rules;
 

--- a/services/src/main/resources/META-INF/persistence.xml
+++ b/services/src/main/resources/META-INF/persistence.xml
@@ -9,7 +9,6 @@
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.format_sql" value="false"/>
       <property name="hibernate.transaction.flush_before_completion" value="true"/>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/services/src/test/resources/META-INF/persistence-inmemory.xml
+++ b/services/src/test/resources/META-INF/persistence-inmemory.xml
@@ -9,7 +9,6 @@
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.format_sql" value="false"/>
       <property name="hibernate.transaction.flush_before_completion" value="true"/>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/services/src/test/resources/META-INF/persistence-ondisk.xml
+++ b/services/src/test/resources/META-INF/persistence-ondisk.xml
@@ -9,7 +9,6 @@
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.format_sql" value="false"/>
       <property name="hibernate.transaction.flush_before_completion" value="true"/>
-      <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
This creates automatic backups of the db every 6 hours. It will keep 3 days
of these backups in a backup folder underneat the global Windup data folder.

Also, this makes sure to clean up any dangling rule entity objects. Previously
these were causing the database to grow in size, almost without bound.