### PR TITLE
T775 Analysis details page redesign

### DIFF
--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -2,7 +2,7 @@
     <h2 i18n="Loading analysis heading|Analysis Page">Loading analysis data</h2>
 </div>
 <div *ngIf="execution">
-    <h2 i18n="Heading|Analysis Page">Analysis details</h2>
+    <h2 i18n="Heading|Analysis Page">Analysis #{{execution.id}}</h2>
 
     <div *ngIf="execution.state === 'QUEUED' || execution.state === 'STARTED'">
         <wu-progress-bar
@@ -32,50 +32,68 @@
             </ul>
         </wu-tab>
 -->
-        <wu-tab [tabTitle]="'Analysis Status'">
+        <wu-tab [tabTitle]="'Details'">
+            <h3 i18n="Analysis status|Section">Status</h3>
             <dl>
-                <dt i18n="Analysis state">State</dt>
+                <dt i18n="Analysis status">Status:</dt>
                 <dd><wu-status-icon [status]="execution.state"></wu-status-icon>{{execution.state | wuPrettyExecutionStatus}}</dd>
-                <dt i18n="Analysis start date">Started Date</dt>
+                <dt i18n="Analysis start date">Started:</dt>
                 <dd>{{execution.timeStarted | date: 'short'}}</dd>
                 <ng-container *ngIf="execution.timeCompleted">
+<!--
                     <dt i18n="Analysis completion date">Completed Date</dt>
                     <dd>{{execution.timeCompleted | date: 'short'}}</dd>
-                    <dt i18n="Analysis duration">Duration</dt>
+-->
+                    <dt i18n="Analysis duration">Duration:</dt>
                     <dd>{{ execution.timeCompleted - execution.timeStarted | wuDuration }}</dd>
                 </ng-container>
                 <ng-container *ngIf="!execution.timeCompleted">
-                    <dt i18n="Analysis last modification">Last Modified Date</dt>
+                    <dt i18n="Analysis last modification">Last modification:</dt>
                     <dd>{{execution.lastModified | date: 'short'}}</dd>
                 </ng-container>
             </dl>
 
             <h3 i18n="Analysis configuration|Section">Configuration</h3>
+            <dl>
+                <dt i18n="Migration Path">Migration path:</dt>
+                <dd>{{execution.analysisContext?.migrationPath?.name}}</dd>
 
-            <h4 i18n="Migration Path">Migration path</h4>
-            {{execution.analysisContext?.migrationPath?.name}}
+                <dt i18n="Analyzed applications">Analyzed applications:</dt>
+                <dd *ngFor="let application of execution.filterApplications">{{application.fileName}}</dd>
 
-            <h4 i18n="Analyzed applications">Analyzed applications</h4>
-            <ul>
-                <li *ngFor="let application of execution.filterApplications">{{application.fileName}}</li>
-            </ul>
+                <dt i18n="Rules used for analysis">Rules:</dt>
+                <dd *ngFor="let rulePath of execution.analysisContext.rulesPaths">{{rulePath.path}}</dd>
+            </dl>
 
-            <h4 i18n="Rules used for analysis">Rules</h4>
-            <ul>
-                <li *ngFor="let rulePath of execution.analysisContext.rulesPaths">{{rulePath.path}}</li>
-            </ul>
+            <fieldset *ngIf="execution.analysisContext.includePackages.length > 0" class="fields-section-pf" id="includedPkgsSection">
+                <legend class="fields-section-header-pf" aria-expanded="includedPkgsShow">
+                    <span *ngIf="!includedPkgsShow" class="fa fa-angle-right field-section-toggle-pf"></span>
+                    <span *ngIf="includedPkgsShow" class="fa fa-angle-right field-section-toggle-pf fa-angle-down"></span>
+                    <a (click)="includedPkgsShow = !includedPkgsShow;" class="field-section-toggle-pf" i18n>Included packages</a>
+                </legend>
+                <div [hidden]="!includedPkgsShow" class="form-group">
+                    <ul>
+                        <li *ngFor="let package of execution.analysisContext.includePackages">{{package.fullName}}</li>
+                    </ul>
+                </div>
+            </fieldset>
 
-            <h4 i18n="Packages included for analysis">Included packages</h4>
-            <ul>
-                <li *ngFor="let package of execution.analysisContext.includePackages">{{package.fullName}}</li>
-            </ul>
+            <fieldset *ngIf="execution.analysisContext.excludePackages.length > 0" class="fields-section-pf" id="excludedPkgsSection">
+                <legend class="fields-section-header-pf" aria-expanded="excludedPkgsShow">
+                    <span *ngIf="!excludedPkgsShow" class="fa fa-angle-right field-section-toggle-pf"></span>
+                    <span *ngIf="excludedPkgsShow" class="fa fa-angle-right field-section-toggle-pf fa-angle-down"></span>
+                    <a (click)="excludedPkgsShow = !excludedPkgsShow;" class="field-section-toggle-pf" i18n>Excluded packages</a>
+                </legend>
+                <div [hidden]="!excludedPkgsShow" class="form-group">
+                    <ul>
+                        <li *ngFor="let package of execution.analysisContext.excludePackages">{{package.fullName}}</li>
+                    </ul>
+                </div>
+            </fieldset>
 
-            <h4 i18n="Packages excluded from analysis">Excluded packages</h4>
-            <ul>
-                <li *ngFor="let package of execution.analysisContext.excludePackages">{{package.fullName}}</li>
-            </ul>
-
-            <h4 i18n="Advanced Options|Analysis">Advanced options</h4>
+        </wu-tab>
+        <wu-tab [tabTitle]="'Advanced Options'">
+            <h3 i18n="Advanced Options|Analysis">Advanced options</h3>
             <wu-analysis-context-advanced-options
                 [(selectedOptions)]="execution.analysisContext.advancedOptions"
                 [isReadOnly]="true"

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -48,21 +48,15 @@
                     <dd>{{ execution.timeCompleted - execution.timeStarted | wuDuration }}</dd>
                 </ng-container>
                 <ng-container *ngIf="!execution.timeCompleted">
-                    <dt i18n="Analysis last modification">Last modification:</dt>
+                    <dt i18n="Analysis last modification">Duration:</dt>
                     <dd>{{execution.lastModified | date: 'short'}}</dd>
                 </ng-container>
             </dl>
 
             <h3 i18n="Analysis configuration|Section">Configuration</h3>
             <dl>
-                <dt i18n="Migration Path">Migration path:</dt>
+                <dt i18n="Migration Path">Transformation path:</dt>
                 <dd>{{execution.analysisContext?.migrationPath?.name}}</dd>
-
-                <dt i18n="Analyzed applications">Analyzed applications:</dt>
-                <dd *ngFor="let application of execution.filterApplications">{{application.fileName}}</dd>
-
-                <dt i18n="Rules used for analysis">Rules:</dt>
-                <dd *ngFor="let rulePath of execution.analysisContext.rulesPaths">{{rulePath.path}}</dd>
             </dl>
 
             <fieldset *ngIf="execution.analysisContext.includePackages.length > 0" class="fields-section-pf" id="includedPkgsSection">
@@ -91,6 +85,39 @@
                 </div>
             </fieldset>
 
+        </wu-tab>
+        <wu-tab [tabTitle]="'Applications (' + execution.filterApplications.length + ')'">
+            <h3 i18n="Analysis configuration|Section">Applications</h3>
+            <span *ngFor="let application of execution.filterApplications">{{application.fileName}}<br/></span>
+        </wu-tab>
+        <wu-tab [tabTitle]="'Rules'">
+            <table class="table table-bordered table-hover table-mobile executions-list-table">
+                <thead wu-sortable-table
+                       [data]="phases"
+                       [tableHeaders]="[
+                            { title: 'Rule ID', isSortable: false  },
+                            { title: 'Phase', isSortable: false  },
+                            { title: 'Rule Provider', isSortable: false  },
+                            { title: 'Executed', isSortable: false },
+                            { title: 'Succeed', isSortable: false },
+                            { title: 'Failure Cause', isSortable: false }
+                        ]">
+                </thead>
+                <tbody>
+                <template ngFor [ngForOf]="phases" let-phase>
+                    <template ngFor [ngForOf]="(phase?.ruleProviders | async)" let-ruleProvider>
+                        <tr *ngFor="let rule of (ruleProvider?.rules | async)" class="execution-row">
+                            <td>{{rule.ruleId}}</td>
+                            <td>{{phase.name}}</td>
+                            <td>{{ruleProvider.ruleProviderID}}</td>
+                            <td>{{rule.executed ? 'Yes' : 'No'}}</td>
+                            <td>{{rule.failed ? 'No' : 'Yes'}}</td>
+                            <td>{{rule.failureMessage}}</td>
+                        </tr>
+                    </template>
+                </template>
+                <tbody>
+            </table>
         </wu-tab>
         <wu-tab [tabTitle]="'Advanced Options'">
             <h3 i18n="Advanced Options|Analysis">Advanced options</h3>

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
@@ -8,6 +8,9 @@ import {WindupExecutionService} from "../services/windup-execution.service";
 import {EventBusService} from "../core/events/event-bus.service";
 import {ExecutionEvent} from "../core/events/windup-event";
 import {Observable} from "rxjs";
+import {RuleProviderExecutionsService} from "../reports/rule-provider-executions/rule-provider-executions.service";
+import {RuleExecutionModel} from "../generated/tsModels/RuleExecutionModel";
+import {ExecutionPhaseModel} from "../generated/tsModels/ExecutionPhaseModel";
 
 @Component({
     templateUrl: './execution-detail.component.html',
@@ -19,10 +22,11 @@ export class ExecutionDetailComponent implements OnInit {
     logLines:string[];
     includedPkgsShow: boolean = false;
     excludedPkgsShow: boolean = false;
+    phases: ExecutionPhaseModel[];
 
     hideUnfinishedFeatures: boolean = WINDUP_WEB.config.hideUnfinishedFeatures;
 
-    constructor(private _activatedRoute: ActivatedRoute, private _eventBus: EventBusService, private _windupService: WindupService) {
+    constructor(private _activatedRoute: ActivatedRoute, private _eventBus: EventBusService, private _windupService: WindupService, private _ruleProviderExecutionsService: RuleProviderExecutionsService) {
     }
 
     ngOnInit(): void {
@@ -35,11 +39,16 @@ export class ExecutionDetailComponent implements OnInit {
                 .subscribe((event: ExecutionEvent) => {
                     this.execution = event.execution;
                     this.loadLogData();
+                    console.log("qui");
                 });
 
             this._windupService.getExecution(executionId).subscribe(execution => {
                 this.execution = execution;
                 this.loadLogData();
+                this._ruleProviderExecutionsService.getPhases(params.executionId)
+                    .subscribe(phases => {
+                        this.phases = phases;
+                    });
             });
         });
     }

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
@@ -17,6 +17,8 @@ export class ExecutionDetailComponent implements OnInit {
 
     execution: WindupExecution;
     logLines:string[];
+    includedPkgsShow: boolean = false;
+    excludedPkgsShow: boolean = false;
 
     hideUnfinishedFeatures: boolean = WINDUP_WEB.config.hideUnfinishedFeatures;
 

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -15,7 +15,7 @@
     </thead>
     <tbody>
     <tr *ngFor="let execution of sortedExecutions" [class]="getClass(execution)" class="execution-row">
-        <td><a [routerLink]="['/projects', execution.projectId, execution.id, 'execution-details']">{{execution.id}}</a></td>
+        <td><a [routerLink]="['/projects', execution.projectId, execution.id, 'execution-details']">#{{execution.id}}</a></td>
         <td>
             <wu-status-icon [status]="execution.state"></wu-status-icon>
             {{execution.state | wuPrettyExecutionStatus}}

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -159,7 +159,7 @@ describe('ExecutionsListComponent', () => {
                 let el = row[i].nativeElement;
 
                 expect(el.children.length).toEqual(COUNT_COLUMNS);
-                expect(el.children[COL_ID].textContent.trim()).toEqual(SORTED_EXECUTIONS_DATA[i].id.toString());
+                expect(el.children[COL_ID].textContent.trim()).toEqual("#" + SORTED_EXECUTIONS_DATA[i].id.toString());
                 expect(el.children[COL_STATE].textContent.trim()).toContain((new PrettyExecutionStatus().transform(SORTED_EXECUTIONS_DATA[i].state)));
             }
         });


### PR DESCRIPTION
Redesign for the analysis details page:

- new layout for data presentation (see mockup, slide 22)
- collapse/expand section for {in,ex}cluded packages
- dedicated tab for advanced options
- little change in analysis list (introduction of "#" sign before analysis id)
- tests updated