### PR TITLE
T779 fix for adding advanced options with 'Save & Run'

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/model/AdvancedOption.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/AdvancedOption.java
@@ -43,6 +43,14 @@ public class AdvancedOption implements Serializable
     @Column(length = 8192)
     private String value;
 
+    public AdvancedOption() {}
+
+    public AdvancedOption(String name, String value)
+    {
+        this.name = name;
+        this.value = value;
+    }
+
     public Long getId()
     {
         return id;

--- a/services/src/main/java/org/jboss/windup/web/services/service/AnalysisContextService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/AnalysisContextService.java
@@ -6,10 +6,8 @@ import javax.persistence.PersistenceContext;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.NotFoundException;
 
-import org.jboss.windup.web.services.model.AnalysisContext;
-import org.jboss.windup.web.services.model.MigrationProject;
+import org.jboss.windup.web.services.model.*;
 import org.jboss.windup.web.services.model.Package;
-import org.jboss.windup.web.services.model.RulesPath;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -64,9 +62,25 @@ public class AnalysisContextService
         analysisContext.setId(null); // creating new instance, should not have id
         this.ensureSystemRulesPathsPresent(analysisContext);
         this.loadPackagesToAnalysisContext(analysisContext);
+        this.loadAdvancedOptionsToAnalysisContext(analysisContext);
         entityManager.persist(analysisContext);
 
         return analysisContext;
+    }
+
+    protected void loadAdvancedOptionsToAnalysisContext(AnalysisContext analysisContext)
+    {
+        analysisContext.setAdvancedOptions(this.loadAdvancedOptionsFromPersistenceContext(analysisContext.getAdvancedOptions()));
+    }
+
+    protected Collection<AdvancedOption> loadAdvancedOptionsFromPersistenceContext(Collection<AdvancedOption> advancedOptions)
+    {
+        return advancedOptions.stream()
+                .filter(anOption -> anOption.getId() != null && anOption.getId() != 0)
+                .map(anOption -> this.entityManager.find(AdvancedOption.class, anOption.getId()))
+                .filter(anOption -> anOption != null)
+                .map(anOption -> new AdvancedOption(anOption.getName(), anOption.getValue()))
+                .collect(Collectors.toList());
     }
 
     protected void loadPackagesToAnalysisContext(AnalysisContext analysisContext)


### PR DESCRIPTION
Implemented the method to add the advanced option when a new analysis is executed, just like it is done for rules path and packages.