### PR TITLE
(GENERAL FOR ALL INFO/ERROR MESSAGES) Remove the “Info: ” or “Error: …

### DIFF
--- a/ui/src/main/webapp/src/app/shared/notification.component.html
+++ b/ui/src/main/webapp/src/app/shared/notification.component.html
@@ -1,7 +1,11 @@
 <div [ngClass]="getClass(notification)" class="alert alert-dismissable" *ngFor="let notification of notificationsStack">
+
     <button type="button" class="close" data-dismiss="alert" aria-hidden="true" (click)="closeNotification(notification)">
         <span class="pficon pficon-close"></span>
     </button>
+
     <span [ngClass]="getIcon(notification)" class="pficon"></span>
-    <strong>{{getInfoMessage(notification)}}: </strong> {{notification.message}}
+
+    <!-- <strong>{{getInfoMessage(notification)}}: </strong> -->
+    {{notification.message}}
 </div>


### PR DESCRIPTION
…” text before the message. The icon and color are enough to signalize the nature of the message.