### PR TITLE
T836 Active analysis page wording

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -301,7 +301,6 @@ export class AnalysisContextFormComponent extends FormComponent
         if (this.action === Action.SaveAndRun) {
             this._windupExecutionService.execute(analysisContext, this.project)
                 .subscribe(execution => {
-                    this._notificationService.success('Windup execution has started');
                     this._router.navigate([`/projects/${this.project.id}`]);
                 },
                 error => {

--- a/ui/src/main/webapp/src/app/executions/active-executions-progressbar.component.html
+++ b/ui/src/main/webapp/src/app/executions/active-executions-progressbar.component.html
@@ -1,12 +1,13 @@
 <div *ngIf="activeExecutions && activeExecutions.length > 0">
-    <h2 i18n="heading|Active Executions">Active Executions</h2>
+    <h2 i18n="heading|Active Executions">Active analysis</h2>
     <div>
         <ng-container *ngFor="let activeExecution of activeExecutions">
             <wu-progress-bar *ngIf="activeExecution.currentTask || activeExecutions.length == 1"
                  [taskName]="activeExecution.currentTask"
                  [currentValue]="activeExecution.workCompleted"
                  [minValue]="0"
-                 [maxValue]="activeExecution.totalWork">
+                 [maxValue]="activeExecution.totalWork"
+                 [activeExecutionId]="activeExecution.id">
             </wu-progress-bar>
         </ng-container>
     </div>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -39,7 +39,9 @@
         </td>
         <td>{{execution.timeStarted | date: 'short'}}</td>
         <td>
-            <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" i18n="button">Cancel</a>
+            <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
+                <i class="fa fa-ban fa-fw"></i>
+            </a>
             <!-- left for when dynamic report will be linked again
             <a
                     class="link"

--- a/ui/src/main/webapp/src/app/shared/progress-bar.component.ts
+++ b/ui/src/main/webapp/src/app/shared/progress-bar.component.ts
@@ -5,7 +5,7 @@ import {Inject, Input} from '@angular/core';
     selector: 'wu-progress-bar',
     template: `
         <div class="progress-description">
-            <div class="spinner spinner-xs spinner-inline"></div><strong i18n="Progressbar task">Task:</strong> {{taskName ? taskName : "Starting..."}}
+            <div class="spinner spinner-xs spinner-inline"></div>&nbsp;<strong i18n="Analysis id">Analysis:</strong> #{{activeExecutionId}}&nbsp;&nbsp;<strong i18n="Progressbar task">Task:</strong> {{taskName ? taskName : "Starting..."}}
         </div>
         <div class="progress progress-label-top-right">
             <div
@@ -30,6 +30,8 @@ export class ProgressBarComponent {
     maxValue:number;
     @Input()
     currentValue:number;
+    @Input()
+    activeExecutionId: number;
 
     constructor() {}
 }

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -110,7 +110,7 @@ describe('ExecutionsListComponent', () => {
 
             expect(el.children[COL_ACTIONS].children.length).toBe(1);
             expect(el.children[COL_ACTIONS].children[0].nodeName.toLowerCase()).toEqual('a');
-            expect(el.children[COL_ACTIONS].children[0].textContent).toEqual('Cancel');
+            expect(el.children[COL_ACTIONS].children[0].title).toEqual('Cancel');
         });
     });
 


### PR DESCRIPTION
Refer to task [#836](https://tree.taiga.io/project/rdruss-jboss-migration-windup-v3/task/836)

- Completely remove the hint telling “Windup execution has started”.
- Rename “Active Executions” in “Active analysis”
- Add the analysis number of the current analysis. It should look as follows: `<Turning GIF> Analysis: #11937  Task: Executing ...`
- Replace the text “Cancel” with an icon 
- fixed tests
