### PR TITLE
T854 Analysis list page: add basic filtering

### DIFF
--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -1,10 +1,21 @@
 <wu-active-executions-progressbar [activeExecutions]="activeExecutions"></wu-active-executions-progressbar>
 
-<h2 i18n="heading|executions list">Analysis</h2>
+<div class="panel-body">
+    <div class="header-bar">
+        <h2>Analysis</h2>
+        <div class="search-and-create">
+            <wu-search [(searchValue)]="searchText" (searchValueChange)="updateSearch()"></wu-search>
+<!--        to be implemented next
+            <div class="button-container">
+                <button (click)="runExecution()" class="btn btn-primary" type="button">Run analysis</button>
+            </div>-->
+        </div>
+    </div>
+
 <table class="table table-bordered table-hover table-mobile executions-list-table">
     <thead wu-sortable-table
         [(sortedData)]="sortedExecutions"
-        [data]="executions"
+        [data]="filteredExecutions"
         [initialSortBy]="initialSort"
         [tableHeaders]="[
             { title: 'Analysis', isSortable: true, sortBy: 'id' },
@@ -46,10 +57,12 @@
                     *ngIf="execution.state == 'COMPLETED'"
                     [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">View Reports</a>
             -->
-            <a *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports" class="pointer link" target="_blank" href="{{formatStaticReportUrl(execution)}}" title="Show static reports">
-                <i class="fa fa-bar-chart fa-fw"></i>
-            </a>
-            &nbsp;
+            <span *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports">
+                <a  class="pointer link" target="_blank" href="{{formatStaticReportUrl(execution)}}" title="Show static reports">
+                    <i class="fa fa-bar-chart fa-fw"></i>
+                </a>
+                &nbsp;
+            </span>
             <a *ngIf="execution.state != 'STARTED' && execution.state != 'QUEUED'" class="pointer link" (click)="confirmDeleteExecution(execution)" title="Delete">
                 <i class="fa fa-trash-o fa-fw"></i>
             </a>
@@ -59,3 +72,4 @@
 </table>
 <wu-confirmation-modal #deleteExecutionDialog [id]="'deleteExecutionDialog'"></wu-confirmation-modal>
 <wu-confirmation-modal #cancelExecutionDialog [id]="'cancelExecutionDialog'"></wu-confirmation-modal>
+</div>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.scss
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.scss
@@ -1,0 +1,21 @@
+.header-bar {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.button-container {
+  padding-top: 15px;
+}
+
+.search-and-create {
+  display: flex;
+  flex-direction: row;
+}
+
+:host /deep/ {
+  .search-and-create .search-component {
+    padding-top: 15px;
+    margin-right: 10px;
+  }
+}

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.ts
@@ -13,7 +13,7 @@ import {ConfirmationModalComponent} from "../shared/confirmation-modal.component
     selector: 'wu-executions-list',
     templateUrl: './executions-list.component.html',
     providers: [SortingService],
-    styleUrls: ['../../../css/tables.scss']
+    styleUrls: ['../../../css/tables.scss', 'executions-list.component.scss']
 })
 export class ExecutionsListComponent implements OnInit, OnDestroy {
     @Output()
@@ -35,6 +35,10 @@ export class ExecutionsListComponent implements OnInit, OnDestroy {
 
     @ViewChild('cancelExecutionDialog')
     readonly cancelExecutionDialog: ConfirmationModalComponent;
+
+    searchText: string = '';
+
+    private filteredExecutions: WindupExecution[];
 
     constructor(
         private _elementRef: ElementRef,
@@ -73,6 +77,7 @@ export class ExecutionsListComponent implements OnInit, OnDestroy {
     public set executions(executions: WindupExecution[]) {
         this._executions = this._sortingService.sort(executions || []);
         this.sortedExecutions = this._executions;
+        this.filteredExecutions = this._executions;
     }
 
     public get executions(): WindupExecution[] {
@@ -162,4 +167,14 @@ export class ExecutionsListComponent implements OnInit, OnDestroy {
         return WindupExecutionService.formatStaticReportUrl(execution);
     }
 
+    updateSearch() {
+        if (this.searchText && this.searchText.length > 0) {
+            this.filteredExecutions = this._executions.filter(execution => (
+                execution.id.toString().search(new RegExp(this.searchText, 'i')) !== -1 ||
+                execution.state.search(new RegExp(this.searchText, 'i')) !== -1
+            ));
+        } else {
+            this.filteredExecutions = this._executions;
+        }
+    }
 }

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -19,6 +19,7 @@ import {SchedulerService} from "../../../../src/app/shared/scheduler.service";
 import {PrettyExecutionStatus} from "../../../../src/app/shared/pretty-execution-state.pipe";
 import {ConfirmationModalComponent} from "../../../../src/app/shared/confirmation-modal.component";
 import {FormsModule} from "@angular/forms";
+import {SearchComponent} from "../../../../src/app/shared/search/search.component";
 
 let comp:    ExecutionsListComponent;
 let fixture: ComponentFixture<ExecutionsListComponent>;
@@ -53,7 +54,8 @@ describe('ExecutionsListComponent', () => {
                 SortIndicatorComponent,
                 StatusIconComponent,
                 PrettyExecutionStatus,
-                ConfirmationModalComponent
+                ConfirmationModalComponent,
+                SearchComponent
             ],
             providers: [
                 SchedulerService,


### PR DESCRIPTION
Changes for [#854](https://tree.taiga.io/project/rdruss-jboss-migration-windup-v3/task/854)
- add "panel-body" div so that Analysis and Applications page have the titles aligned
- add "header-bar" to have the search box with scss file for related styles ("Run analysis" button added commented because it has to be added soon)
- filtering function works on id and status
- added span otherwise &nbsp; dis-aligned the trash icon in case of Cancelled analysis