### PR TITLE
Task 844: Deleting a project is not possible while an execution is in progress

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/messaging/StatusUpdateMDB.java
+++ b/services/src/main/java/org/jboss/windup/web/services/messaging/StatusUpdateMDB.java
@@ -82,7 +82,16 @@ public class StatusUpdateMDB extends AbstractMDB implements MessageListener
             WindupExecution fromDB = entityManager.find(WindupExecution.class, execution.getId());
 
             if (fromDB == null)
+            {
                 LOG.warning("Received unrecognized status update for execution: " + fromDB);
+                return;
+            }
+
+            if (fromDB.getState() == ExecutionState.CANCELLED)
+            {
+                LOG.warning("Not continuing to update state for cancelled status...");
+                return;
+            }
 
             fromDB.setLastModified(new GregorianCalendar());
             if (fromDB.getState() == ExecutionState.QUEUED)
@@ -110,6 +119,7 @@ public class StatusUpdateMDB extends AbstractMDB implements MessageListener
                 setReportIndexPath(fromDB);
                 setApplicationFilters(fromDB);
             }
+
         }
         catch (Throwable e)
         {

--- a/services/src/main/java/org/jboss/windup/web/services/service/MigrationProjectService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/MigrationProjectService.java
@@ -1,5 +1,8 @@
 package org.jboss.windup.web.services.service;
 
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -11,7 +14,6 @@ import org.jboss.windup.web.addons.websupport.WebPathUtil;
 import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
 import org.jboss.windup.web.services.model.AnalysisContext;
 import org.jboss.windup.web.services.model.MigrationProject;
-import org.jboss.windup.web.services.model.RegisteredApplication;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,7 +22,6 @@ import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.logging.Level;
@@ -29,6 +30,7 @@ import java.util.logging.Logger;
 /**
  * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
  */
+@Stateless
 public class MigrationProjectService
 {
     private static Logger LOG = Logger.getLogger(MigrationProjectService.class.getSimpleName());
@@ -96,9 +98,12 @@ public class MigrationProjectService
         return project;
     }
 
-    @Transactional
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public void deleteProject(MigrationProject project)
     {
+        // Reload to insure we have the latest version
+        project = this.entityManager.find(MigrationProject.class, project.getId());
+
         /* TODO: This is workaround to remove report filters
            For some reason filter didn't get removed even though
            both WindupExecution and ReportFilter have cascade REMOVE set....

--- a/services/src/main/java/org/jboss/windup/web/services/service/WindupExecutionService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/WindupExecutionService.java
@@ -1,28 +1,152 @@
 package org.jboss.windup.web.services.service;
 
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.jms.JMSContext;
+import javax.jms.Queue;
+import javax.jms.Topic;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.ws.rs.NotFoundException;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.windup.web.addons.websupport.WebPathUtil;
+import org.jboss.windup.web.furnaceserviceprovider.FromFurnace;
+import org.jboss.windup.web.services.messaging.ExecutionStateCache;
+import org.jboss.windup.web.services.messaging.MessagingConstants;
+import org.jboss.windup.web.services.model.AnalysisContext;
+import org.jboss.windup.web.services.model.ExecutionState;
+import org.jboss.windup.web.services.model.MigrationProject;
+import org.jboss.windup.web.services.model.RegisteredApplication;
 import org.jboss.windup.web.services.model.WindupExecution;
+import org.jboss.windup.web.services.rest.WindupEndpointImpl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.GregorianCalendar;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
  */
 public class WindupExecutionService
 {
+    private static Logger LOG = Logger.getLogger(WindupEndpointImpl.class.getSimpleName());
+
     @PersistenceContext
     private EntityManager entityManager;
 
+    @Inject
+    @FromFurnace
+    private WebPathUtil webPathUtil;
+
+    @Inject
+    private ConfigurationService configurationService;
+
+    @Inject
+    private AnalysisContextService analysisContextService;
+
+    @Inject
+    private MigrationProjectService migrationProjectService;
+
+    @Inject
+    private JMSContext messaging;
+
+    @Resource(lookup = "java:/queues/" + MessagingConstants.EXECUTOR_QUEUE)
+    private Queue executorQueue;
+
+    @Resource(lookup = "java:/queues/" + MessagingConstants.STATUS_UPDATE_QUEUE)
+    private Queue statusUpdateQueue;
+
+    @Resource(lookup = "java:/topics/" + MessagingConstants.CANCELLATION_TOPIC)
+    private Topic cancellationTopic;
+
+
+    /**
+     * Gets an execution by ID, or throws NotFoundException if it does not exist.
+     *
+     * @param id
+     * @return
+     */
     public WindupExecution get(Long id)
     {
         WindupExecution execution = this.entityManager.find(WindupExecution.class, id);
 
         if (execution == null)
         {
-            throw new NotFoundException("Execution with id " + id + " does not exist");
+            throw new NotFoundException("Analysis with id " + id + " not found");
         }
 
         return execution;
+    }
+
+    public WindupExecution executeProjectWithContext(AnalysisContext originalContext, Long projectId)
+    {
+        // make clone of analysis context and use it for execution
+        AnalysisContext analysisContext = originalContext.clone();
+
+        MigrationProject project = this.migrationProjectService.getMigrationProject(projectId);
+        project.setLastModified(new GregorianCalendar());
+        analysisContext.setMigrationProject(project); // ensure project is correctly set
+
+        analysisContext = this.analysisContextService.create(analysisContext);
+
+        for (RegisteredApplication application : analysisContext.getApplications())
+        {
+            application.setReportIndexPath(null);
+        }
+
+        WindupExecution execution = new WindupExecution(analysisContext);
+        execution.setTimeStarted(new GregorianCalendar());
+        execution.setState(ExecutionState.QUEUED);
+
+        entityManager.persist(execution);
+
+        Path reportOutputPath = this.webPathUtil.createWindupReportOutputPath(
+                execution.getProject().getId().toString(),
+                execution.getId().toString());
+
+        execution.setOutputPath(reportOutputPath.toString());
+        entityManager.merge(execution);
+
+        messaging.createProducer().send(executorQueue, execution);
+
+        return execution;
+    }
+
+    public void cancelExecution(Long executionID)
+    {
+        WindupExecution execution = this.get(executionID);
+        ExecutionStateCache.setCancelled(execution);
+
+        execution.setState(ExecutionState.CANCELLED);
+
+        messaging.createProducer().send(statusUpdateQueue, execution);
+        messaging.createProducer().send(cancellationTopic, execution);
+    }
+
+    public void deleteExecution(Long executionID)
+    {
+        WindupExecution execution = this.get(executionID);
+        if (StringUtils.isBlank(execution.getOutputPath()))
+            return;
+
+        File executionDir = new File(execution.getOutputPath());
+        if (executionDir.exists())
+        {
+            LOG.info("Removing report from: " + executionDir);
+            try
+            {
+                FileUtils.deleteDirectory(executionDir);
+            }
+            catch (IOException e)
+            {
+                LOG.log(Level.WARNING, "Unable to execution contents at " + executionDir.getAbsolutePath() + " (cause: " + e.getMessage() + ")", e);
+            }
+        }
+        this.entityManager.remove(execution);
     }
 }

--- a/ui/src/main/webapp/src/app/core/events/windup-event.ts
+++ b/ui/src/main/webapp/src/app/core/events/windup-event.ts
@@ -45,6 +45,10 @@ export class UpdateMigrationProjectEvent extends MigrationProjectEvent {
 
 }
 
+export class DeleteMigrationProjectEvent extends MigrationProjectEvent {
+
+}
+
 export class ExecutionEvent extends MigrationProjectEvent {
     public static TYPE = 'ExecutionEvent';
     private _execution: WindupExecution;

--- a/ui/src/main/webapp/src/app/project/migration-project.service.ts
+++ b/ui/src/main/webapp/src/app/project/migration-project.service.ts
@@ -8,7 +8,7 @@ import {Observable} from "rxjs";
 import {isNumber} from "util";
 import {
     MigrationProjectEvent, NewExecutionStartedEvent, ExecutionUpdatedEvent,
-    ApplicationRegisteredEvent, ApplicationDeletedEvent, UpdateMigrationProjectEvent
+    ApplicationRegisteredEvent, ApplicationDeletedEvent, UpdateMigrationProjectEvent, DeleteMigrationProjectEvent
 } from "../core/events/windup-event";
 import {EventBusService} from "../core/events/event-bus.service";
 import {AnalysisContext} from "windup-services";
@@ -100,6 +100,7 @@ export class MigrationProjectService extends AbstractService {
 
         return this._http.delete(Constants.REST_BASE + this.DELETE_MIGRATION_PROJECT_URL, options)
             .map(res => res.json())
+            .do(res => this._eventBus.fireEvent(new DeleteMigrationProjectEvent(migrationProject, this)))
             .catch(this.handleError);
     }
 

--- a/ui/src/main/webapp/src/app/shared/abtract.service.ts
+++ b/ui/src/main/webapp/src/app/shared/abtract.service.ts
@@ -21,7 +21,7 @@ export class AbstractService {
     protected handleError(error: Response) {
         // in a real world app, we may send the error to some remote logging infrastructure
         // instead of just logging it to the console
-        console.error("Service error: (" + typeof error + ") " + error);
+        console.error("Service error: (" + typeof error + ") ", error);
         let json;
 
         try {

--- a/ui/src/main/webapp/tests/app/services/windup-execution.service.spec.ts
+++ b/ui/src/main/webapp/tests/app/services/windup-execution.service.spec.ts
@@ -54,6 +54,26 @@ describe("WindupExecution service", () => {
         eventBusMock = jasmine.createSpyObj('EventBusService', [
             'fireEvent'
         ]);
+
+        Object.defineProperty(eventBusMock, 'onEvent', {
+            value: {
+                filter: () => {
+                    return {
+                        filter: () => {
+                            return {
+                                subscribe: () => {}
+                            }
+                        },
+                        subscribe: () => {}
+                    }
+                }
+            }
+        });
+
+        console.log("1Mock: ", eventBusMock);
+        console.log("2Mock onEvent: " + eventBusMock.onEvent);
+        console.log("3Mock onEvent: " + eventBusMock.onEvent.subscribe);
+
         schedulerMock = new SchedulerServiceMock();
         windupExecutionService = new WindupExecutionService(windupServiceMock, eventBusMock, schedulerMock);
     });


### PR DESCRIPTION
…es crashes

This does a few things:
 - Send a cancellation event for any related active executions just before deleting the project
 - Mark the job as cancelled in the current server instance so that status updates no longer happen
 - Treats status updates that come in for non-existent executions as a minor warning instead of a stacktrace
 - Stops the client from monitoring related executions after a project is deleted