### PR TITLE
T836 Icon enhancement for Cancel/Failed analysis

### DIFF
--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -51,7 +51,7 @@
         <td>{{execution.timeStarted | date: 'short'}}</td>
         <td>
             <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
-                <i class="fa fa-ban fa-fw"></i>
+                <i class="fa fa-times fa-fw"></i>
             </a>
             <!-- left for when dynamic report will be linked again
             <a

--- a/ui/src/main/webapp/src/app/shared/status-icon.component.ts
+++ b/ui/src/main/webapp/src/app/shared/status-icon.component.ts
@@ -26,7 +26,7 @@ export class StatusIconComponent {
             case 'COMPLETED':
                 return 'fa fa-check text-success';
             case 'FAILED':
-                return 'fa fa-times text-danger';
+                return 'fa fa-ban text-danger';
             case 'CANCELLED':
                 return 'fa fa-ban text-muted';
         }


### PR DESCRIPTION
Further enhancement requested by @Maarc:
"please use fa-times for the "cancel" action and replace the used fa-times icon for the "failed" symbol by "fa-ban" (like for CANCELLED)"

This PR completes #354 