### PR TITLE
WINDUP-1360

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/model/RuleProviderEntity.java
+++ b/services/src/main/java/org/jboss/windup/web/services/model/RuleProviderEntity.java
@@ -42,18 +42,22 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 @NamedQueries({
     @NamedQuery(name = RuleProviderEntity.FIND_ALL, query = "select rpe from RuleProviderEntity rpe"),
     @NamedQuery(name = RuleProviderEntity.DELETE_ALL, query = "delete from RuleProviderEntity"),
-    @NamedQuery(
-            name = RuleProviderEntity.DELETE_BY_RULES_PATH,
+    @NamedQuery(name = RuleProviderEntity.SELECT_BY_RULES_PATH,
+            query = "FROM RuleProviderEntity rpe WHERE rpe.rulesPath = :" + RuleProviderEntity.RULES_PATH_PARAM),
+    @NamedQuery(name = RuleProviderEntity.DELETE_BY_RULES_PATH,
             query = "delete from RuleProviderEntity rpe where rpe.rulesPath = :" + RuleProviderEntity.RULES_PATH_PARAM),
-    @NamedQuery(
-            name = RuleProviderEntity.DELETE_WITH_NULL_RULES_PATH,
+    @NamedQuery(name = RuleProviderEntity.SELECT_WITH_NULL_RULES_PATH,
+            query = "FROM RuleProviderEntity rpe WHERE rpe.rulesPath IS NULL"),
+    @NamedQuery(name = RuleProviderEntity.DELETE_WITH_NULL_RULES_PATH,
             query = "delete from RuleProviderEntity rpe where rpe.rulesPath is null")
 })
 public class RuleProviderEntity implements Serializable
 {
     public static final String FIND_ALL = "RuleProviderEntity.findAll";
     public static final String DELETE_ALL = "RuleProviderEntity.deleteAll";
+    public static final String SELECT_BY_RULES_PATH = "RuleProviderEntity.selectByRulesPath";
     public static final String DELETE_BY_RULES_PATH = "RuleProviderEntity.deleteByRulesPath";
+    public static final String SELECT_WITH_NULL_RULES_PATH = "RuleProviderEntity.selectNullPath";
     public static final String DELETE_WITH_NULL_RULES_PATH = "RuleProviderEntity.deleteNullPath";
     public static final String RULES_PATH_PARAM = "rulesPath";
 
@@ -107,6 +111,7 @@ public class RuleProviderEntity implements Serializable
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @OrderColumn(name = RuleEntity.RULE_SEQUENCE)
     private List<RuleEntity> rules;
+
 
     @ManyToOne(fetch = FetchType.EAGER)
     private RulesPath rulesPath;

--- a/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/WindupEndpointImpl.java
@@ -30,6 +30,7 @@ public class WindupEndpointImpl implements WindupEndpoint
 
     private static int MAX_LOG_SIZE = 1024 * 1024 * 3; // 3 Megabytes
     private static String cachedCoreVersion = null;
+
     @PersistenceContext
     private EntityManager entityManager;
     @Inject
@@ -37,6 +38,7 @@ public class WindupEndpointImpl implements WindupEndpoint
     @Inject
     @FromFurnace
     private LogService logService;
+
 
     /**
      * @see org.jboss.windup.web.services.messaging.ExecutorMDB


### PR DESCRIPTION
The Cascade.ALL doesn't apply to bulk DELETE's.
So this changes loadRules() to use em.remove().

## SQL to sanitize your current h2db file:
(fresh installation recommended instead though)

DELETE FROM RULEENTITY WHERE RULE_ENTITY_ID < 200000;
DELETE FROM RULEENTITY WHERE RULE_ENTITY_ID BETWEEN 200000 AND 300000;
DELETE FROM RULEENTITY WHERE RULE_ENTITY_ID BETWEEN 300000 AND 400000;
... until you hit the FK constraint. Might not delete all that are stale as they are FK-referenced from the join table.
And then:
SHUTDOWN COMPACT;
