### PR TITLE
Fix compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
         <version.forge>3.6.0.Final</version.forge>
         <version.furnace>2.25.4.Final</version.furnace>
-        <version.windup>3.1.0-SNAPSHOT</version.windup>
+        <version.windup>4.0.0-SNAPSHOT</version.windup>
         <version.keycloak>2.1.0.Final</version.keycloak>
         <version.resteasy>3.0.19.Final</version.resteasy>
         <version.jboss.javaee>1.0.3.Final</version.jboss.javaee>

--- a/tsmodelsgen-invocation/pom.xml
+++ b/tsmodelsgen-invocation/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <version.windup.core>3.1.0-SNAPSHOT</version.windup.core>
+        <version.windup.core>4.0.0-SNAPSHOT</version.windup.core>
         <!-- For now, we need to pass this to the Mojo explicitly (through META-INF/versions.properties),
              but it should be possible to figure that out from the Windup POM. -->
         <version.forge>3.6.0.Final</version.forge>

--- a/tsmodelsgen-maven-plugin/pom.xml
+++ b/tsmodelsgen-maven-plugin/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <version.windup.core>3.1.0-SNAPSHOT</version.windup.core>
+        <version.windup.core>4.0.0-SNAPSHOT</version.windup.core>
         <version.windup.web>3.0.0-SNAPSHOT</version.windup.web>
         <!-- For now, we need to pass this to the Mojo explicitly (through META-INF/versions.properties),
              but it should be possible to figure that out from the Windup POM. -->

--- a/tsmodelsgen-maven-plugin/src/it/sample-project/pom.xml
+++ b/tsmodelsgen-maven-plugin/src/it/sample-project/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.windup.core>3.1.0-SNAPSHOT</version.windup.core>
+        <version.windup.core>4.0.0-SNAPSHOT</version.windup.core>
         <version.windup.web>3.0.0-SNAPSHOT</version.windup.web>
 
         <version.forge>3.6.0.Final</version.forge>


### PR DESCRIPTION
It seems PR #364 broke compilation.
~~~`RuleLoaderContext` is missing method `setFileBasedRulesOnly`.~~~

Update: 
It was caused by me having older version of windup-distribution. But meanwhile, @mareknovotny  updated artifact id to `4.0.0-SNAPSHOT` on windup and windup-distribution. So when I pulled latest version, it was already version 4 and because windup-web still depends on 3.1 I could not compile it.

I will remove it from my local cache and download latest 3.1.0 from maven central for now.

We can merge this PR whenever we decide to use version 4 in windup-web.
