### PR TITLE
T887 Disable cancel icon when analysis is running

### DIFF
--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -49,7 +49,7 @@
         </td>
         <td>{{execution.timeStarted | date: 'short'}}</td>
         <td>
-            <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
+            <a class="pointer link cancel" [ngClass]="{'disabled': (execution.state == 'STARTED')}" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="{{execution.state == 'STARTED' ? (execution.state | wuPrettyExecutionStatus) + ' analysis can not be canceled' : 'Cancel'}}">
                 <i class="fa fa-times fa-fw"></i>
             </a>
             <!-- left for when dynamic report will be linked again

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.scss
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.scss
@@ -19,3 +19,8 @@
     margin-right: 10px;
   }
 }
+
+.disabled {
+  color: lightgrey;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
Maybe it's no the best solution but it's temporary:

- if the analysis is running it adds the 'disabled' class
- disabled class "greyed" the icon and change the cursor when you're over the icon (maybe not necessary to change the cursor but i add it if it can help the user)
- the anchor's title change to 'In Progress analysis can not be canceled'

I took some screenshot to make easier understand the final effect.
General overview with the first analysis queued and the second one running
![cancel_icon_overview](https://cloud.githubusercontent.com/assets/7288588/25541185/091c168e-2c4e-11e7-826e-e9fc89b1687a.png)
Title when you get over the "cancelable" analysis with the enabled icon:
![cancel_icon_enable](https://cloud.githubusercontent.com/assets/7288588/25541212/20e7fecc-2c4e-11e7-906b-be08c999aa70.png)
Title when you get over the "un-cancelable" analysis with the disabled icon (sorry, it's a little bit too cropped):
![cancel_icon_disable](https://cloud.githubusercontent.com/assets/7288588/25541227/338f0bb0-2c4e-11e7-9c62-7ad745c893b6.png)
