### PR TITLE
T889 Add number of analyzed applications to the analysis list

### DIFF
--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -44,7 +44,7 @@
                     <dd>{{ execution.timeCompleted - execution.timeStarted | wuDuration }}</dd>
                 </ng-container>
                 <ng-container *ngIf="!execution.timeCompleted">
-                    <dt i18n="Analysis last modification">Duration:</dt>
+                    <dt i18n="Analysis last modification">Last Modification:</dt>
                     <dd>{{execution.lastModified | date: 'short'}}</dd>
                 </ng-container>
             </dl>
@@ -74,9 +74,9 @@
                 </wu-analysis-context-advanced-options>
             </wu-expand-collapse>
         </wu-tab>
-        <wu-tab [tabTitle]="'Applications (' + execution.filterApplications.length + ')'">
+        <wu-tab [tabTitle]="'Applications (' + getAnalyzedApplications(execution).length + ')'">
             <h3 i18n="Analysis configuration|Section">Applications</h3>
-            <span *ngFor="let application of execution.filterApplications">{{application.fileName}}<br/></span>
+            <span *ngFor="let application of getAnalyzedApplications(execution)">{{application.title}}<br/></span>
         </wu-tab>
         <wu-tab [tabTitle]="'Rules'">
             <span *ngIf="phases == null">

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
@@ -38,7 +38,6 @@ export class ExecutionDetailComponent implements OnInit {
                 .subscribe((event: ExecutionEvent) => {
                     this.execution = event.execution;
                     this.loadLogData();
-                    console.log("qui");
                 });
 
             this._windupService.getExecution(executionId).subscribe(execution => {

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
@@ -11,6 +11,7 @@ import {Observable} from "rxjs";
 import {RuleProviderExecutionsService} from "../reports/rule-provider-executions/rule-provider-executions.service";
 import {RuleExecutionModel} from "../generated/tsModels/RuleExecutionModel";
 import {ExecutionPhaseModel} from "../generated/tsModels/ExecutionPhaseModel";
+import {RegisteredApplication} from "windup-services";
 
 @Component({
     templateUrl: './execution-detail.component.html',
@@ -65,5 +66,9 @@ export class ExecutionDetailComponent implements OnInit {
 
     private loadLogData() {
         this._windupService.getLogData(this.execution.id).subscribe(logLines => this.logLines = logLines);
+    }
+
+    getAnalyzedApplications(execution : WindupExecution) : RegisteredApplication[] {
+        return execution.analysisContext.applications.filter(application => !application.deleted);
     }
 }

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -49,7 +49,7 @@
             </span>
         </td>
         <td>{{execution.timeStarted | date: 'short'}}</td>
-        <td>{{getNumberAnalyzedApplications(execution)}}</td>
+        <td class="pad-number-application">{{getNumberAnalyzedApplications(execution)}}</td>
         <td>
             <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
                 <i class="fa fa-times fa-fw"></i>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -20,7 +20,7 @@
             { title: 'Analysis', isSortable: true, sortBy: 'id' },
             { title: 'Status', isSortable: true, sortBy: 'state' },
             { title: 'Start Date', isSortable: true, sortBy: 'timeStarted' },
-            { title: 'Analyzed Applications', isSortable: true, sortBy: 'getNumberAnalyzedApplications(this);' },
+            { title: 'Analyzed Applications', isSortable: true, sortBy: sortByNumberAnalyzedApplicationsCallback },
             { title: 'Actions', isSortable: false }
         ]">
     </thead>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -20,6 +20,7 @@
             { title: 'Analysis', isSortable: true, sortBy: 'id' },
             { title: 'Status', isSortable: true, sortBy: 'state' },
             { title: 'Start Date', isSortable: true, sortBy: 'timeStarted' },
+            { title: 'Analyzed Applications', isSortable: true, sortBy: 'getNumberAnalyzedApplications(this);' },
             { title: 'Actions', isSortable: false }
         ]">
     </thead>
@@ -48,6 +49,7 @@
             </span>
         </td>
         <td>{{execution.timeStarted | date: 'short'}}</td>
+        <td>{{getNumberAnalyzedApplications(execution)}}</td>
         <td>
             <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
                 <i class="fa fa-times fa-fw"></i>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.scss
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.scss
@@ -19,3 +19,7 @@
     margin-right: 10px;
   }
 }
+
+.pad-number-application {
+  padding-left: 130px;
+}

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.ts
@@ -188,4 +188,8 @@ export class ExecutionsListComponent implements OnInit, OnDestroy {
     getNumberAnalyzedApplications(execution : WindupExecution) : number {
         return execution.analysisContext.applications.filter(application => !application.deleted).length;
     }
+
+    sortByNumberAnalyzedApplicationsCallback = (item: WindupExecution) => {
+        return this.getNumberAnalyzedApplications(item);
+    };
 }

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.ts
@@ -184,4 +184,8 @@ export class ExecutionsListComponent implements OnInit, OnDestroy {
     startExecution() {
         this.runExecution.emit();
     }
+
+    getNumberAnalyzedApplications(execution : WindupExecution) : number {
+        return execution.analysisContext.applications.filter(application => !application.deleted).length;
+    }
 }

--- a/ui/src/main/webapp/tests/app/components/executions/executions-data.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-data.ts
@@ -12,7 +12,33 @@ export const EXECUTIONS_DATA: Partial<WindupExecution>[] = [
         "currentTask": null,
         "lastModified": 1477907647318,
         "state": "COMPLETED",
-        "analysisContext": null,
+        "analysisContext":
+            {
+                "id": 11,
+                "version": 0,
+                "generateStaticReports": true,
+                "cloudTargetsIncluded": true,
+                "migrationPath": null,
+                "advancedOptions": null,
+                "rulesPaths": null,
+                "includePackages": null,
+                "excludePackages": null,
+                "applications": [
+                    {
+                        "id": 3,
+                        "version": 0,
+                        "registrationType": "UPLOADED",
+                        "title": "jee-example-app-1.0.0.ear",
+                        "inputPath": null,
+                        "reportIndexPath": null,
+                        "created": null,
+                        "lastModified": null,
+                        "deleted": false,
+                        "inputFilename": null
+                    }
+                ]
+            }
+        ,
         "filterApplications": null,
         "outputDirectoryName": "Default Group.ANnIuZsNxbfq.report",
         "applicationListRelativePath": "Default Group.ANnIuZsNxbfq.report/index.html",
@@ -29,7 +55,33 @@ export const EXECUTIONS_DATA: Partial<WindupExecution>[] = [
         "currentTask": null,
         "lastModified": 1477907948484,
         "state": "FAILED",
-        "analysisContext": null,
+        "analysisContext":
+            {
+                "id": 11,
+                "version": 0,
+                "generateStaticReports": true,
+                "cloudTargetsIncluded": true,
+                "migrationPath": null,
+                "advancedOptions": null,
+                "rulesPaths": null,
+                "includePackages": null,
+                "excludePackages": null,
+                "applications": [
+                    {
+                        "id": 3,
+                        "version": 0,
+                        "registrationType": "UPLOADED",
+                        "title": "jee-example-app-1.0.0.ear",
+                        "inputPath": null,
+                        "reportIndexPath": null,
+                        "created": null,
+                        "lastModified": null,
+                        "deleted": false,
+                        "inputFilename": null
+                    }
+                ]
+            }
+        ,
         "filterApplications": null,
         "outputDirectoryName": "Default Group.ANnIuZsNxbfq.report",
         "applicationListRelativePath": "Default Group.ANnIuZsNxbfq.report/index.html",
@@ -46,7 +98,33 @@ export const EXECUTIONS_DATA: Partial<WindupExecution>[] = [
         "currentTask": "PostFinalizePhase - RenderRuleProviderReportRuleProvider - RenderRuleProviderReportRuleProvider_1",
         "lastModified": 1478000316581,
         "state": "STARTED",
-        "analysisContext": null,
+        "analysisContext":
+            {
+                "id": 11,
+                "version": 0,
+                "generateStaticReports": true,
+                "cloudTargetsIncluded": true,
+                "migrationPath": null,
+                "advancedOptions": null,
+                "rulesPaths": null,
+                "includePackages": null,
+                "excludePackages": null,
+                "applications": [
+                    {
+                        "id": 3,
+                        "version": 0,
+                        "registrationType": "UPLOADED",
+                        "title": "jee-example-app-1.0.0.ear",
+                        "inputPath": null,
+                        "reportIndexPath": null,
+                        "created": null,
+                        "lastModified": null,
+                        "deleted": false,
+                        "inputFilename": null
+                    }
+                ]
+            }
+        ,
         "filterApplications": null,
         "outputDirectoryName": "Default Group.ANnIuZsNxbfq.report",
         "applicationListRelativePath": "Default Group.ANnIuZsNxbfq.report/index.html",
@@ -63,7 +141,33 @@ export const EXECUTIONS_DATA: Partial<WindupExecution>[] = [
         "currentTask": null,
         "lastModified": 1478000242721,
         "state": "QUEUED",
-        "analysisContext": null,
+        "analysisContext":
+            {
+                "id": 11,
+                "version": 0,
+                "generateStaticReports": true,
+                "cloudTargetsIncluded": true,
+                "migrationPath": null,
+                "advancedOptions": null,
+                "rulesPaths": null,
+                "includePackages": null,
+                "excludePackages": null,
+                "applications": [
+                    {
+                        "id": 3,
+                        "version": 0,
+                        "registrationType": "UPLOADED",
+                        "title": "jee-example-app-1.0.0.ear",
+                        "inputPath": null,
+                        "reportIndexPath": null,
+                        "created": null,
+                        "lastModified": null,
+                        "deleted": false,
+                        "inputFilename": null
+                    }
+                ]
+            }
+        ,
         "filterApplications": null,
         "outputDirectoryName": "Default Group.ANnIuZsNxbfq.report",
         "applicationListRelativePath": "Default Group.ANnIuZsNxbfq.report/index.html",
@@ -80,7 +184,33 @@ export const EXECUTIONS_DATA: Partial<WindupExecution>[] = [
         "currentTask": null,
         "lastModified": 1478000242721,
         "state": "CANCELLED",
-        "analysisContext": null,
+        "analysisContext":
+            {
+                "id": 11,
+                "version": 0,
+                "generateStaticReports": true,
+                "cloudTargetsIncluded": true,
+                "migrationPath": null,
+                "advancedOptions": null,
+                "rulesPaths": null,
+                "includePackages": null,
+                "excludePackages": null,
+                "applications": [
+                    {
+                        "id": 3,
+                        "version": 0,
+                        "registrationType": "UPLOADED",
+                        "title": "jee-example-app-1.0.0.ear",
+                        "inputPath": null,
+                        "reportIndexPath": null,
+                        "created": null,
+                        "lastModified": null,
+                        "deleted": false,
+                        "inputFilename": null
+                    }
+                ]
+            }
+        ,
         "filterApplications": null,
         "outputDirectoryName": "Default Group.ANnIuZsNxbfq.report",
         "applicationListRelativePath": "Default Group.ANnIuZsNxbfq.report/index.html",

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -34,9 +34,10 @@ let SORTED_EXECUTIONS_DATA = EXECUTIONS_DATA.slice().sort((a, b) => <any>b.timeS
 const COL_ID = 0;
 const COL_STATE = 1;
 const COL_DATE_STARTED = 2;
-const COL_ACTIONS = 3;
+const COL_APPLICATION_ANALYZED = 3;
+const COL_ACTIONS = 4;
 
-const COUNT_COLUMNS = 4;
+const COUNT_COLUMNS = 5;
 
 let mockProjects = [
     { id: 1, title: 'Dummy project' }
@@ -152,9 +153,10 @@ describe('ExecutionsListComponent', () => {
             let state = el.children[COL_STATE];
             let stateText = state.textContent ? state.textContent.trim() : "";
 
-            if (stateText == "Completed") {
-                expect(el.children[COL_ACTIONS].children.length).toBe(1);
-                expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('Static Report');
+            if (stateText.startsWith("Completed")) {
+                expect(el.children[COL_ACTIONS].children.length).toBe(2);
+                expect(el.children[COL_ACTIONS].children[0].children[0].title).toEqual('Show static reports');
+                expect(el.children[COL_ACTIONS].children[1].title).toEqual('Delete');
             } else {
                 expect(el.children[COL_ACTIONS].children.length).toBe(1);
                 expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('');


### PR DESCRIPTION
- Analysis list page:
    - created `getNumberAnalyzedApplications`, a dedicated method to calculate the number of analyzed applications
    - add column w/ the number of analyzed applications
- Analysis details page:
    - created `getAnalyzedApplications` to retrieve the analyzed applications because when an analysis is running the number of applications is 0
    - rewording "Duration:" label in "Last Modification:" for running analysis
- Tests:
     - created `analysisContext` data object for testing new column in analysis list page
     - updated test that first was not working

@klinki still needs to be fixed the sorting in the 'Analyzed Applications' column because it's based not on an available field but on the value calculated from `getNumberAnalyzedApplications` method

BTW, maybe `getNumberAnalyzedApplications` and `getAnalyzedApplications` can be placed in a "common" library?