### PR TITLE
T908 Added cloud readiness analysis information to analysis details page

### DIFF
--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -52,7 +52,12 @@
             <h3 i18n="Analysis configuration|Section">Configuration</h3>
             <dl>
                 <dt i18n="Migration Path">Transformation path:</dt>
-                <dd>{{execution.analysisContext?.migrationPath?.name}}</dd>
+                <dd>
+                    {{execution.analysisContext?.migrationPath?.name}}
+                    <span *ngIf="execution.analysisContext?.cloudTargetsIncluded">
+                        (with cloud readiness analysis)
+                    </span>
+                </dd>
             </dl>
 
             <wu-expand-collapse [tabTitle]="'Included Packages'" *ngIf="execution.analysisContext.includePackages.length > 0">


### PR DESCRIPTION
Now in "Details" tab of analysis details page, if the analysis had the flag to also run the cloud readiness analysis, you'll see:
 `Transformation path:    Migration to Red Hat JBoss EAP 7 (with cloud readiness analysis) `