### PR TITLE
T834 Configuration Page: Advanced Panels should automatically open if used

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
@@ -88,7 +88,7 @@
             <p class="help-block">Select the Java packages that will be decompiled and analyzed. If no package is selected, all classes will be considered.</p>
         </div>
 
-        <wu-expand-collapse [tabTitle]="'Exclude some packages'">
+        <wu-expand-collapse [tabTitle]="'Exclude some packages'" [isActive]="analysisContext.excludePackages?.length > 0">
             <div class="form-group">
                 <div>
                     <label class="control-label" i18n>Excluded packages</label>
@@ -103,7 +103,7 @@
         </wu-expand-collapse>
 
         <!-- Rulesets selection -->
-        <wu-expand-collapse [tabTitle]="'Use local custom rules'">
+        <wu-expand-collapse [tabTitle]="'Use local custom rules'" [isActive]="isActiveRulesPaths()">
             <div class="form-group">
                 <label class="control-label" i18n>Custom rulesets</label>
                 <wu-custom-rule-selection
@@ -114,7 +114,7 @@
         </wu-expand-collapse>
 
         <!-- Advanced options -->
-        <wu-expand-collapse [tabTitle]="'Advanced options'">
+        <wu-expand-collapse [tabTitle]="'Advanced options'" [isActive]="analysisContext.advancedOptions?.length > 0">
             <div class="form-group">
                 <label *ngIf="!hideUnfinishedFeatures" for="createStaticReports" i18n>
                     <input id="createStaticReports" name="generateStaticReports" type="checkbox"

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -336,6 +336,10 @@ export class AnalysisContextFormComponent extends FormComponent
     rulesPathsChanged(rulesPaths: RulesPath[]) {
         this.analysisContext.rulesPaths = rulesPaths;
     }
+
+    isActiveRulesPaths():boolean {
+        return this.analysisContext.rulesPaths.filter(rulesPath => rulesPath.rulesPathType == 'USER_PROVIDED').length > 0;
+    }
 }
 
 enum Action {


### PR DESCRIPTION
If someone removes all the options from an advanced panel (i.e. deselect all the excluded packages) the panel automatically closes: this was not a requirement but it seems to be a good approach.