### PR TITLE
Task 912: Fix Update Project

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectEndpointImpl.java
@@ -101,6 +101,15 @@ public class MigrationProjectEndpointImpl implements MigrationProjectEndpoint
         if (otherProjectID != null && !otherProjectID.equals(migrationProject.getId()))
             throw new ValidationException("The project name is already in use: " + migrationProject.getTitle());
 
+        if (migrationProject.getDefaultAnalysisContext() == null)
+        {
+            MigrationProject fromDB = this.entityManager.find(MigrationProject.class, migrationProject.getId());
+            if (fromDB.getDefaultAnalysisContext() != null)
+            {
+                migrationProject.setDefaultAnalysisContext(fromDB.getDefaultAnalysisContext());
+            }
+        }
+
         return entityManager.merge(migrationProject);
     }
 


### PR DESCRIPTION
Previously, if the project were being updated, the default context would get destroyed.
With this change, we insure that we preserve it, even if the client does not send the data
(as it typically would not).