### PR TITLE
T929 Left nav bar: replace white line - T930 Left nav bar: remove bold black line

### DIFF
--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.scss
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.scss
@@ -2,10 +2,9 @@ $context-menu-background-color: #30363D;
 
 .nav-pf-vertical {
   background: $context-menu-background-color;
-  top: 122px;
+  top: 121px;
 }
 
 .nav-pf-vertical li {
   border-bottom: 1px solid #050505;
-  border-top: 1px solid rgba(255,255,255,0.04);
 }


### PR DESCRIPTION
I also removed the `border-top` because after digging into CSS details, it turn out that the first entry in the left bar, if active, generates a strange "double" black line on hover event (see next screenshot).
![screenshot from 2017-05-11 18-46-15](https://cloud.githubusercontent.com/assets/7288588/25961837/f55df454-367b-11e7-844e-6ec71deb20a3.png)

Without the `border-top` entry, it's better (see next screenshot).
![screenshot from 2017-05-11 18-46-20](https://cloud.githubusercontent.com/assets/7288588/25961865/0ab1e8a6-367c-11e7-8cc6-85cab86daebd.png)

