### PR TITLE
T935 Rules Configuration page: change texts

### DIFF
--- a/ui/src/main/webapp/css/windup-web.css
+++ b/ui/src/main/webapp/css/windup-web.css
@@ -164,6 +164,10 @@ fieldset.fields-section-pf {
     padding-top: inherit;
 }
 
+button.btn {
+    text-transform: capitalize;
+}
+
 @media (max-width: 767px) {
     .wu-horizontal-nav-content, .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical {
         margin-left: 0;

--- a/ui/src/main/webapp/src/app/configuration/add-rules-path-modal.component.html
+++ b/ui/src/main/webapp/src/app/configuration/add-rules-path-modal.component.html
@@ -14,7 +14,7 @@
                         {{errorMessage}}
                     </div>
                     <div class="form-group" [ngClass]="{'has-error': hasError(addRulesPathForm.get('inputPathControl'))}">
-                        <label class="control-label" for="addRulesPathInput">Rules Path (file or directory)</label>
+                        <label class="control-label" for="addRulesPathInput">Rules path (file or directory)</label>
                         <input
                                 [(ngModel)]="inputPath"
                                 formControlName="inputPathControl"
@@ -24,7 +24,7 @@
                                 placeholder="/opt/rules or /opt/rules/my-rules.windup.xml"
                         >
                         <div>
-                            Path to the file or folder containing the rule(s).
+                            Path to the file or directory containing the rules.
                         </div>
                         <span [class.hidden]="!hasError(addRulesPathForm.get('inputPathControl'))" class="help-block">
                             The path must exist on the server.

--- a/ui/src/main/webapp/src/app/configuration/add-rules-path-modal.component.html
+++ b/ui/src/main/webapp/src/app/configuration/add-rules-path-modal.component.html
@@ -14,7 +14,7 @@
                         {{errorMessage}}
                     </div>
                     <div class="form-group" [ngClass]="{'has-error': hasError(addRulesPathForm.get('inputPathControl'))}">
-                        <label class="control-label" for="addRulesPathInput">Rules path (file or directory)</label>
+                        <label class="control-label" for="addRulesPathInput">Rules path (server-side file or directory)</label>
                         <input
                                 [(ngModel)]="inputPath"
                                 formControlName="inputPathControl"
@@ -24,7 +24,7 @@
                                 placeholder="/opt/rules or /opt/rules/my-rules.windup.xml"
                         >
                         <div>
-                            Path to the file or directory containing the rules.
+                            Path to the server-side file or directory containing the rules.
                         </div>
                         <span [class.hidden]="!hasError(addRulesPathForm.get('inputPathControl'))" class="help-block">
                             The path must exist on the server.

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.html
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.html
@@ -49,7 +49,7 @@
                 </div>
 
                 <div *ngIf="areRulesLoaded(rulePath) && !hasFileBasedProviders(rulePath)">
-                    <h3 i18n>No rule found.</h3>
+                    <h3 i18n>No rules found.</h3>
                 </div>
 
                 <div *ngIf="rulePath.loadError">
@@ -106,7 +106,7 @@
 <wu-confirmation-modal
         #removeRulesConfirmationModal
         [id]="'deleteRulesConfirmationDialog'"
-        [title]="'Confirm rule removal'"
-        [body]="'Do you really want to remove the rules from ...?'"
+        [title]="'Confirm Rule Removal'"
+        [body]="'Are you sure you want to remove the rules from ...?'"
 >
 </wu-confirmation-modal>

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.ts
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.ts
@@ -170,7 +170,7 @@ export class ConfigurationComponent implements OnInit, AfterViewInit {
     }
 
     confirmRemoveRules(rulesPath: RulesPath) {
-        this.removeRulesConfirmationModal.body = `Do you really want to remove the rules from '${rulesPath.path}'?`;
+        this.removeRulesConfirmationModal.body = `Are you sure you want to remove the rules from '${rulesPath.path}'?`;
         this.removeRulesConfirmationModal.data = rulesPath;
         this.removeRulesConfirmationModal.show();
     }


### PR DESCRIPTION
Added `button.btn` class to `windup.css` to have all the buttons `capitalize`d

Rows 31-35

|Existing Text	|Suggested Text	|Notes|
|---------- | ---------- | ---------- |
|Show rules	|Show Rules	|Buttons are title case  - consistency|
|Rules Path (file or directory)	|Rules path (file or directory)	|Field labels are sentence case - consistency|
|Path to the file or folder containing the rule(s).	|Path to the file or directory containing the rules.	|* It is unnecessary to do "(s)". It is fine in field labels to assume there are multiple, even if there will only be one.<br/>* Use "directory" to be consistent with (file or directory)|
|No rule found.	|No rules found.	||
"Confirm rule removal<br/>Do you really want to remove the rules from '/home/ahoffer/.windup/'?"|	"Confirm Rule Removal<br/>Are you sure you want to remove the rules from '/home/ahoffer/.windup/'?"	|Trying to make consistent with other confirm popups|