### PR TITLE
T922 cleanup stale executions after server reboot

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/StartupCleanupOfStaleExecutions.java
+++ b/services/src/main/java/org/jboss/windup/web/services/StartupCleanupOfStaleExecutions.java
@@ -1,0 +1,27 @@
+package org.jboss.windup.web.services;
+
+import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.inject.Inject;
+import org.jboss.windup.web.services.service.WindupExecutionService;
+
+/**
+ * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
+ */
+@Singleton
+@Startup
+public class StartupCleanupOfStaleExecutions
+{
+    private static Logger LOG = Logger.getLogger(StartupCleanupOfStaleExecutions.class.getName());
+
+    @Inject
+    private WindupExecutionService execService;
+
+    @PostConstruct
+    public void cleanupStaleExecutions()
+    {
+        execService.cleanupStaleExecutions();
+    }
+}

--- a/services/src/main/java/org/jboss/windup/web/services/messaging/ExecutionCancellationMDB.java
+++ b/services/src/main/java/org/jboss/windup/web/services/messaging/ExecutionCancellationMDB.java
@@ -18,6 +18,9 @@ import org.jboss.windup.web.services.model.WindupExecution;
 /**
  * This receives requests to run Windup and executes them.
  *
+ * The WindupExecutor is given a WindupWebProgressMonitor instance when launched in WindupExecutionTask.
+ * That monitor is later called through WindupProgressMonitor interface in DefaultRuleLifecycleListener.
+ *
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
 @MessageDriven(activationConfig = {

--- a/services/src/main/java/org/jboss/windup/web/services/service/WindupExecutionService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/WindupExecutionService.java
@@ -27,8 +27,11 @@ import org.jboss.windup.web.services.rest.WindupEndpointImpl;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
+import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -154,5 +157,27 @@ public class WindupExecutionService
             }
         }
         this.entityManager.remove(execution);
+    }
+
+    public void cleanupStaleExecutions()
+    {
+        LOG.info("Cleaning up stale executions.");
+
+        long jvmStartTimeMs = ManagementFactory.getRuntimeMXBean().getStartTime();
+        Calendar serverBootTime = GregorianCalendar.getInstance();
+        serverBootTime.setTimeInMillis(jvmStartTimeMs);
+
+        final String query = String.format("FROM %s AS exec WHERE exec.timeStarted < :serverBoot AND exec.state = :state", WindupExecution.class.getSimpleName());
+        List<WindupExecution> staleExecutions = this.entityManager.createQuery(query)
+                .setParameter("serverBoot", serverBootTime)
+                .setParameter("state", ExecutionState.STARTED).getResultList();
+
+        for (WindupExecution staleExecution : staleExecutions)
+        {
+            LOG.info("    Changing status of stale execution to CANCELLED:\n    " + staleExecution);
+            staleExecution.setState(ExecutionState.CANCELLED);
+            entityManager.merge(staleExecution);
+        }
+        entityManager.flush();
     }
 }


### PR DESCRIPTION
At boot time, Changes the state of the unfinished executions started before this JVM started.

1) The task was deferred but I didn't reload taiga before I started
2) Doesn't work, it changes the wrong executions. I would need to look at how the state transitions look like.