### PR TITLE
T969 Analysis details: fix visual layout of queued analysis

### DIFF
--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -45,7 +45,7 @@
                 </ng-container>
                 <ng-container *ngIf="!execution.timeCompleted">
                     <dt i18n="Analysis last modification">Last modification</dt>
-                    <dd>{{execution.lastModified | date: 'short'}}</dd>
+                    <dd>{{execution.lastModified ? (execution.lastModified | date: 'short') : 'n/a'}}</dd>
                 </ng-container>
             </dl>
 


### PR DESCRIPTION
I inserted a "n/a" as `Last modification`'s value instead of removing `Last modification` field to keep the page's layout fixed (avoiding `Configuration` box to move down when `Last modification` is available).