### PR TITLE
T972 Create Project step: focus on name input

### DIFF
--- a/ui/src/main/webapp/src/app/project/migration-project-form.component.html
+++ b/ui/src/main/webapp/src/app/project/migration-project-form.component.html
@@ -25,7 +25,9 @@
                    [project]="model"
                    type="text"
                    placeholder="My Project"
-                   class="form-control">
+                   class="form-control"
+                   #idProjectTitle
+                   tabindex=1>
             <p class="help-block" i18n="hint">A unique name for the project</p>
             <span [class.hidden]="!titleIsDuplicated(projectTitleControl)" class="help-block" i18n="valid. error"> The entered name is already in use. </span>
             <span [class.hidden]="!hasError(projectTitleControl, 'pattern') || hasError(projectTitleControl, 'minlength') || hasError(projectTitleControl, 'maxlength')" class="help-block" i18n="valid. error pattern">
@@ -42,7 +44,7 @@
         <div class="form-group">
             <label class="control-label" for="idDescription">Description</label>
             <textarea name="description" id="idDescription" name="idDescription" class="form-control" maxlength="4095" i18n="placeholder" placeholder="A short description of the project." [rows]="getDescriptionHeight()"
-                #controlDescription="ngModel" [(ngModel)]="model.description"></textarea>
+                #controlDescription="ngModel" [(ngModel)]="model.description" tabindex=2 ></textarea>
             <span [class.hidden]="!hasError(controlDescription)" class="help-block">
                 The description must contain fewer than 4096 characters.
             </span>

--- a/ui/src/main/webapp/src/app/project/migration-project-form.component.ts
+++ b/ui/src/main/webapp/src/app/project/migration-project-form.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, OnDestroy} from "@angular/core";
+import {Component, OnInit, OnDestroy, AfterViewInit, ViewChildren} from "@angular/core";
 import {ActivatedRoute, Router, NavigationEnd} from "@angular/router";
 
 import {MigrationProject} from "../generated/windup-services";
@@ -16,7 +16,7 @@ import {FormControl} from "@angular/forms";
         }      
     `]
 })
-export class MigrationProjectFormComponent extends FormComponent implements OnInit, OnDestroy
+export class MigrationProjectFormComponent extends FormComponent implements OnInit, OnDestroy, AfterViewInit
 {
     title: string = "Create Project";
 
@@ -27,6 +27,8 @@ export class MigrationProjectFormComponent extends FormComponent implements OnIn
 
     errorMessages: string[];
     private routerSubscription: Subscription;
+
+    @ViewChildren('idProjectTitle') inputProjectName;
 
     constructor(
         private _router: Router,
@@ -63,6 +65,10 @@ export class MigrationProjectFormComponent extends FormComponent implements OnIn
 
     ngOnDestroy(): void {
         this.routerSubscription.unsubscribe();
+    }
+
+    ngAfterViewInit(): void {
+        this.inputProjectName.first.nativeElement.focus();
     }
 
     getDescriptionHeight() {


### PR DESCRIPTION
`Create Project`, the first step of new project wizard, now has the focus on project's name input field just after the page has loaded.
More when, from project's name input field, you press `TAB` key you move to next text area for writing project's description in order to get quicker into filling values like the task requests.