### PR TITLE
T967 {In,Ex}cluded package checkboxes list into scrollable container

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
@@ -89,8 +89,10 @@
                     <ng-container i18n>Identifying packages...</ng-container>
                 </p>
             </div>
-            <wu-js-tree-wrapper [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.includePackages">
-            </wu-js-tree-wrapper>
+            <div class="fixed-height">
+                <wu-js-tree-wrapper [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.includePackages">
+                </wu-js-tree-wrapper>
+            </div>
             <p class="help-block" i18n="include packages description">Select the Java packages to decompile and analyze. If no packages are selected, all will be analyzed.</p>
         </div>
 
@@ -104,8 +106,10 @@
                             <ng-container i18n>Identifying packages...</ng-container>
                         </p>
                     </div>
-                    <wu-js-tree-wrapper [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.excludePackages">
-                    </wu-js-tree-wrapper>
+                    <div class="fixed-height">
+                        <wu-js-tree-wrapper [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.excludePackages">
+                        </wu-js-tree-wrapper>
+                    </div>
                 </div>
                 <p class="help-block" i18n="exclude packages description">All classes in the selected packages will be ignored during analysis.</p>
             </div>

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
@@ -89,10 +89,8 @@
                     <ng-container i18n>Identifying packages...</ng-container>
                 </p>
             </div>
-            <div class="fixed-height">
-                <wu-js-tree-wrapper [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.includePackages">
-                </wu-js-tree-wrapper>
-            </div>
+            <wu-js-tree-wrapper style="max-height: 240px;" [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.includePackages">
+            </wu-js-tree-wrapper>
             <p class="help-block" i18n="include packages description">Select the Java packages to decompile and analyze. If no packages are selected, all will be analyzed.</p>
         </div>
 
@@ -106,10 +104,8 @@
                             <ng-container i18n>Identifying packages...</ng-container>
                         </p>
                     </div>
-                    <div class="fixed-height">
-                        <wu-js-tree-wrapper [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.excludePackages">
-                        </wu-js-tree-wrapper>
-                    </div>
+                    <wu-js-tree-wrapper style="max-height: 240px;" [treeNodes]="packageTree" [(selectedNodes)]="analysisContext.excludePackages">
+                    </wu-js-tree-wrapper>
                 </div>
                 <p class="help-block" i18n="exclude packages description">All classes in the selected packages will be ignored during analysis.</p>
             </div>

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.scss
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.scss
@@ -13,11 +13,6 @@
   flex-direction: row;
 }
 
-.fixed-height {
-  max-height: 240px;
-  overflow: auto;
-}
-
 :host /deep/ {
   .save-and-run {
     padding-top: 15px;

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.scss
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.scss
@@ -13,6 +13,11 @@
   flex-direction: row;
 }
 
+.fixed-height {
+  max-height: 240px;
+  overflow: auto;
+}
+
 :host /deep/ {
   .save-and-run {
     padding-top: 15px;

--- a/ui/src/main/webapp/src/app/shared/js-tree-angular-wrapper.component.ts
+++ b/ui/src/main/webapp/src/app/shared/js-tree-angular-wrapper.component.ts
@@ -11,7 +11,8 @@ import 'jstree';
  */
 @Component({
     templateUrl: './js-tree-angular-wrapper.component.html',
-    selector: 'wu-js-tree-wrapper'
+    selector: 'wu-js-tree-wrapper',
+    host: { 'style': 'display: block; overflow: auto;' }
 })
 export class JsTreeAngularWrapperComponent implements OnInit, OnChanges {
     @Input()


### PR DESCRIPTION
The box is height 240px to let the user see 10 values before scroll appears because each checkbox is height 24px.
10 entries seem to me a reasonable compromise between let the user see packages and not "destroy" page layout while navigating through packages.
It also been tested in wizard configuration step.