### PR TITLE
T978 Advanced options: no more filtering 'openshift' target

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/messaging/WindupExecutionTask.java
+++ b/services/src/main/java/org/jboss/windup/web/services/messaging/WindupExecutionTask.java
@@ -32,7 +32,7 @@ public class WindupExecutionTask implements Runnable
 {
     private static Logger LOG = Logger.getLogger(WindupExecutionTask.class.getName());
     
-    private static String[] CLOUD_TARGETS = {"openshift", "cloud-readiness"};
+    private static String CLOUD_TARGET = "cloud-readiness";
 
     @Inject
     @FromFurnace
@@ -136,7 +136,7 @@ public class WindupExecutionTask implements Runnable
             }
             
             if (analysisContext.isCloudTargetsIncluded()) {
-                targets.addAll(Arrays.asList(CLOUD_TARGETS));
+                targets.add(CLOUD_TARGET);
             }
             
             Map<String, Object> otherOptions = getOtherOptions(analysisContext);

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-advanced-options-modal.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-advanced-options-modal.component.ts
@@ -141,10 +141,10 @@ export class AnalysisContextAdvancedOptionsModalComponent {
         optionValues = optionValues.sort();
         // We should rather get rid of the reviewed tags in rules. WINDUPRULE-206.
         optionValues = optionValues.filter((v: any) => (!isString(v) || !(<string>v).startsWith("reviewed-")));
-        // We also filter 'cloud-readiness' and 'openshift' targets because they can only be selected
+        // We also filter 'cloud-readiness' target because it can only be selected
         // through the "Cloud readiness analysis" check-box
         if (this.newOption.name === "target") {
-            optionValues = optionValues.filter((v: any) => (!((<string>v) === "cloud-readiness" || (<string>v) === "openshift")));
+            optionValues = optionValues.filter((v: any) => !((<string>v) === "cloud-readiness"));
         }
         return optionValues;
     }


### PR DESCRIPTION
Due to removing `openshift` as target id, it's not necessary to filter it anymore (see windup/windup-rulesets#204)
Even further, once we add it again as target in the future we'll be able to select it from values in advanced options.