### PR TITLE
T968 Analysis list: fix the active analysis progress bars to not change page too dramatically

### DIFF
--- a/ui/src/main/webapp/src/app/executions/active-executions-progressbar.component.html
+++ b/ui/src/main/webapp/src/app/executions/active-executions-progressbar.component.html
@@ -1,6 +1,6 @@
-<div *ngIf="activeExecutions && activeExecutions.length > 0">
+<div>
     <h2 i18n="heading|Active Executions">Active Analysis</h2>
-    <div>
+    <div *ngIf="activeExecutions && activeExecutions.length > 0">
         <ng-container *ngFor="let activeExecution of activeExecutions">
             <wu-progress-bar *ngIf="activeExecution.currentTask || activeExecutions.length == 1"
                  [taskName]="activeExecution.currentTask"
@@ -11,8 +11,7 @@
             </wu-progress-bar>
         </ng-container>
     </div>
-</div>
-<div *ngIf="!activeExecutions || activeExecutions.length == 0">
-    <h2 i18n="heading|No Active Executions">There is no Active Analysis</h2>
-    Click <strong i18n="Analysis id">Run Analysis</strong> button to start a new analysis.
+    <div *ngIf="!activeExecutions || activeExecutions.length == 0">
+        There is no active analysis.
+    </div>
 </div>

--- a/ui/src/main/webapp/src/app/executions/active-executions-progressbar.component.html
+++ b/ui/src/main/webapp/src/app/executions/active-executions-progressbar.component.html
@@ -12,3 +12,7 @@
         </ng-container>
     </div>
 </div>
+<div *ngIf="!activeExecutions || activeExecutions.length == 0">
+    <h2 i18n="heading|No Active Executions">There is no Active Analysis</h2>
+    Click <strong i18n="Analysis id">Run Analysis</strong> button to start a new analysis.
+</div>

--- a/ui/src/main/webapp/src/app/shared/progress-bar.component.ts
+++ b/ui/src/main/webapp/src/app/shared/progress-bar.component.ts
@@ -4,21 +4,22 @@ import {Inject, Input} from '@angular/core';
 @Component({
     selector: 'wu-progress-bar',
     template: `
-        <div class="progress-description">
-            <div class="spinner spinner-xs spinner-inline"></div>&nbsp;<strong i18n="Analysis id">Analysis:</strong> #{{activeExecutionId}}&nbsp;&nbsp;<strong i18n="Progressbar task">Task:</strong> {{taskName ? taskName : "Starting..."}}
+        <div class="progress-container progress-description-left" style="padding-left: 135px;">
+        <div class="progress-description" style="max-width: 130px;">
+            <div class="spinner spinner-xs spinner-inline"></div>&nbsp;<strong i18n="Analysis id">Analysis:</strong> #{{activeExecutionId}}
         </div>
-        <div class="progress progress-label-top-right">
+        <div class="progress" style="margin-bottom: 0px;">
             <div
                     class="progress-bar" role="progressbar"
                     aria-valuemin="0"
                     [attr.aria-valuenow]="currentValue"
                     [attr.aria-valuemax]="maxValue"
                     [style.width]="(currentValue/maxValue)*100 + '%'">
-                <span>
-                    {{currentValue ? currentValue : "?"}}/{{maxValue ? maxValue : "?"}}
+                <span style="position: absolute; display: block; width: 100%; color: #363636;">
+                    <strong i18n="Progressbar task">Task:</strong> {{taskName ? taskName : "Starting..."}} ({{currentValue ? currentValue : "?"}}/{{maxValue ? maxValue : "?"}})
                 </span>
             </div>
-        </div>`
+        </div></div>`
 })
 export class ProgressBarComponent {
 


### PR DESCRIPTION
- i put everyone as reviewer in order to discuss all together
- all styles added are in-line because it's a PR to discuss since there's no mockup about the goal to achieve; once the solution will be identified, i'll put every style in CSS file 
- all information is presented in just one line behind the heading in order to avoid having a lot of empty space when there's no active analysis.
- `There is no Active Analysis` style is headline
- `Click Run Analysis button to start a new analysis.` used to fill the line when there's no active analysis
- `Analysis: #{id}` i tried to keep enough space on the right to not have the bar too near
- `Task` information centered (i change the default behavior that makes it moving with the progress bar) in the progress bar because it's value changes and so does its length: in this way the UI layout is not affected by the length of the name of the task executed
- removed the 20px margin at the bottom of the progress bar because i perceive it as another empty and wasted space in the page but obviously i want you feedback and impressions about it

some screenshots about the final result:
- active analysis with small progress bar (label on greyed part of the bar)
![screenshot from 2017-05-24 12-32-11](https://cloud.githubusercontent.com/assets/7288588/26399652/f5f1808c-407d-11e7-8264-3861aed8a562.png)
- active analysis with big progress bar (label on "blued" part of the bar)
![screenshot from 2017-05-24 12-32-27](https://cloud.githubusercontent.com/assets/7288588/26399686/2698b444-407e-11e7-95e0-7a6b59d4ca2a.png)
- no active analysis
![screenshot from 2017-05-24 12-31-57](https://cloud.githubusercontent.com/assets/7288588/26399690/2fd371b6-407e-11e7-8eee-28c8cc881d38.png)


