### PR TITLE
987 - do not autoselect all applications

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/service/RegisteredApplicationService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/RegisteredApplicationService.java
@@ -118,6 +118,8 @@ public class RegisteredApplicationService
         this.entityManager.merge(application);
         this.entityManager.merge(project);
 
+        this.addApplicationToConfiguration(application, project);
+
         return application;
     }
 
@@ -154,6 +156,17 @@ public class RegisteredApplicationService
         this.entityManager.merge(project);
 
         return registeredApplicationList;
+    }
+
+    protected void addApplicationToConfiguration(RegisteredApplication application, MigrationProject project)
+    {
+        AnalysisContext context = project.getDefaultAnalysisContext();
+
+        if (context != null)
+        {
+            context.getApplications().add(application);
+            this.entityManager.merge(context);
+        }
     }
 
     private File[] getFilesFromDirectory(File directory, String[] allowedExtensions)
@@ -220,6 +233,7 @@ public class RegisteredApplicationService
         entityManager.persist(application);
 
         this.enqueuePackageDiscovery(application);
+        this.addApplicationToConfiguration(application, project);
 
         return application;
     }

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -148,6 +148,10 @@ export class AnalysisContextFormComponent extends FormComponent
                                     this.analysisContext = context;
                                     if (this.analysisContext.migrationPath == null)
                                         this.analysisContext.migrationPath = AnalysisContextFormComponent.DEFAULT_MIGRATION_PATH;
+
+                                    if (this.isInWizard) {
+                                        this.analysisContext.applications = apps.slice();
+                                    }
                                 });
                         }
                         this.loadPackageMetadata();

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -148,7 +148,6 @@ export class AnalysisContextFormComponent extends FormComponent
                                     this.analysisContext = context;
                                     if (this.analysisContext.migrationPath == null)
                                         this.analysisContext.migrationPath = AnalysisContextFormComponent.DEFAULT_MIGRATION_PATH;
-                                    this.analysisContext.applications = apps.slice();
                                 });
                         }
                         this.loadPackageMetadata();


### PR DESCRIPTION
Taiga task #987.

- Do not automatically select all applications anymore in `AnalysisContextForm`
- Add newly uploaded applications to default `AnalysisContext`