### PR TITLE
996 - Remove redirect from analysis context form

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.ts
@@ -337,7 +337,10 @@ export class AnalysisContextFormComponent extends FormComponent
         } else if (this.isInWizard) {
             this._router.navigate([`/projects/${this.project.id}`]);
         } else {
-            this.navigateBack();
+            /**
+             * As requested, saving configuration doesn't trigger navigation anymore.
+             * It also doesn't create any notification, which is IMHO inherently wrong, but also requested.
+             */
         }
     }
 


### PR DESCRIPTION
Save button doesn't navigate away anymore. It also doesn't create any  notification, so UI appears to be frozen/doing nothing. But it is requested :(