### PR TITLE
Fix AOT complains for new versions of @ngtools/webpack

### DIFF
--- a/ui/src/main/webapp/config/webpack.prod.js
+++ b/ui/src/main/webapp/config/webpack.prod.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var webpackMerge = require('webpack-merge');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var commonConfig = require('./webpack.common.js');
+var path = require('path');
 var helpers = require('./helpers');
 var ngtools = require('@ngtools/webpack');
 var AotPlugin = ngtools.AotPlugin;
@@ -34,6 +35,7 @@ module.exports = webpackMerge(commonConfig, {
             tsConfigPath: './tsconfig-production.json',
             basePath: '.',
             mainPath: 'src/main.ts'
+//            skipCodeGeneration: true // I'm not sure what it means, but without it code would be in bundle twice
         }),
         new webpack.optimize.UglifyJsPlugin({ // https://github.com/angular/angular/issues/10618
             mangle: {

--- a/ui/src/main/webapp/package.json
+++ b/ui/src/main/webapp/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@angularclass/hmr": "^1.0.1",
     "@angularclass/hmr-loader": "^3.0.2",
-    "@ngtools/webpack": "^1.2.10",
+    "@ngtools/webpack": "^1.3.3",
     "@types/bootstrap": "^3.3.32",
     "@types/core-js": "^0.9.35",
     "@types/d3": "4.4.1",
@@ -98,7 +98,7 @@
     "angular2-template-loader": "^0.4.0",
     "autoprefixer": "^6.3.2",
     "awesome-typescript-loader": "3.0.3",
-    "codelyzer": "^2.0.0-beta.4",
+    "codelyzer": "^3.0.1",
     "copy-webpack-plugin": "^3.0.0",
     "css-loader": "^0.25.0",
     "extract-text-webpack-plugin": "^2.0.0-beta.4",

--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-advanced-options-modal.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-advanced-options-modal.component.ts
@@ -23,7 +23,7 @@ export class AnalysisContextAdvancedOptionsModalComponent {
     @Output()
     advancedOptionsChanged: EventEmitter<AdvancedOption[]> = new EventEmitter<AdvancedOption[]>();
 
-    private newOption: AdvancedOption;
+    newOption: AdvancedOption;
     private newOptionError: string;
 
     private get currentSelectedOptionDefinition(): ConfigurationOption {

--- a/ui/src/main/webapp/src/app/analysis-context/custom-rule-selection.component.ts
+++ b/ui/src/main/webapp/src/app/analysis-context/custom-rule-selection.component.ts
@@ -31,11 +31,11 @@ export class CustomRuleSelectionComponent implements OnInit {
     }
 
     private _selectedRuleIDs;
-    private get selectedRuleIDs(): number[] {
+    get selectedRuleIDs(): number[] {
         return this._selectedRuleIDs;
     }
 
-    private set selectedRuleIDs(ids: number[]) {
+    set selectedRuleIDs(ids: number[]) {
         this.selectedRulePaths = this.rulesPaths.filter((value) => {
             return ids.indexOf(value.id) != -1;
         });

--- a/ui/src/main/webapp/src/app/app.routing.ts
+++ b/ui/src/main/webapp/src/app/app.routing.ts
@@ -113,10 +113,12 @@ export const appRoutes: Routes = [
                             { path: '', component: DefaultLayoutComponent, children: [
                                 {path: 'edit', component: MigrationProjectFormComponent, data: {displayName: 'Edit Project'}},
                             ]},
+                            /*
                             {
                                 path: 'reports',
                                 loadChildren: './reports/reports.module#ReportsModule'
                             },
+                            */
                         ]
                     }
                 ]

--- a/ui/src/main/webapp/src/app/executions/all-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/all-executions.component.ts
@@ -12,7 +12,7 @@ import {ExecutionsMonitoringComponent} from "./executions-monitoring.component";
     template: '<wu-executions-list [executions]="executions" [activeExecutions]="activeExecutions"></wu-executions-list>'
 })
 export class AllExecutionsComponent extends ExecutionsMonitoringComponent implements OnInit {
-    protected executions: WindupExecution[];
+    executions: WindupExecution[];
 
     constructor(
         private _windupService: WindupService,

--- a/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
@@ -18,8 +18,8 @@ import {WindupExecutionService} from "../services/windup-execution.service";
     templateUrl: './executions-layout.component.html',
 })
 export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements OnInit, OnDestroy {
-    protected execution: WindupExecution;
-    protected allExecutions: WindupExecution[];
+    execution: WindupExecution;
+    allExecutions: WindupExecution[];
 
     constructor(
         _router: Router,

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.ts
@@ -23,7 +23,7 @@ export class ExecutionsListComponent extends AbstractComponent implements OnInit
     runExecution: EventEmitter<void> = new EventEmitter<void>();
 
     @Input()
-    private showRunAnalysisButton: boolean;
+    showRunAnalysisButton: boolean;
 
     protected element;
 
@@ -44,7 +44,7 @@ export class ExecutionsListComponent extends AbstractComponent implements OnInit
 
     searchText: string = '';
 
-    private filteredExecutions: WindupExecution[];
+    filteredExecutions: WindupExecution[];
 
     private deletedExecutions: Map<number, WindupExecution> = new Map<number, WindupExecution>();
 

--- a/ui/src/main/webapp/src/app/executions/executions-monitoring.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-monitoring.component.ts
@@ -5,7 +5,7 @@ import {ExecutionEvent} from "../core/events/windup-event";
 
 export abstract class ExecutionsMonitoringComponent extends AbstractComponent {
     protected activeExecutionsMap: Map<number, WindupExecution> = new Map<number, WindupExecution>();
-    protected activeExecutions: WindupExecution[];
+    activeExecutions: WindupExecution[];
     public project: MigrationProject;
 
     public constructor(protected _windupExecutionService: WindupExecutionService) {

--- a/ui/src/main/webapp/src/app/executions/project-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/project-executions.component.ts
@@ -15,7 +15,7 @@ import {utils} from "../shared/utils";
     templateUrl: './project-executions.component.html'
 })
 export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent implements OnInit {
-    protected executions: WindupExecution[];
+    executions: WindupExecution[];
     private doNotRefreshList: boolean;
     private analysisContext: AnalysisContext;
 

--- a/ui/src/main/webapp/src/app/executions/rule-provider-executions/rule-provider-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/rule-provider-executions/rule-provider-executions.component.ts
@@ -19,7 +19,7 @@ import {ExecutionPhaseModel} from "../../generated/tsModels/ExecutionPhaseModel"
     ]
 })
 export class RuleProviderExecutionsComponent implements OnInit, AfterViewChecked {
-    protected phases: ExecutionPhaseModel[];
+    phases: ExecutionPhaseModel[];
     protected anchor: string;
 
     constructor(

--- a/ui/src/main/webapp/src/app/project/project-layout.component.ts
+++ b/ui/src/main/webapp/src/app/project/project-layout.component.ts
@@ -18,10 +18,10 @@ import {DEFAULT_MENU_ITEMS} from "../shared/navigation/hamburger-menu.component"
     templateUrl: './project-layout.component.html',
 })
 export class ProjectLayoutComponent extends RoutedComponent implements OnInit, OnDestroy {
-    protected allProjects: MigrationProject[];
-    protected project: MigrationProject;
-    protected menuItems: ContextMenuItemInterface[];
-    protected hamburgerMenuItems: ContextMenuItemInterface[];
+    allProjects: MigrationProject[];
+    project: MigrationProject;
+    menuItems: ContextMenuItemInterface[];
+    hamburgerMenuItems: ContextMenuItemInterface[];
 
     // TODO: Execution progress: Project Layout must be updated when execution state changes (is completed)
 

--- a/ui/src/main/webapp/src/app/registered-application/register-application-form.component.ts
+++ b/ui/src/main/webapp/src/app/registered-application/register-application-form.component.ts
@@ -27,13 +27,13 @@ import formatString = utils.formatString;
 })
 export class RegisterApplicationFormComponent extends FormComponent implements OnInit, OnDestroy
 {
-    protected registrationForm: FormGroup;
+    registrationForm: FormGroup;
     protected application: RegisteredApplication;
-    protected multipartUploader: FileUploader;
+    multipartUploader: FileUploader;
     protected mode: RegistrationType = "UPLOADED";
-    protected fileInputPath: string = '';
-    private isDirWithExplodedApp: boolean = false;
-    protected isAllowUploadMultiple: boolean = true;
+    fileInputPath: string = '';
+    isDirWithExplodedApp: boolean = false;
+    isAllowUploadMultiple: boolean = true;
 
     isInWizard: boolean = false;
     project: MigrationProject;
@@ -41,7 +41,7 @@ export class RegisterApplicationFormComponent extends FormComponent implements O
 
     countUploadedApplications: number = 0;
 
-    protected labels = {
+    labels = {
         heading: 'Add Applications',
         uploadButton: 'Upload'
     };
@@ -137,7 +137,7 @@ export class RegisterApplicationFormComponent extends FormComponent implements O
         this._migrationProjectService.stopMonitoringProject(this.project);
     }
 
-    protected register() {
+    register() {
         if (this.mode == "PATH") {
             this.registerPath();
         } else {
@@ -212,7 +212,7 @@ export class RegisterApplicationFormComponent extends FormComponent implements O
         this.navigateAway([`/projects/${this.project.id}/analysis-context`]);
     }
 
-    private cancelRegistration() {
+    cancelRegistration() {
         if (this.isInWizard) {
             this.navigateAway([`/wizard/project/${this.project.id}/create-project`]);
         } else {

--- a/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
+++ b/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues-table.component.ts
@@ -147,7 +147,7 @@ export class MigrationIssuesTableComponent extends FilterableReportComponent imp
         return (summary.effortPerIncident * summary.numberFound);
     }
 
-    sortBy(property: string) {
+    sortBy(property: string|any) {
         if (property === this.orderBy) {
             this.orderDirection = (this.orderDirection === OrderDirection.ASC) ? OrderDirection.DESC : OrderDirection.ASC;
             this._sortingService.setOrderDirection(this.orderDirection);

--- a/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues.component.ts
+++ b/ui/src/main/webapp/src/app/reports/migration-issues/migration-issues.component.ts
@@ -22,7 +22,7 @@ import {FilterableReportComponent} from "../filterable-report.component";
 })
 export class MigrationIssuesComponent extends FilterableReportComponent implements OnInit {
     protected categorizedIssues: Dictionary<ProblemSummary[]>;
-    protected categories: string[];
+    categories: string[];
 
     public hideFilter = WINDUP_WEB.config.hideUnfinishedFeatures;
     public execution: WindupExecution;

--- a/ui/src/main/webapp/src/app/reports/package-chart/package-chart.component.html
+++ b/ui/src/main/webapp/src/app/reports/package-chart/package-chart.component.html
@@ -19,7 +19,7 @@
                        [activeEntries]="activeEntries"
                        [outerRadius]="outerRadius"
                        [gradient]="gradient"
-                       (select)="onClick($event)">
+                       (select)="onClick($event, null)">
                 </svg:g>
             </svg:g>
         </ngx-charts-chart>

--- a/ui/src/main/webapp/src/app/reports/package-chart/package-chart.component.ts
+++ b/ui/src/main/webapp/src/app/reports/package-chart/package-chart.component.ts
@@ -34,6 +34,7 @@ export class PackageChartComponent extends BaseChartComponent implements OnChang
     transform: string;
     colors: ColorHelper;
     legendWidth: number;
+    labels: boolean;
 
     constructor(element: ElementRef, zone: NgZone, cd: ChangeDetectorRef, location: LocationStrategy) {
         super(element, zone, cd, location);

--- a/ui/src/main/webapp/src/app/reports/source/source-report.component.ts
+++ b/ui/src/main/webapp/src/app/reports/source/source-report.component.ts
@@ -30,15 +30,15 @@ export class SourceReportComponent extends RoutedComponent implements OnInit, Af
     private execID: number;
     private fileID: number;
     private fileSource: string = "Loading...";
-    private fileLines: string[];
+    fileLines: string[];
 
-    private fileModel: FileModel;
+    fileModel: FileModel;
     private sourceFileModel: SourceFileModel;
-    private transformedLinks: LinkModel[];
+    transformedLinks: LinkModel[];
 
-    private classifications: ClassificationModel[];
+    classifications: ClassificationModel[];
     private classificationLinks: Map<ClassificationModel, LinkModel[]> = new Map<ClassificationModel, LinkModel[]>();
-    private hints: InlineHintModel[];
+    hints: InlineHintModel[];
     private rendered: boolean = false;
 
     constructor(route: ActivatedRoute,

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report.component.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report.component.ts
@@ -19,7 +19,7 @@ export class TechnologiesReportComponent implements OnInit {
 
     private execID: number;
     private technologiesStats: ProjectTechnologiesStatsModel[] = [];
-    private filteredTechnologiesStats: TechnologiesStats;
+    filteredTechnologiesStats: TechnologiesStats;
 
     constructor(
         private route: ActivatedRoute,

--- a/ui/src/main/webapp/src/app/shared/chosen/chosen-abstract.ts
+++ b/ui/src/main/webapp/src/app/shared/chosen/chosen-abstract.ts
@@ -21,7 +21,7 @@ export abstract class AbstractChosenComponent<T> implements ControlValueAccessor
 
     public chosenWithDrop: boolean = false;
 
-    protected inputValue: string;
+    inputValue: string;
 
     filterMode: boolean;
 
@@ -104,7 +104,7 @@ export abstract class AbstractChosenComponent<T> implements ControlValueAccessor
         }
     }
 
-    protected inputKeyUp(inputValue) {
+    inputKeyUp(inputValue) {
         this.filterMode = true;
         let dropOptions = null;
         if (inputValue.trim().length > 0) {

--- a/ui/src/main/webapp/src/app/shared/chosen/chosen-multiple.component.ts
+++ b/ui/src/main/webapp/src/app/shared/chosen/chosen-multiple.component.ts
@@ -81,7 +81,7 @@ export class ChosenMultipleComponent extends AbstractChosenComponent<Array<strin
     @ViewChildren(ChosenDropComponent)
     private chosenDropComponentQueryList: QueryList<ChosenDropComponent>;
 
-    private multipleSelectedOptions: InternalChosenOption[];
+    multipleSelectedOptions: InternalChosenOption[];
 
     previousInputLength: number = 0;
 

--- a/ui/src/main/webapp/src/app/shared/chosen/chosen-single.component.html
+++ b/ui/src/main/webapp/src/app/shared/chosen/chosen-single.component.html
@@ -2,7 +2,7 @@
      [class.chosen-container-active]="chosenContainerActive"
      [class.chosen-with-drop]="chosenWithDrop">
 
-    <a (click)="chosenFocus(chosenInput)"  class="chosen-single"
+    <a (click)="chosenFocus()"  class="chosen-single"
        [class.chosen-single-with-deselect]="!isSelectionEmpty() && allow_single_deselect"
        [class.chosen-default]="isSelectionEmpty()">
                 <span [ngSwitch]="isSelectionEmpty()">

--- a/ui/src/main/webapp/src/app/shared/chosen/chosen-single.component.ts
+++ b/ui/src/main/webapp/src/app/shared/chosen/chosen-single.component.ts
@@ -18,6 +18,8 @@ export const ChosenSingleComponent_CONTROL_VALUE_ACCESSOR: any = {
 })
 export class ChosenSingleComponent extends AbstractChosenComponent<string> {
 
+    chosenInput: any;
+
     @Input()
     no_results_text = AbstractChosenComponent.NO_RESULTS_TEXT_DEFAULT;
 

--- a/ui/src/main/webapp/src/app/shared/dialog/modal-dialog.component.ts
+++ b/ui/src/main/webapp/src/app/shared/dialog/modal-dialog.component.ts
@@ -35,6 +35,8 @@ export class ModalDialogComponent {
     @Input()
     id = `modal-${modalID++}`;
 
+    title: string;
+
     constructor() {}
 
     show(): void {

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.ts
@@ -9,7 +9,7 @@ import {ContextMenuItemInterface} from "./context-menu-item.class";
 })
 export class ContextMenuComponent {
     protected _menuItems: ContextMenuItemInterface[] = [];
-    protected enabledItems: ContextMenuItemInterface[] = [];
+    enabledItems: ContextMenuItemInterface[] = [];
 
     @Input()
     public set menuItems(items: ContextMenuItemInterface[]) {

--- a/ui/src/main/webapp/src/app/shared/notification.component.ts
+++ b/ui/src/main/webapp/src/app/shared/notification.component.ts
@@ -19,7 +19,7 @@ export class NotificationComponent implements OnInit, OnDestroy {
 
     protected subscription: Subscription;
 
-    protected notificationsStack: Notification[] = [];
+    notificationsStack: Notification[] = [];
 
     constructor(private _notificationService: NotificationService) {
 

--- a/ui/src/main/webapp/src/app/shared/sort/sort.component.ts
+++ b/ui/src/main/webapp/src/app/shared/sort/sort.component.ts
@@ -14,7 +14,7 @@ export class SortComponent {
     private _selectedOption: SortOption;
     private _direction: OrderDirection = OrderDirection.ASC;
 
-    private isOpen = false;
+    isOpen = false;
 
     @Input()
     public set sortOptions(sortOptions: SortOption[]) {

--- a/ui/src/main/webapp/src/polyfills.ts
+++ b/ui/src/main/webapp/src/polyfills.ts
@@ -1,12 +1,77 @@
-import 'core-js/client/shim';
-import 'reflect-metadata';
-require('zone.js/dist/zone');
+/**
+ * This file includes polyfills needed by Angular and is loaded before the app.
+ * You can add your own extra polyfills to this file.
+ *
+ * This file is divided into 2 sections:
+ *   1. Browser polyfills. These are applied before loading ZoneJS and are sorted by browsers.
+ *   2. Application imports. Files imported after ZoneJS that should be loaded before your main
+ *      file.
+ *
+ * The current setup is for so-called "evergreen" browsers; the last versions of browsers that
+ * automatically update themselves. This includes Safari >= 10, Chrome >= 55 (including Opera),
+ * Edge >= 13 on the desktop, and iOS 10 and Chrome on mobile.
+ *
+ * Learn more in https://angular.io/docs/ts/latest/guide/browser-support.html
+ */
+
+/***************************************************************************************************
+ * BROWSER POLYFILLS
+ */
+
+/** IE9, IE10 and IE11 requires all of the following polyfills. **/
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/set';
+
+/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+//import 'classlist.js';  // Run `npm install --save classlist.js`.
+
+/** IE10 and IE11 requires the following to support `@angular/animation`. */
+//import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+
+
+/** Evergreen browsers require these. **/
+import 'core-js/es6/reflect';
+import 'core-js/es7/reflect';
+
+
+/** ALL Firefox browsers require the following to support `@angular/animation`. **/
+// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
+
+
+
+/***************************************************************************************************
+ * Zone JS is required by Angular itself.
+ */
+import 'zone.js/dist/zone';  // Included with Angular CLI.
+
+
+
+/***************************************************************************************************
+ * APPLICATION IMPORTS
+ */
+
+/**
+ * Date, currency, decimal and percent pipes.
+ * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
+ */
+import 'intl';  // Run `npm install --save intl`.
+/**
+ * Need to import at least one locale-data with intl.
+ */
+import 'intl/locale-data/jsonp/en';
 
 import 'ts-helpers';
-
-// Intl API required for PhantomJS and some browsers
-import 'intl';
-import 'intl/locale-data/jsonp/en';
 
 declare var process: any;
 

--- a/ui/src/main/webapp/src/vendor.ts
+++ b/ui/src/main/webapp/src/vendor.ts
@@ -16,16 +16,6 @@ import 'd3';
 import 'd3-selection-multi';
 */
 
-// Angular 2
-import "@angular/platform-browser";
-import "@angular/platform-browser-dynamic";
-import "@angular/core";
-import "@angular/common";
-import "@angular/http";
-import "@angular/router";
-
-import "@angularclass/hmr";
-
 // Other vendors for example jQuery, Lodash or Bootstrap
 // You can import js, ts, css, sass, ...
 

--- a/ui/src/main/webapp/webpack.config.js
+++ b/ui/src/main/webapp/webpack.config.js
@@ -10,18 +10,18 @@ module.exports = function(environment) {
   switch (mode) {
     case 'prod':
     case 'production':
-      console.info('Running webpack in production mode');
+      console.error('Running webpack in production mode');
       return require('./config/webpack.prod');
       break;
     case 'test':
     case 'testing':
-      console.info('Running webpack in test mode');
+      console.error('Running webpack in test mode');
       return require('./config/webpack.test');
       break;
     case 'dev':
     case 'development':
     default:
-      console.info('Running webpack in dev mode');
+      console.error('Running webpack in dev mode');
       return require('./config/webpack.dev');
     break;
   }

--- a/ui/src/main/webapp/yarn.lock
+++ b/ui/src/main/webapp/yarn.lock
@@ -73,9 +73,9 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@angularclass/hmr/-/hmr-1.2.2.tgz#46a18f89a1e94d05c268b83c9480e005f73fc265"
 
-"@ngtools/webpack@^1.2.10":
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-1.2.12.tgz#19142e760a30172806acc7363e590d870cb30c26"
+"@ngtools/webpack@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-1.3.3.tgz#f7941eb4fe9c77ef28fe7aec15f58a64a7be1457"
   dependencies:
     enhanced-resolve "^3.1.0"
     loader-utils "^1.0.2"
@@ -1039,9 +1039,9 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codelyzer@^2.0.0-beta.4:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-2.0.1.tgz#d0f7121f67a8424c92d21d3b31f3640b83def9ed"
+codelyzer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-3.0.1.tgz#ba66b7b2aa564fe9f45d6004b4003ad2cf116828"
   dependencies:
     app-root-path "^2.0.1"
     css-selector-tokenizer "^0.7.0"


### PR DESCRIPTION
- fixes complains about non-accessible access modifiers for component properties/methods (and other AOT complains)
- updates webpack config - now correctly handles vendor and doesn't mix it up with app
- adds description to polyfills file - describes which polyfill is required for which browser
- improves IDE hints (at least for IntelliJ Idea) - some properties/methods incorrectly marked as unused are now correctly recognized as used

I'm still trying to find out why `@angular/compiler` is present in result bundle.  