### PR TITLE
Fix confirm leave modal dialog.

### DIFF
--- a/ui/src/main/webapp/src/app/shared/dialog/confirmation-modal.component.html
+++ b/ui/src/main/webapp/src/app/shared/dialog/confirmation-modal.component.html
@@ -1,4 +1,5 @@
-<div id="{{id}}" class="modal fade" tabindex="-1" role="dialog" [attr.aria-labelledby]="title" aria-hidden="true">
+<div id="{{id}}" class="modal fade" tabindex="-1" role="dialog" [attr.aria-labelledby]="title" aria-hidden="true"
+     data-keyboard="false" data-backdrop="static">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">

--- a/ui/src/main/webapp/src/app/shared/is-route-active.directive.ts
+++ b/ui/src/main/webapp/src/app/shared/is-route-active.directive.ts
@@ -26,7 +26,7 @@ export class IsRouteActiveDirective implements OnChanges, OnDestroy {
      * @type {string[]|string}
      */
     @Input()
-    public routerLink: string|string[] = [];
+    public wuRouterLink: string|string[] = [];
 
     /**
      * CSS classes to use when route is active
@@ -55,7 +55,7 @@ export class IsRouteActiveDirective implements OnChanges, OnDestroy {
     }
 
     update() {
-        if (!this._router.navigated || !this.routerLink) {
+        if (!this._router.navigated || !this.wuRouterLink) {
             return;
         }
 
@@ -76,7 +76,7 @@ export class IsRouteActiveDirective implements OnChanges, OnDestroy {
     }
 
     protected isRouteActive() {
-        const routeUrl = Array.isArray(this.routerLink) ? this.routerLink.join('') : this.routerLink;
+        const routeUrl = Array.isArray(this. wuRouterLink) ? this.wuRouterLink.join('') : this.wuRouterLink;
 
         return this._router.isActive(routeUrl, false);
     }

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
@@ -5,7 +5,7 @@
             [item]="item"
             wu-is-route-active
             [activeClasses]="['active']"
-            [routerLink]="item.link"
+            [wuRouterLink]="item.link"
         >
             <span class="fa" ngClass="{{item.icon}}" data-toggle="tooltip" title="" [attr.data-original-title]="item.label" router-mode></span>
             <span class="list-group-item-value" router-mode>{{item.label}}</span>


### PR DESCRIPTION
First issue was caused by using [routerLink] property on
`wu-is-route-active`  directive. This property conflicts with Angular's one, so it needs
 to be renamed.

Second issue was caused by not getting any output from user - dialog
was closed outside Angular's scope. To prevent that, use dialog which
 cannot be closed by keyboard/clicking outside.

Solves https://issues.jboss.org/browse/WINDUP-1390