### PR TITLE
Rules filtering part 2 - with version support

### DIFF
--- a/ui/src/main/webapp/src/app/configuration/technology-filter.ts
+++ b/ui/src/main/webapp/src/app/configuration/technology-filter.ts
@@ -1,0 +1,95 @@
+import {RuleProviderEntity, Technology} from "../generated/windup-services";
+import {utils} from "../shared/utils";
+import {FilterOption} from "../shared/filter/text-filter.component";
+
+function filterByNameAndVersion(filter: FilterOption<Technology>, provider: RuleProviderEntity): boolean {
+    const propertyValues: Technology[] = provider[filter.field];
+
+    return propertyValues.some(item => {
+        return item === filter.value || item.name === filter.value.name && item.versionRange === filter.value.versionRange;
+    });
+}
+
+function filterByName(filter: FilterOption<string>, provider: RuleProviderEntity): boolean {
+    const propertyValues: Technology[] = provider[filter.field];
+
+    return propertyValues.some(item => {
+        return item.name === filter.value;
+    });
+}
+
+export function getAvailableFilters(ruleProviders: RuleProviderEntity[], field: 'sources'|'targets') {
+    const allTechnologies = utils.Arrays.flatMap<RuleProviderEntity, Technology>(ruleProviders, provider => provider[field]);
+
+    const filteredTechnologies: Technology[] = allTechnologies.filter((item: Technology, index, array) => {
+        // remove duplicities from array (keep only first occurrence of item)
+        return array.findIndex((indexItem: Technology) => indexItem.id === item.id) === index;
+    }).sort((a, b) => {
+        if (a.name < b.name) {
+            return -1;
+        } else if (a.name > b.name) {
+            return 1;
+        } else {
+            return 0;
+        }
+    });
+
+    const technologyVersions = utils.Arrays.flatMap<Technology, FilterOption>(filteredTechnologies, technology => getAllTechnologyVersionsFilters(technology))
+        // remove duplicities from array (keep only first occurrence of item)
+        .filter((item: FilterOption, index, array) => array.findIndex(indexItem => indexItem.name === item.name) === index);
+    technologyVersions.forEach(item => item.field = field);
+
+    return technologyVersions;
+}
+
+function getAllTechnologyVersionsFilters(technology: Technology): FilterOption[] {
+    const nameOption = {
+        name: technology.name,
+        value: technology.name,
+        field: '',
+        callback: function(provider: RuleProviderEntity) {
+            return filterByName(this, provider);
+        }
+    };
+
+    if (technology.versionRange === null || technology.versionRange.length === 0) {
+        return [ nameOption ];
+    }
+
+    const versionRanges = technology.versionRange.replace(/[(\[\])]/g, '').split(',').filter(version => version !== '');
+
+    return [
+        nameOption,
+        ...versionRanges.map(version => {
+            return {
+                name: `${technology.name} ${version}`,
+                value: technology,
+                field: '',
+                callback: function(provider: RuleProviderEntity) {
+                    return filterByNameAndVersion(this, provider);
+                }
+            };
+        })
+    ];
+}
+
+function advancedFilter(technology: Technology) {
+    if (technology.versionRange === null || technology.versionRange.length === 0) {
+        return [ technology.name ];
+    }
+
+    let technologyVersions = [ ];
+    const versionRanges = technology.versionRange.replace(/[(\[\])]/g, '').split(',');
+
+    if (versionRanges.length > 2) {
+        // treat version ranges as set
+        technologyVersions = [ technology.name, ...versionRanges.map(version => `${technology.name} ${version}`) ];
+    } else {
+        let versionFrom = '';
+
+        if (technology.versionRange[0] === '[') {
+            versionFrom = versionRanges[0];
+        } else if (technology.version) {
+        }
+    }
+}

--- a/ui/src/main/webapp/src/app/shared/chosen/chosen-abstract.ts
+++ b/ui/src/main/webapp/src/app/shared/chosen/chosen-abstract.ts
@@ -1,5 +1,5 @@
 import {InternalChosenOption, InternalChosenOptionGroup, ChosenOption, ChosenOptionGroup} from "./chosen-commons";
-import {ElementRef, Renderer} from "@angular/core";
+import {ElementRef, Input, Renderer} from "@angular/core";
 import {ControlValueAccessor} from "@angular/forms";
 import {ChosenDropComponent} from "./chosen-drop.component";
 
@@ -24,6 +24,42 @@ export abstract class AbstractChosenComponent<T> implements ControlValueAccessor
     inputValue: string;
 
     filterMode: boolean;
+
+    @Input()
+    no_results_text = AbstractChosenComponent.NO_RESULTS_TEXT_DEFAULT;
+
+    @Input()
+    protected set options(options: ChosenOption[]) {
+        this.setOptions(options);
+    }
+
+    @Input()
+    protected set groups(groups: ChosenOptionGroup[]) {
+        this.setGroups(groups);
+    }
+
+    @Input()
+    set getLabel(fn: (a: any) => string) {
+        if (typeof fn !== 'function') {
+            throw new Error(`getLabel must be a function, but received ${JSON.stringify(fn)}`);
+        }
+
+        this._getLabel = fn;
+
+        // This is necessary, in case the options were set before the label function gets set
+        // (this seems to happen intermittently)
+        if (this._options)
+            this.setOptions(this._options.map(internalOption => <ChosenOption>internalOption.value));
+    }
+
+    @Input()
+    set compareWith(fn: (a: any, b: any) => boolean) {
+        if (typeof fn !== 'function') {
+            throw new Error(`compareWith must be a function, but received ${JSON.stringify(fn)}`);
+        }
+
+        this._compareWith = fn;
+    }
 
     onChange = (_: any) => {
     };

--- a/ui/src/main/webapp/src/app/shared/chosen/chosen-multiple.component.ts
+++ b/ui/src/main/webapp/src/app/shared/chosen/chosen-multiple.component.ts
@@ -8,7 +8,7 @@ import {
     ElementRef,
     Renderer,
     EventEmitter,
-    forwardRef
+    forwardRef, AfterViewInit
 } from "@angular/core";
 import {AbstractChosenComponent} from "./chosen-abstract";
 import {InternalChosenOption, ChosenOptionGroup, ChosenOption} from "./chosen-commons";
@@ -25,49 +25,12 @@ export const ChosenMultipleComponent_CONTROL_VALUE_ACCESSOR: any = {
     templateUrl: './chosen-multiple.component.html',
     providers: [ChosenMultipleComponent_CONTROL_VALUE_ACCESSOR]
 })
-export class ChosenMultipleComponent extends AbstractChosenComponent<Array<string>> {
-
-    @Input()
-    no_results_text = AbstractChosenComponent.NO_RESULTS_TEXT_DEFAULT;
-
+export class ChosenMultipleComponent extends AbstractChosenComponent<string[]> implements AfterViewInit {
     @Input()
     placeholder_text_multiple: string = "Select Some Options";
 
     @Input()
     max_shown_results = null;
-
-    @Input()
-    protected set options(options: ChosenOption[]) {
-        super.setOptions(options);
-    }
-
-    @Input()
-    protected set groups(groups: ChosenOptionGroup[]) {
-        super.setGroups(groups);
-    }
-
-    @Input()
-    set getLabel(fn: (a: any) => string) {
-        if (typeof fn !== 'function') {
-            throw new Error(`getLabel must be a function, but received ${JSON.stringify(fn)}`);
-        }
-
-        this._getLabel = fn;
-
-        // This is necessary, in case the options were set before the label function gets set
-        // (this seems to happen intermittently)
-        if (this._options)
-            super.setOptions(this._options.map(internalOption => <ChosenOption>internalOption.value));
-    }
-
-    @Input()
-    set compareWith(fn: (a: any, b: any) => boolean) {
-        if (typeof fn !== 'function') {
-            throw new Error(`compareWith must be a function, but received ${JSON.stringify(fn)}`);
-        }
-
-        this._compareWith = fn;
-    }
 
     @Input()
     single_backstroke_delete: boolean = true;

--- a/ui/src/main/webapp/src/app/shared/chosen/chosen-single.component.ts
+++ b/ui/src/main/webapp/src/app/shared/chosen/chosen-single.component.ts
@@ -1,5 +1,8 @@
 import {NgModel} from "@angular/forms";
-import {Component, Input, ViewChildren, QueryList, ElementRef, Renderer , forwardRef} from "@angular/core";
+import {
+    Component, Input, ViewChildren, QueryList, ElementRef, Renderer, forwardRef,
+    AfterViewInit
+} from "@angular/core";
 import {InternalChosenOption, ChosenOption, ChosenOptionGroup} from "./chosen-commons";
 import {AbstractChosenComponent} from "./chosen-abstract";
 import {ChosenDropComponent} from "./chosen-drop.component";
@@ -16,12 +19,9 @@ export const ChosenSingleComponent_CONTROL_VALUE_ACCESSOR: any = {
     templateUrl: './chosen-single.component.html',
     providers: [ChosenSingleComponent_CONTROL_VALUE_ACCESSOR]
 })
-export class ChosenSingleComponent extends AbstractChosenComponent<string> {
+export class ChosenSingleComponent extends AbstractChosenComponent<string> implements AfterViewInit {
 
     chosenInput: any;
-
-    @Input()
-    no_results_text = AbstractChosenComponent.NO_RESULTS_TEXT_DEFAULT;
 
     @Input() allow_single_deselect: boolean = false;
 
@@ -36,16 +36,6 @@ export class ChosenSingleComponent extends AbstractChosenComponent<string> {
 
     @Input()
     max_shown_results = null;
-
-    @Input()
-    set options(options: ChosenOption[]) {
-        super.setOptions(options);
-    }
-
-    @Input()
-    protected set groups(groups: ChosenOptionGroup[]) {
-        super.setGroups(groups);
-    }
 
     @ViewChildren(ChosenDropComponent)
     private chosenDropComponentQueryList: QueryList<ChosenDropComponent>;

--- a/ui/src/main/webapp/src/app/shared/filter/active-filters-list.component.html
+++ b/ui/src/main/webapp/src/app/shared/filter/active-filters-list.component.html
@@ -5,7 +5,7 @@
         <ul class="list-inline">
             <li *ngFor="let filter of activeFilters">
                 <span class="label label-info">
-                    {{filter.name}}: {{filter.value}}
+                    {{getLabel(filter)}}
                     <a href="javascript:void(0)" (click)="removeFilter(filter)"><span class="pficon pficon-close"></span></a>
                 </span>
             </li>

--- a/ui/src/main/webapp/src/app/shared/filter/active-filters-list.component.ts
+++ b/ui/src/main/webapp/src/app/shared/filter/active-filters-list.component.ts
@@ -16,6 +16,21 @@ export class ActiveFiltersListComponent {
     @Input()
     countResults: number;
 
+    _getLabel = (filter: any): string => `${filter.name}: ${filter.value}`;
+
+    @Input()
+    set getLabel(fn: (item: any) => string) {
+        if (typeof fn !== 'function') {
+            throw new Error(`Expected function, got ${JSON.stringify(fn)}`);
+        }
+
+        this._getLabel = fn;
+    }
+
+    get getLabel() {
+        return this._getLabel;
+    }
+
     removeFilter(filter: FilterOption) {
         this.activeFilters = this.activeFilters.filter(item => item.name !== filter.name);
         this.updateFilters();

--- a/ui/src/main/webapp/src/app/shared/filter/dropdown-filter.component.html
+++ b/ui/src/main/webapp/src/app/shared/filter/dropdown-filter.component.html
@@ -1,0 +1,21 @@
+<div class="form-group toolbar-pf-filter">
+    <label class="sr-only" for="filter">{{selectedAttribute}}</label>
+    <div class="input-group">
+        <div class="input-group-btn">
+            <button type="button" class="btn btn-default dropdown-toggle"
+                    data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{selectedAttribute}} <span class="caret"></span></button>
+            <ul class="dropdown-menu">
+                <li *ngFor="let attribute of filterableAttributes" [ngClass]="{'selected': attribute === selectedAttribute}">
+                    <a (click)="selectAttribute(attribute)" href="javascript:void(0)">{{attribute}}</a>
+                </li>
+            </ul>
+        </div><!-- /btn-group -->
+        <chosen-single
+                [options]="filterOptions"
+                [getLabel]="getOptionLabelCallback"
+                [(ngModel)]="selectedOption"
+                (ngModelChange)="selectOption($event)"
+                name="selectedApplications">
+        </chosen-single>
+    </div><!-- /input-group -->
+</div>

--- a/ui/src/main/webapp/src/app/shared/filter/dropdown-filter.component.ts
+++ b/ui/src/main/webapp/src/app/shared/filter/dropdown-filter.component.ts
@@ -1,0 +1,68 @@
+import {
+    AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input,
+    Output
+} from "@angular/core";
+import {FilterOption} from "./filter.component";
+
+@Component({
+    selector: 'wu-dropdown-filter',
+    templateUrl: './dropdown-filter.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DropdownFilterComponent implements AfterViewInit {
+    private _filterableAttributes: string[] = [];
+    private _filterOptions: any[] = [];
+
+    @Input()
+    selectedAttribute: string = '';
+
+    selectedOption: any;
+
+    getOptionLabelCallback = (option) => option.name;
+
+    @Output()
+    selectedAttributeChange = new EventEmitter<string>();
+
+    @Output()
+    setFilter = new EventEmitter<FilterOption>();
+
+    public constructor(protected _element: ElementRef) {
+    }
+
+    ngAfterViewInit(): void {
+        $(this._element.nativeElement).find('.dropdown-toggle').dropdown();
+    }
+
+    @Input()
+    public set filterableAttributes(attributes: string[]) {
+        if (attributes) {
+            this._filterableAttributes = attributes;
+            this.selectedAttribute = attributes[0];
+        }
+    }
+
+    public get filterableAttributes() {
+        return this._filterableAttributes;
+    }
+
+    @Input()
+    public set filterOptions(options: FilterOption[]) {
+        if (options) {
+            this._filterOptions = options;
+        }
+    }
+
+    public get filterOptions() {
+        return this._filterOptions;
+    }
+
+    public selectAttribute(attribute: string) {
+        this.selectedAttribute = attribute;
+        this.selectedAttributeChange.next(this.selectedAttribute);
+    }
+
+    public selectOption(option: FilterOption) {
+        this.selectedOption = null; //option;
+        this.setFilter.next(option as any);
+    }
+}

--- a/ui/src/main/webapp/src/app/shared/filter/dropdown-filter.component.ts
+++ b/ui/src/main/webapp/src/app/shared/filter/dropdown-filter.component.ts
@@ -2,7 +2,7 @@ import {
     AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input,
     Output
 } from "@angular/core";
-import {FilterOption} from "./filter.component";
+import {FilterOption} from "./text-filter.component";
 
 @Component({
     selector: 'wu-dropdown-filter',

--- a/ui/src/main/webapp/src/app/shared/filter/text-filter.component.ts
+++ b/ui/src/main/webapp/src/app/shared/filter/text-filter.component.ts
@@ -54,9 +54,9 @@ export class TextFilterComponent implements AfterViewInit {
     }
 }
 
-export interface FilterOption {
+export interface FilterOption<T = any> {
     name: string;
-    value: string;
+    value: T;
     field?: string;
     callback?: (item: any) => boolean;
 }

--- a/ui/src/main/webapp/src/app/shared/shared.module.ts
+++ b/ui/src/main/webapp/src/app/shared/shared.module.ts
@@ -54,6 +54,7 @@ import {ActiveFiltersListComponent} from "./filter/active-filters-list.component
 import {TextFilterComponent} from "./filter/text-filter.component";
 import {ToolbarComponent} from "./toolbar/toolbar.component";
 import {AllDataFilteredMessageComponent} from "./all-data-filtered-message.component";
+import {DropdownFilterComponent} from "./filter/dropdown-filter.component";
 
 @NgModule({
     imports: [
@@ -118,6 +119,7 @@ import {AllDataFilteredMessageComponent} from "./all-data-filtered-message.compo
         ActiveFiltersListComponent,
         ToolbarComponent,
         AllDataFilteredMessageComponent,
+        DropdownFilterComponent,
 
         ShortenPipe,
 
@@ -163,6 +165,7 @@ import {AllDataFilteredMessageComponent} from "./all-data-filtered-message.compo
         ActiveFiltersListComponent,
         ToolbarComponent,
         AllDataFilteredMessageComponent,
+        DropdownFilterComponent,
 
         ProjectNameNotExistsValidator,
         IsRouteActiveDirective,

--- a/ui/src/main/webapp/src/app/shared/toolbar/toolbar.component.html
+++ b/ui/src/main/webapp/src/app/shared/toolbar/toolbar.component.html
@@ -2,11 +2,14 @@
     <div class="row toolbar-pf">
         <div class="col-sm-12">
             <form class="toolbar-pf-actions">
-                <wu-text-filter
-                        [filterableAttributes]="filterConfiguration.filterOptions"
+                <wu-dropdown-filter
+                        [filterableAttributes]="filterConfiguration.filterableAttributes"
+                        [filterOptions]="filterConfiguration.filterOptions"
+                        [(selectedAttribute)]="filterConfiguration.selectedAttribute"
                         (setFilter)="addFilter($event)"
+                        (selectedAttributeChange)="updateFilters()"
                 >
-                </wu-text-filter>
+                </wu-dropdown-filter>
                 <div class="form-group">
                     <wu-sort
                         [sortOptions]="sortConfiguration.sortOptions"
@@ -19,6 +22,7 @@
             <wu-active-filters-list *ngIf="isFilterActive()"
                     [(activeFilters)]="filterConfiguration.selectedFilters"
                     [countResults]="filterConfiguration.countFilteredItems"
+                    [getLabel]="filterConfiguration.getLabel"
                     (activeFiltersChange)="updateFilters()"
             ></wu-active-filters-list>
         </div><!-- /col -->

--- a/ui/src/main/webapp/src/app/shared/toolbar/toolbar.component.ts
+++ b/ui/src/main/webapp/src/app/shared/toolbar/toolbar.component.ts
@@ -10,9 +10,12 @@ export interface SortConfiguration {
 }
 
 export interface FilterConfiguration {
+    filterableAttributes?: string[];
+    selectedAttribute?: string;
     filterOptions: FilterOption[];
     selectedFilters: FilterOption[];
     countFilteredItems: number;
+    getLabel?: (filter: FilterOption) => string;
 }
 
 @Component({
@@ -41,14 +44,14 @@ export class ToolbarComponent {
 
     addFilter(filter: FilterOption) {
         this.filterConfiguration.selectedFilters = [
-            ...this.filterConfiguration.selectedFilters.filter(item => item.name !== filter.name),
+            ...this.filterConfiguration.selectedFilters.filter(item => item.field !== filter.field),
             filter
         ];
         this.updateFilters();
     }
 
     updateFilters() {
-        this.filterChange.next(this.filterConfiguration.selectedFilters);
+        this.filterChange.next(this.filterConfiguration);
     }
 
     isFilterActive() {

--- a/ui/src/main/webapp/src/app/shared/utils.ts
+++ b/ui/src/main/webapp/src/app/shared/utils.ts
@@ -27,6 +27,13 @@ export module utils {
         return format.replace(/{(\d+)}/g, function(match, number) {
             return typeof replacements[number] != 'undefined' ? replacements[number] : match;
         });
-    };
+    }
+
+    export class Arrays {
+        public static flatMap<T, U>(array: T[], callbackfn: (value: T, index: number, array: T[]) => U[], thisArg?: any): U[] {
+            return array.map(callbackfn, thisArg)
+                .reduce((allItems, currentItems) => [...allItems, ...currentItems ], []);
+        }
+    }
 
 }


### PR DESCRIPTION
Rules filtering enhanced to support versions. (Depends on #448 )

There are several issues, which needs to be resolved first:
1) we have 2 formats of technology entity: 
for example `hibernate` with versionRange: `[5,)`  and `hibernate5` 

I'm trying to enable selecting technology even without specifying version, so ideally I would like to have options: 
- `hibernate`
- `hibernate 5`

but now I will have:
- `hibernate`
- `hibernate 5`
- `hibernate5`

where `hibernate5` and `hibernate 5` are sort of duplicities. Also the they might not be interchangeable which would lead to confusion. 

2) Input now allows only to select from predefined options (which is probably not a real problem)
3) Version based filtering is not completely finished yet. It decomposes versionRange string into array following these steps: 
- removes interval markers (this is the main missing part now - for interval `[1,10)` it would generate version strings only for version `1` and `10`.
- splits string by `,`
- generates separate versions for given result

4) What to do with interval without upper limit? (Like `hibernate [5,)`). It means all versions above 5 (including 5), but since it is displayed as finite distinct set of options, we cannot really represent infinite number of versions like that. Should we show `hibernate 5+` in that case?



Screenshot: 
[![Screenshot from 2017-06-07 14-53-45.png](https://s12.postimg.org/i63f6qnvh/Screenshot_from_2017-06-07_14-53-45.png)](https://postimg.org/image/u7yt0vx3t/)