### PR TITLE
WINDUP-1441 File upload: lines spacing and upload percentage

### DIFF
--- a/ui/src/main/webapp/src/app/registered-application/application-queue-list.component.html
+++ b/ui/src/main/webapp/src/app/registered-application/application-queue-list.component.html
@@ -14,6 +14,7 @@
                         <i class="glyphicon fa fa-trash-o"></i>
                     </span>
                 </div>
+                <div>100%</div>
             </div>
         </div>
     </li>

--- a/ui/src/main/webapp/src/app/registered-application/application-queue-list.component.html
+++ b/ui/src/main/webapp/src/app/registered-application/application-queue-list.component.html
@@ -14,7 +14,6 @@
                         <i class="glyphicon fa fa-trash-o"></i>
                     </span>
                 </div>
-                <div>100%</div>
             </div>
         </div>
     </li>

--- a/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.html
+++ b/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.html
@@ -9,13 +9,13 @@
                 <div class="file-info">
                     <span>{{item?.file?.name}}</span>
                     <span class="file-size">({{ item?.file?.size / 1024 / 1024 | number:'.2' }} MB)</span>
+                    <span>{{getProgressLabel(item)}}</span>
                 </div>
                 <div class="action-button">
                     <span (click)="isCancellable(item) ? item.cancel() : null" [ngClass]="{'pointer': isCancellable(item)}">
                         <i class="glyphicon" [ngClass]="getStatusIcon(item)"></i>
                     </span>
                 </div>
-                <div>{{getProgressLabel(item)}}</div>
             </div>
         </div>
     </li>

--- a/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.scss
+++ b/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.scss
@@ -26,7 +26,6 @@ li {
 .progress-bar {
   padding-top: 5px;
   padding-bottom: 5px;
-  color: #363636;
 }
 // #F6F9FC - light blue
 // #E9F4FF - progressbar blue

--- a/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.scss
+++ b/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.scss
@@ -26,6 +26,7 @@ li {
 .progress-bar {
   padding-top: 5px;
   padding-bottom: 5px;
+  color: #363636;
 }
 // #F6F9FC - light blue
 // #E9F4FF - progressbar blue
@@ -42,8 +43,9 @@ ul {
 span.file-size {
   position: relative;
   left: 10px;
+  margin-right: 15px;
 }
 
-.app-list li:not(:last-child) {
+.app-list li {
   margin-bottom: -15px;
 }


### PR DESCRIPTION
* weird spacing between uploaded and to-be-uploaded file lines has been fixed letting also the last element of the file list to have the negative padding 
* percentage value for uploading files has been placed right after the file size to not overlap anymore (giving some margin-right to `file-size` span)
* `100%` percentage value for uploaded files has been placed just after the file name to be consistent with the percentage positioning for uploading files: in this way we also avoid that the previously centered `100%` percentage label would have overlapped in case of narrow screen and long file name
* `.progress-bar` text color has been modfied to be color `#363636` to gain a better readablity  and to be consisten with color of other texts in the UI (white text is used for hover on left-nav bar entries and for buttons' labels)