### PR TITLE
Allow user to delete app from upload queue

### DIFF
--- a/ui/src/main/webapp/src/app/registered-application/application-queue-list.component.html
+++ b/ui/src/main/webapp/src/app/registered-application/application-queue-list.component.html
@@ -1,5 +1,10 @@
 <ul *ngIf="registeredApplications?.length > 0" class="app-list">
     <li *ngFor="let application of registeredApplications">
+        <div class="action-button">
+            <span class="pointer" (click)="confirmDeleteApplication(application)">
+                <i class="glyphicon fa fa-trash-o"></i>
+            </span>
+        </div>
         <div class="progress">
             <div class="progress-bar success"
                  role="progressbar"
@@ -8,11 +13,6 @@
                 <div class="file-info">
                     <span>{{application.title}}</span>
                     <span class="file-size">({{ application.fileSize / 1024 / 1024 | number:'.2' }} MB)</span>
-                </div>
-                <div class="action-button">
-                    <span class="pointer" (click)="confirmDeleteApplication(application)">
-                        <i class="glyphicon fa fa-trash-o"></i>
-                    </span>
                 </div>
                 <div>100%</div>
             </div>

--- a/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.html
+++ b/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.html
@@ -1,5 +1,10 @@
 <ul *ngIf="uploader.queue.length > 0" class="app-list">
     <li *ngFor="let item of uploader.queue">
+        <div class="action-button">
+            <span (click)="isCancellable(item) ? cancelUpload(item) : null" [ngClass]="{'pointer': isCancellable(item)}">
+                <i class="glyphicon" [ngClass]="getStatusIcon(item)"></i>
+            </span>
+        </div>
         <div class="progress">
             <div class="progress-bar"
                  [ngClass]="{'progress-bar-danger': item.isError, 'progress-bar-warning': item.isCancel, 'success': item.isSuccess}"
@@ -10,11 +15,6 @@
                     <span>{{item?.file?.name}}</span>
                     <span class="file-size">({{ item?.file?.size / 1024 / 1024 | number:'.2' }} MB)</span>
                     <span>{{getProgressLabel(item)}}</span>
-                </div>
-                <div class="action-button">
-                    <span (click)="isCancellable(item) ? item.cancel() : null" [ngClass]="{'pointer': isCancellable(item)}">
-                        <i class="glyphicon" [ngClass]="getStatusIcon(item)"></i>
-                    </span>
                 </div>
             </div>
         </div>

--- a/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.scss
+++ b/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.scss
@@ -1,4 +1,5 @@
 $progress-success-color: #3f9c35;
+$progress-bar-height: 30px;
 
 .file-info {
   position: absolute;
@@ -12,7 +13,13 @@ li {
 .action-button {
   float: right;
   padding-right: 10px;
-  padding-top: 3px;
+  padding-left: 10px;
+  width: 22px;
+}
+
+.action-button span i {
+  vertical-align: middle;
+  line-height: $progress-bar-height;
 }
 
 .glyphicon-remove {
@@ -20,7 +27,7 @@ li {
 }
 
 .progress {
-  height: 30px;
+  height: $progress-bar-height;
 }
 
 .progress-bar {

--- a/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.ts
+++ b/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.ts
@@ -132,6 +132,14 @@ export class AlternativeUploadQueueComponent extends AbstractComponent implement
         return !item.isUploaded && !item.isCancel && !item.isError;
     }
 
+    public cancelUpload(item: FileItem) {
+        if (item.isUploading) {
+            item.cancel();
+        } else {
+            item.remove();
+        }
+    }
+
     public getUploadItemError(item: FileItem): string {
         return this.uploadErrors.get(item) || '';
     }


### PR DESCRIPTION
- allows user to delete app from upload queue even if it is not currently uploading
- always show status icon next to progress bar

Status icon might be:
- cancel upload (remove from upload queue)
- upload cancelled (item in already cancelled state)
- delete application

#close WINDUP-1451