### PR TITLE
WINDUP-1457: syncing context menu items with page titles

### DIFF
--- a/ui/src/main/webapp/css/windup-web.css
+++ b/ui/src/main/webapp/css/windup-web.css
@@ -128,8 +128,6 @@ form .wizard-form {
     padding-right: 10px;
 }
 
-label.required {
-}
 label.required:before {
     content: '*';
     position: relative;
@@ -156,6 +154,22 @@ fieldset.fields-section-pf {
     padding-top: 122px;
     margin-top: 0;
 }
+
+/* Redefining pf styles */
+.nav-pf-vertical .list-group-item .list-group-item-value {
+    padding-right: 5px;
+}
+
+.nav-pf-vertical .list-group-item > a {
+    padding-right: 5px;
+    padding-left: 5px;
+}
+
+.nav-pf-vertical .list-group-item > li > a  {
+    padding-right: 5px;
+    padding-left: 5px;
+}
+
 /*
 .wu-horizontal-nav-content.container-fluid, .wu-horizontal-nav-content .container-fluid {
     padding-top: inherit;
@@ -169,12 +183,6 @@ fieldset.fields-section-pf {
 
     .container-fluid {
         padding-top: initial;
-    }
-}
-
-@media (min-width: 768px) and (max-width: 1599px) {
-    .wu-horizontal-nav-content, .layout-pf.layout-pf-fixed .container-pf-nav-pf-vertical {
-        margin-left: 145px;
     }
 }
 

--- a/ui/src/main/webapp/src/app/executions/project-executions.component.html
+++ b/ui/src/main/webapp/src/app/executions/project-executions.component.html
@@ -1,6 +1,6 @@
 <div class="panel-body" *ngIf="executions?.length == 0">
     <div class="header-bar">
-        <h2>Analysis</h2>
+        <h2>Analysis Results</h2>
     </div>
 
     <div  class="blank-slate-pf" style="border: none;">

--- a/ui/src/main/webapp/src/app/project/project-layout.component.ts
+++ b/ui/src/main/webapp/src/app/project/project-layout.component.ts
@@ -67,7 +67,7 @@ export class ProjectLayoutComponent extends RoutedComponent implements OnInit, O
     protected createContextMenuItems() {
         this.menuItems = [
             {
-                label: 'Analysis',
+                label: 'Analysis Results',
                 link: this._routeLinkProviderService.getRouteForComponent(ProjectExecutionsComponent, { projectId: this.project.id }),
                 icon: 'fa-tachometer',
                 isEnabled: true,
@@ -80,7 +80,7 @@ export class ProjectLayoutComponent extends RoutedComponent implements OnInit, O
                 isEnabled: true
             },
             {
-                label: 'Configuration', // MarcZ 2017-04
+                label: 'Analysis Configuration',
                 link: this._routeLinkProviderService.getRouteForComponent(AnalysisContextFormComponent, { projectId: this.project.id }),
                 icon: 'fa-cogs',
                 isEnabled: true,

--- a/ui/src/main/webapp/src/app/shared/navigation/navigation-responsive-styles.scss
+++ b/ui/src/main/webapp/src/app/shared/navigation/navigation-responsive-styles.scss
@@ -1,9 +1,5 @@
 :host /deep/ {
   @media (max-width: 1599px) {
-    .nav-pf-vertical, .navbar-primary li.home a {
-      width: 145px;
-    }
-
     .navbar-primary li.home a span:first-child {
         text-align: center;
     }
@@ -14,14 +10,11 @@
 
     .navbar-primary li.home a {
       display: flex;
+      display: -webkit-flex; /* Safari */
       flex: 1 0 0;
       align-items: center;
       align-content: center;
       justify-content: center;
-    }
-
-    .nav-pf-vertical .list-group-item > a .fa {
-      display: none;
     }
   }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-1457

I discovered that `text-overflow: ellipsis `style is not working in every situation and it depends on size of browser window.
It seems that **width** css property is not properly set or inherited `max-width: none;` breaks the correct rendering