### PR TITLE
WINDUP-1417 Analysis list and details page: get to Reports easily

### DIFF
--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -49,7 +49,7 @@
                 </ng-container>
                 <ng-container *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports">
                     <dt i18n="Analysis static report">Report</dt>
-                    <dd><a class="link" target="_blank" href="{{formatStaticReportUrl(execution)}}">Static Report <i class="fa fa-external-link"></i></a></dd>
+                    <dd><a class="link" target="_blank" href="{{formatStaticReportUrl(execution)}}">Open <i class="fa fa-external-link"></i></a></dd>
                 </ng-container>
             </dl>
 

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -47,6 +47,10 @@
                     <dt i18n="Analysis last modification">Last modification</dt>
                     <dd>{{execution.lastModified ? (execution.lastModified | date: 'short') : 'n/a'}}</dd>
                 </ng-container>
+                <ng-container *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports">
+                    <dt i18n="Analysis static report">Report</dt>
+                    <dd><a class="link" target="_blank" href="{{formatStaticReportUrl(execution)}}">Static Report <i class="fa fa-external-link"></i></a></dd>
+                </ng-container>
             </dl>
 
             <h3 i18n="Analysis configuration|Section">Configuration</h3>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -30,7 +30,16 @@
         </thead>
         <tbody>
         <tr *ngFor="let execution of sortedExecutions" [class]="getClass(execution)" class="execution-row">
-            <td><a [routerLink]="['/projects', execution.projectId, execution.id, 'execution-details']">#{{execution.id}}</a></td>
+            <td>
+                <span *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports; else elseExecutionState">
+                    <a  class="pointer link" target="_blank" href="{{formatStaticReportUrl(execution)}}" title="Show reports">
+                        #{{execution.id}} <i class="fa fa-external-link fa-fw"></i>
+                    </a>
+                </span>
+                <ng-template #elseExecutionState>
+                    #{{execution.id}}
+                </ng-template>
+            </td>
             <td>
                 <wu-status-icon [status]="execution.state"></wu-status-icon>
                 {{execution.state | wuPrettyExecutionStatus}}
@@ -60,6 +69,7 @@
             </td>
             <ng-template #showActions>
                 <td>
+                    <a [routerLink]="['/projects', execution.projectId, execution.id, 'execution-details']" title="Details"><i class="fa fa-info fa-fw"></i></a>
                     <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
                         <i class="fa fa-times fa-fw"></i>
                     </a>
@@ -69,10 +79,6 @@
                             *ngIf="execution.state == 'COMPLETED'"
                             [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">View Reports</a>
                     -->
-                    <span *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports">
-                        <a  class="pointer link" target="_blank" href="{{formatStaticReportUrl(execution)}}" title="Show reports"> <i class="fa fa-bar-chart fa-fw"></i></a>
-                        &nbsp;
-                    </span>
                     <a *ngIf="execution.state != 'STARTED' && execution.state != 'QUEUED'" class="pointer link" (click)="confirmDeleteExecution(execution)" title="Delete">
                         <i class="fa fa-trash-o fa-fw"></i>
                     </a>

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -33,7 +33,7 @@
             <td>
                 <span *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports; else elseExecutionState">
                     <a  class="pointer link" target="_blank" href="{{formatStaticReportUrl(execution)}}" title="Show reports">
-                        #{{execution.id}} <i class="fa fa-external-link fa-fw"></i>
+                        #{{execution.id}}
                     </a>
                 </span>
                 <ng-template #elseExecutionState>
@@ -70,6 +70,7 @@
             <ng-template #showActions>
                 <td>
                     <a [routerLink]="['/projects', execution.projectId, execution.id, 'execution-details']" title="Details"><i class="fa fa-info fa-fw"></i></a>
+                    &nbsp;
                     <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
                         <i class="fa fa-times fa-fw"></i>
                     </a>
@@ -79,6 +80,10 @@
                             *ngIf="execution.state == 'COMPLETED'"
                             [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">View Reports</a>
                     -->
+                    <span *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports">
+                        <a  class="pointer link" target="_blank" href="{{formatStaticReportUrl(execution)}}" title="Show reports"> <i class="fa fa-bar-chart fa-fw"></i></a>
+                        &nbsp;
+                    </span>
                     <a *ngIf="execution.state != 'STARTED' && execution.state != 'QUEUED'" class="pointer link" (click)="confirmDeleteExecution(execution)" title="Delete">
                         <i class="fa fa-trash-o fa-fw"></i>
                     </a>

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -134,9 +134,11 @@ describe('ExecutionsListComponent', () => {
         queuedExecutions.forEach(row => {
             let el = row.nativeElement;
 
-            expect(el.children[COL_ACTIONS].children.length).toBe(1);
+            expect(el.children[COL_ACTIONS].children.length).toBe(2);
             expect(el.children[COL_ACTIONS].children[0].nodeName.toLowerCase()).toEqual('a');
-            expect(el.children[COL_ACTIONS].children[0].title).toEqual('Cancel');
+            expect(el.children[COL_ACTIONS].children[0].title).toEqual('Details');
+            expect(el.children[COL_ACTIONS].children[1].nodeName.toLowerCase()).toEqual('a');
+            expect(el.children[COL_ACTIONS].children[1].title).toEqual('Cancel');
         });
     });
 
@@ -157,10 +159,10 @@ describe('ExecutionsListComponent', () => {
 
             if (stateText.startsWith("Completed")) {
                 expect(el.children[COL_ACTIONS].children.length).toBe(2);
-                expect(el.children[COL_ACTIONS].children[0].children[0].title).toEqual('Show reports');
+                expect(el.children[COL_ACTIONS].children[0].title).toEqual('Details');
                 expect(el.children[COL_ACTIONS].children[1].title).toEqual('Delete');
             } else {
-                expect(el.children[COL_ACTIONS].children.length).toBe(1);
+                expect(el.children[COL_ACTIONS].children.length).toBe(2);
                 expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('');
             }
         });

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -158,9 +158,10 @@ describe('ExecutionsListComponent', () => {
             let stateText = state.textContent ? state.textContent.trim() : "";
 
             if (stateText.startsWith("Completed")) {
-                expect(el.children[COL_ACTIONS].children.length).toBe(2);
+                expect(el.children[COL_ACTIONS].children.length).toBe(3);
                 expect(el.children[COL_ACTIONS].children[0].title).toEqual('Details');
-                expect(el.children[COL_ACTIONS].children[1].title).toEqual('Delete');
+                expect(el.children[COL_ACTIONS].children[1].children[0].title).toEqual('Show reports');
+                expect(el.children[COL_ACTIONS].children[2].title).toEqual('Delete');
             } else {
                 expect(el.children[COL_ACTIONS].children.length).toBe(2);
                 expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('');


### PR DESCRIPTION
The requirement was: 
 "_clicking on the ID to get to the reports, and move getting information about the analysis execution to the actions column_"

Analysis list page:
- analysis id has the external link icon and links to the static report if the analysis is `COMPLETED`
- in the `Actions` column, for reaching the analysis details, the bar-chart icon has been changes with the info icon because the action is "getting information"
- tests have been updated

Analysis details page:
- added the link to the static report  if the analysis is `COMPLETED`