### PR TITLE
Notifications formatting

### DIFF
--- a/ui/src/main/webapp/css/windup-web.css
+++ b/ui/src/main/webapp/css/windup-web.css
@@ -182,3 +182,8 @@ fieldset.fields-section-pf {
 .notifications-row {
     padding-top: 24px;
 }
+
+.alert {
+    margin-top: 20px;
+    margin-bottom: 0px;
+}


### PR DESCRIPTION
- margin top to avoid notifications to be too near to top navigation bar
- margin bottom is good to not have a lot of empty space between notification itself and below div title