### PR TITLE
WINDUP-1501 Redesign rules configuration page

### DIFF
--- a/ui/src/main/webapp/src/app/configuration/configuration.component.html
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.html
@@ -76,51 +76,85 @@
                 </div>
                 <ng-template #rulesList>
                     <div class="rulesList list-group list-view-pf list-view-pf-view" *ngIf="hasFileBasedProviders(rulePath)" style="margin-top: 0px;">
-                        <div *ngFor="let ruleProvider of getFilteredRuleProvidersByPath(rulePath)" class="list-group-item">
-                            <!-- If we need a checkbox for actions / global disabling.
-                            <div class="list-view-pf-checkbox">
-                                <input type="checkbox">
-                            </div>
-                            -->
-                            <div class="list-view-pf-actions" style="margin-left: 5px;">
-                                <button class="btn btn-default" [disabled]="ruleProvider.rules.length < 1" (click)="displayRules(ruleProvider, $event)" i18n="Button">Show rules</button>
-                            </div>
-                            <div class="list-view-pf-main-info">
-                                <div class="list-view-pf-left">
-                                    <span class="fa fa-puzzle-piece list-view-pf-icon-sm"></span>
+                        <div *ngFor="let ruleProvider of getFilteredRuleProvidersByPath(rulePath)" class="list-group-item" id="group-item-{{ruleProvider.id}}">
+                            <div class="list-group-item-header" (click)="clickHeader($event, ruleProvider)">
+                                <div class="list-view-pf-expand">
+                                    <span class="fa fa-angle-right" id="span-{{ruleProvider.id}}" [style]="getSpanAngleStyle(ruleProvider)"></span>
                                 </div>
-                                <div class="list-view-pf-body">
-                                    <div class="list-view-pf-description">
-                                        <div class="list-group-item-heading"> {{ruleProvider.providerID}} </div>
-                                        <div class="list-group-item-text">
-                                            <div style="width: 16pt; position: absolute;">
-                                                <span class="fa fa-file-code-o list-view-pf-icon-md" style="font-size: 16pt;"></span>
-                                            </div>
-                                            <div style="margin-left: 25pt; ">
-                                                <div>{{ruleProvider.origin}}</div>
-                                                <div *ngIf="ruleProvider.loadError" style="font-weight: bold">
-                                                    {{ruleProvider.loadError}}
+                                <!-- If we need a checkbox for actions / global disabling.
+                                <div class="list-view-pf-checkbox">
+                                    <input type="checkbox">
+                                </div>
+                                -->
+                                <div class="list-view-pf-actions" style="margin-left: 5px;">
+                                    <!-- I just comment this button in case we'll use it again
+                                    <button class="btn btn-default" [disabled]="ruleProvider.rules.length < 1" (click)="displayRules(ruleProvider, $event)" i18n="Button">Show rules</button>
+                                    -->
+                                </div>
+                                <div class="list-view-pf-main-info">
+                                    <div class="list-view-pf-left">
+                                        <span class="fa fa-puzzle-piece list-view-pf-icon-sm"></span>
+                                    </div>
+                                    <div class="list-view-pf-body">
+                                        <div class="list-view-pf-description">
+                                            <div class="list-group-item-heading"> {{ruleProvider.providerID}} </div>
+                                            <div class="list-group-item-text">
+                                                <div style="width: 16pt; position: absolute;">
+                                                    <span class="fa fa-file-code-o list-view-pf-icon-md" style="font-size: 16pt;"></span>
                                                 </div>
+                                                <div style="margin-left: 25pt; ">
+                                                    <div>{{ruleProvider.origin}}</div>
+                                                    <div *ngIf="ruleProvider.loadError" style="font-weight: bold">
+                                                        {{ruleProvider.loadError}}
+                                                    </div>
 
-                                                <div *ngIf="ruleProvider.sources.length > 0">
-                                                    Source technologies:
-                                                    <wu-technology *ngFor="let source of ruleProvider.sources" [technology]="source" class="techLabel"></wu-technology>
-                                                </div>
-                                                <div *ngIf="ruleProvider.targets.length > 0">
-                                                    Target technologies:
-                                                    <wu-technology *ngFor="let target of ruleProvider.targets" [technology]="target" class="techLabel"></wu-technology>
+                                                    <div *ngIf="ruleProvider.sources.length > 0">
+                                                        Source technologies:
+                                                        <wu-technology *ngFor="let source of ruleProvider.sources" [technology]="source" class="techLabel"></wu-technology>
+                                                    </div>
+                                                    <div *ngIf="ruleProvider.targets.length > 0">
+                                                        Target technologies:
+                                                        <wu-technology *ngFor="let target of ruleProvider.targets" [technology]="target" class="techLabel"></wu-technology>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="list-view-pf-additional-info">
-                                        <div class="list-view-pf-additional-info-item">
-                                            <span class="fa fa-list-ol"></span>
-                                            <strong>{{ruleProvider.rules ? ruleProvider.rules.length : 0}}</strong> <span i18n="Count, e.g. 5 Rules">Rules</span>
+                                        <div class="list-view-pf-additional-info">
+                                            <div class="list-view-pf-additional-info-item">
+                                                <span class="fa fa-list-ol"></span>
+                                                <strong>{{ruleProvider.rules ? ruleProvider.rules.length : 0}}</strong> <span i18n="Count, e.g. 5 Rules">Rules</span>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
+                            <div class="list-group-item-container container-fluid hidden" id="container-{{ruleProvider.id}}" style="padding-top: 0px;">
+                                <div class="row">
+                                    <div class="modal-body">
+                                        <ng-container *ngIf="ruleProvider.rules.length > 0; else elseNoRules">
+                                            <ng-container *ngIf="ruleProvider.rules.length > 1">
+                                                <label>Go to rule:</label>
+                                                <select #selectedRule class="form-control" name="ruleSelect" style="width: auto; display: inline;"
+                                                        (click)="scrollToRule(selectedRule.value)">
+                                                    <option *ngFor="let ruleEntity of ruleProvider.rules; let i = index" [value]="ruleEntity.id">{{getLabelForRuleID(ruleEntity.ruleID, ruleProvider.providerID, i)}}</option>
+                                                </select>
+                                            </ng-container>
+                                            <div *ngFor="let ruleEntity of ruleProvider.rules; let i = index">
+                                                <h4 id="{{ruleEntity.id}}">{{getLabelForRuleID(ruleEntity.ruleID, ruleProvider.providerID, i)}}
+                                                    <i class="fa fa-angle-up fa-pull-right fa-border" aria-hidden="true"
+                                                       (click)="scrollToRuleSetHeader(ruleProvider.id)"
+                                                       title="Go to rules set header"></i>
+                                                </h4>
+                                                <pre (load)="prettyPrint()" class="prettyprint" style="white-space: pre-wrap">{{ruleEntity.ruleContents}}</pre>
+                                            </div>
+                                        </ng-container>
+                                        <ng-template #elseNoRules>
+                                            <span style="font-style: italic">No Rules Defined</span>
+                                        </ng-template>
+                                    </div>
+                                </div>
+                            </div>
+
                         </div>
                     </div>
                 </ng-template>

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.html
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.html
@@ -75,7 +75,7 @@
                     <a href="javascript:void(0)" (click)="removeFilters()" i18n>Remove</a> <ng-container i18n>the filter.</ng-container>
                 </div>
                 <ng-template #rulesList>
-                    <div class="rulesList list-group list-view-pf list-view-pf-view" *ngIf="hasFileBasedProviders(rulePath)" style="margin-top: 0px;">
+                    <div class="rulesList list-group list-view-pf list-view-pf-view" *ngIf="hasFileBasedProviders(rulePath)" style="margin-top: 0px; border: none;">
                         <div *ngFor="let ruleProvider of getFilteredRuleProvidersByPath(rulePath)" class="list-group-item" id="group-item-{{ruleProvider.id}}">
                             <div class="list-group-item-header" (click)="clickHeader($event, ruleProvider)">
                                 <div class="list-view-pf-expand">
@@ -135,7 +135,9 @@
                                             <ng-container *ngIf="ruleProvider.rules.length > 1">
                                                 <label>Go to rule:</label>
                                                 <select #selectedRule class="form-control" name="ruleSelect" style="width: auto; display: inline;"
-                                                        (click)="scrollToRule(selectedRule.value)">
+                                                        (change)="scrollToRule(selectedRule.value)"
+                                                        id="select-{{ruleProvider.id}}">
+                                                    <option value="" disabled selected hidden>Select a rule</option>
                                                     <option *ngFor="let ruleEntity of ruleProvider.rules; let i = index" [value]="ruleEntity.id">{{getLabelForRuleID(ruleEntity.ruleID, ruleProvider.providerID, i)}}</option>
                                                 </select>
                                             </ng-container>

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.scss
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.scss
@@ -103,13 +103,17 @@ h1 {
   margin-bottom: 20px;
 }
 
-.panel>.panel-collapse>.list-group .list-group-item{
-  margin-top: 3px;
+.panel>.panel-collapse>.list-group .list-group-item.selectedRuleHeader,
+.panel>.panel-collapse>.list-group:first-child .list-group-item:first-child.selectedRuleHeader {
+  border-color: #39a5dc;
+  border-width: 1px;
+  border-style: solid;
 }
 
-.panel>.panel-collapse>.list-group .list-group-item.selectedRuleHeader {
-  border-color: darkgrey;
-  border-width: 1px;
-  border-radius: 3px;
-  border-style: solid;
+.panel>.panel-collapse>.list-group .list-group-item.selectedRuleHeader .list-group-item-header {
+  background-color: #def3ff;
+}
+
+.panel>.panel-collapse>.list-group:first-child .list-group-item:first-child {
+  border-top: 1px solid transparent;
 }

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.scss
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.scss
@@ -102,3 +102,14 @@ h3, h1 {
 h1 {
   margin-bottom: 20px;
 }
+
+.panel>.panel-collapse>.list-group .list-group-item{
+  margin-top: 3px;
+}
+
+.panel>.panel-collapse>.list-group .list-group-item.selectedRuleHeader {
+  border-color: darkgrey;
+  border-width: 1px;
+  border-radius: 3px;
+  border-style: solid;
+}

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.ts
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.ts
@@ -270,6 +270,7 @@ export class ConfigurationComponent implements OnInit, AfterViewInit {
     }
 
     scrollToRuleSetHeader(id:number) {
+        $(this._element.nativeElement).find("#select-" + id).val('');
         this.scrollToElement(this._element.nativeElement.querySelector(`div[id="group-item-${id}"]`));
     }
 

--- a/ui/src/main/webapp/src/app/configuration/configuration.component.ts
+++ b/ui/src/main/webapp/src/app/configuration/configuration.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, OnInit, ViewChild} from "@angular/core";
+import {AfterViewInit, Component, OnInit, ViewChild, ElementRef} from "@angular/core";
 import {ConfigurationService} from "./configuration.service";
 import {Configuration, RuleProviderEntity, RulesPath, Technology} from "../generated/windup-services";
 import {RuleService} from "./rule.service";
@@ -12,6 +12,9 @@ import {OrderDirection, SortingService} from "../shared/sort/sorting.service";
 import Arrays = utils.Arrays;
 import {FilterConfiguration} from "../shared/toolbar/toolbar.component";
 import {getAvailableFilters} from "./technology-filter";
+import {DomSanitizer} from '@angular/platform-browser';
+
+declare function prettyPrint();
 
 @Component({
     templateUrl: './configuration.component.html',
@@ -59,7 +62,9 @@ export class ConfigurationComponent implements OnInit, AfterViewInit {
         private _configurationService: ConfigurationService,
         private _ruleService: RuleService,
         private _notificationService: NotificationService,
-        private _sortingService: SortingService<RuleProviderEntity>
+        private _sortingService: SortingService<RuleProviderEntity>,
+        private _element: ElementRef,
+        private _sanitizer: DomSanitizer
     ) {
 
     }
@@ -249,4 +254,49 @@ export class ConfigurationComponent implements OnInit, AfterViewInit {
     isFilterActive() {
         return this.filter.selectedFilters.length > 0;
     }
+
+    clickHeader(event:Event, provider:RuleProviderEntity) {
+        if(!$(event.target).is("button, a, input, .fa-ellipsis-v")){
+            $(this._element.nativeElement).find("#span-" + provider.id).toggleClass("fa-angle-down")
+                .end().parent().toggleClass("list-view-pf-expand-active")
+                .find("#container-" + provider.id).toggleClass("hidden").end().parent()
+                .find("#group-item-" + provider.id).toggleClass("selectedRuleHeader");
+            prettyPrint();
+        }
+    }
+
+    scrollToRule(id:number) {
+        this.scrollToElement(this._element.nativeElement.querySelector(`h4[id="${id}"]`));
+    }
+
+    scrollToRuleSetHeader(id:number) {
+        this.scrollToElement(this._element.nativeElement.querySelector(`div[id="group-item-${id}"]`));
+    }
+
+    private scrollToElement(element:Element) {
+        if (element) {
+            /*
+             * For reference on how the offset is computed:
+             * https://developer.mozilla.org/en/docs/Web/API/Element/getBoundingClientRect
+             *
+             * 60 is the height in px of the top nav bar "header-logo-wrapper"
+             * */
+            let offset = element.getBoundingClientRect().top + window.scrollY - 60;
+            window.scrollTo(0, offset);
+        }
+    }
+
+    getSpanAngleStyle(ruleProvider: RuleProviderEntity) {
+        let margin = 0;
+        if (ruleProvider.sources.length > 0) {
+            if (ruleProvider.targets.length > 0) margin = 14;
+            else margin = 7;
+        } else if (ruleProvider.targets.length > 0) margin = 7;
+        return this._sanitizer.bypassSecurityTrustStyle("margin-top: " + margin + "px;");
+    }
+
+    getLabelForRuleID(ruleID: string, providerID: string, i:number) {
+        return (ruleID.length > 0 ? ruleID : providerID + "_" + (i + 1));
+    }
+
 }

--- a/ui/src/main/webapp/src/app/configuration/rules-modal.component.html
+++ b/ui/src/main/webapp/src/app/configuration/rules-modal.component.html
@@ -9,7 +9,7 @@
                     Rules for: {{ruleProviderEntity.providerID}}
                 </h4>
             </div>
-            <div class="modal-body">
+            <div class="modal-body" style="overflow-y: auto; max-height: 80vh;">
 
                 <div *ngFor="let ruleEntity of ruleProviderEntity.rules">
                     <h4> {{ruleEntity.ruleID}} </h4>


### PR DESCRIPTION
* disabled `Show Rules` button (w/o deleting the modal component)
* added [PF Expanding Rows](https://www.patternfly.org/pattern-library/content-views/list-view/#/list-view-with-expanding-rows) to the existing list
* added all the rules in the expanded panel for each rule set
* added select box to scroll to a particular rule within the rule set
* added border all around the rule set header and its expanded panel to improve the visual feedback
* increased border between rule sets to avoid overlapping borders
* added to each rule text area a link to scroll up again to the rule set header
* at the beginning there was a requirement for having "scroll-bar inside the popup" so the change has been done even if now the modal window is not used anymore