### PR TITLE
Improve exception handling

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
@@ -62,7 +62,7 @@ public class UnhandledExceptionHandler implements ExceptionMapper<Exception>
 
     static final Throwable findFirstOccurenceInExceptionChain(Class<? extends Throwable> type, Throwable exception)
     {
-        Throwable cause = exception;
+        Throwable cause = exception.getCause();
         while (cause != null && type.isAssignableFrom(cause.getClass()))
             cause = exception.getCause();
         return cause;
@@ -70,7 +70,7 @@ public class UnhandledExceptionHandler implements ExceptionMapper<Exception>
 
     static final Throwable findFirstOccurenceInExceptionChain(String typeName, Throwable exception)
     {
-        Throwable cause = exception;
+        Throwable cause = exception.getCause();
         while (cause != null && typeName.equals(cause.getClass().getName()))
             cause = exception.getCause();
         return cause;

--- a/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
@@ -18,13 +18,13 @@ import org.jboss.windup.web.services.ServerMode;
  * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
  */
 @Provider
-public class UnhandledExceptionHandler implements ExceptionMapper<RuntimeException>
+public class UnhandledExceptionHandler implements ExceptionMapper<Exception>
 {
     private static Logger LOG = Logger.getLogger(UnhandledExceptionHandler.class.getSimpleName());
     private final ExceptionHandler applicationExceptionHandler = new ExceptionHandler();
 
     @Override
-    public Response toResponse(RuntimeException exception)
+    public Response toResponse(Exception exception)
     {
         Throwable cause = exception.getCause();
         if (cause == null)

--- a/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandler.java
@@ -8,11 +8,12 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+
 import org.jboss.windup.web.services.ServerMode;
 
 /**
- * This exception handler should handle all runtime exceptions.
- * It should prevent server from returning HTML Error page with stack trace and internals of error.
+ * This exception handler should handle all runtime exceptions. It should prevent server from returning HTML Error page with stack trace and internals
+ * of error.
  *
  * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
  * @author <a href="mailto:zizka@seznam.cz">Ondrej Zizka</a>
@@ -62,17 +63,35 @@ public class UnhandledExceptionHandler implements ExceptionMapper<Exception>
 
     static final Throwable findFirstOccurenceInExceptionChain(Class<? extends Throwable> type, Throwable exception)
     {
-        Throwable cause = exception.getCause();
-        while (cause != null && type.isAssignableFrom(cause.getClass()))
-            cause = exception.getCause();
-        return cause;
+        Throwable cause = exception;
+
+        while (cause != null)
+        {
+            if (type.isAssignableFrom(cause.getClass()))
+            {
+                return cause;
+            }
+
+            cause = cause.getCause();
+        }
+
+        return null;
     }
 
     static final Throwable findFirstOccurenceInExceptionChain(String typeName, Throwable exception)
     {
-        Throwable cause = exception.getCause();
-        while (cause != null && typeName.equals(cause.getClass().getName()))
-            cause = exception.getCause();
-        return cause;
+        Throwable cause = exception;
+
+        while (cause != null)
+        {
+            if (typeName.equals(cause.getClass().getName()))
+            {
+                return cause;
+            }
+
+            cause = cause.getCause();
+        }
+
+        return null;
     }
 }

--- a/services/src/test/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandlerTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/UnhandledExceptionHandlerTest.java
@@ -1,0 +1,99 @@
+package org.jboss.windup.web.services.rest;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
+ */
+public class UnhandledExceptionHandlerTest
+{
+    static class ExtendsException extends Exception
+    {
+        public ExtendsException()
+        {
+            super();
+        }
+
+        public ExtendsException(String message)
+        {
+            super(message);
+        }
+
+        public ExtendsException(String message, Throwable cause)
+        {
+            super(message, cause);
+        }
+
+        public ExtendsException(Throwable cause)
+        {
+            super(cause);
+        }
+    }
+
+    @Test
+    public void findFirstValidOccurrenceInExceptionChain()
+    {
+        Throwable cause = new RuntimeException("This is cause");
+        Throwable exc = new ExtendsException("This is just a test", cause);
+
+        Throwable foundCause = UnhandledExceptionHandler.findFirstOccurenceInExceptionChain(RuntimeException.class, exc);
+
+        Assert.assertEquals(cause, foundCause);
+    }
+
+    @Test
+    public void findFirstOccurrenceInExceptionChainInvalid()
+    {
+        Throwable cause = new RuntimeException("This is cause");
+        Throwable exc = new ExtendsException("This is just a test", cause);
+
+        Throwable foundCause = UnhandledExceptionHandler.findFirstOccurenceInExceptionChain(IOException.class, exc);
+
+        Assert.assertEquals(null, foundCause);
+    }
+
+    @Test
+    public void findFirstOccurrenceInExceptionChainNoCause()
+    {
+        Throwable exc = new ExtendsException("This is just a test");
+
+        Throwable foundCause = UnhandledExceptionHandler.findFirstOccurenceInExceptionChain(ExtendsException.class, exc);
+
+        Assert.assertEquals(exc, foundCause);
+    }
+
+    @Test
+    public void findFirstValidOccurrenceInExceptionChainString()
+    {
+        Throwable cause = new RuntimeException("This is cause");
+        Throwable exc = new ExtendsException("This is just a test", cause);
+
+        Throwable foundCause = UnhandledExceptionHandler.findFirstOccurenceInExceptionChain(RuntimeException.class.getName(), exc);
+
+        Assert.assertEquals(cause, foundCause);
+    }
+
+    @Test
+    public void findFirstOccurrenceInExceptionChainInvalidString()
+    {
+        Throwable cause = new RuntimeException("This is cause");
+        Throwable exc = new ExtendsException("This is just a test", cause);
+
+        Throwable foundCause = UnhandledExceptionHandler.findFirstOccurenceInExceptionChain(IOException.class.getName(), exc);
+
+        Assert.assertEquals(null, foundCause);
+    }
+
+    @Test
+    public void findFirstOccurrenceInExceptionChainNoCauseString()
+    {
+        Throwable exc = new ExtendsException("This is just a test");
+
+        Throwable foundCause = UnhandledExceptionHandler.findFirstOccurenceInExceptionChain(ExtendsException.class.getName(), exc);
+
+        Assert.assertEquals(exc, foundCause);
+    }
+}

--- a/ui/src/main/webapp/src/app/configuration/add-rules-path-modal.component.ts
+++ b/ui/src/main/webapp/src/app/configuration/add-rules-path-modal.component.ts
@@ -75,7 +75,7 @@ export class AddRulesPathModalComponent extends FormComponent implements OnInit,
         }));
 
         this.subscriptions.push(this.multipartUploader.observables.onErrorItem.subscribe((result) => {
-            this.handleError(JSON.parse(result.response));
+            this.handleError(utils.parseServerResponse(result.response));
         }));
         this.subscriptions.push(this.multipartUploader.observables.onAfterAddingFile.subscribe(() => this.uploadRule()));
         this.subscriptions.push(this.multipartUploader.observables.onWhenAddingFileFailed.subscribe(result => {

--- a/ui/src/main/webapp/src/app/configuration/rule.service.ts
+++ b/ui/src/main/webapp/src/app/configuration/rule.service.ts
@@ -9,6 +9,7 @@ import {FileUploader} from "ng2-file-upload";
 import {KeycloakService} from "../core/authentication/keycloak.service";
 import {FileUploaderFactory} from "../shared/upload/file-uploader-factory.service";
 import {FileUploaderWrapper} from "../shared/upload/file-uploader-wrapper.service";
+import {utils} from "../shared/utils";
 
 @Injectable()
 export class RuleService extends AbstractService {
@@ -67,10 +68,12 @@ export class RuleService extends AbstractService {
 
             const promise = new Promise((resolve, reject) => {
                 this._multipartUploader.onCompleteItem = (item, response, status) => {
+                    const parsedResponse = utils.parseServerResponse(response);
+
                     if (status == 200) {
-                        responses.push(JSON.parse(response));
+                        responses.push(parsedResponse);
                     } else {
-                        errors.push(JSON.parse(response));
+                        errors.push(parsedResponse);
                     }
                 };
 
@@ -79,7 +82,7 @@ export class RuleService extends AbstractService {
                 };
 
                 this._multipartUploader.onErrorItem = (item, response) => {
-                    reject(JSON.parse(response));
+                    reject(utils.parseServerResponse(response));
                 };
             });
 

--- a/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
+++ b/ui/src/main/webapp/src/app/registered-application/registered-application.service.ts
@@ -15,6 +15,7 @@ import {SchedulerService} from "../shared/scheduler.service";
 import {ReplaySubject} from "rxjs";
 import {Cached} from "../shared/cache.service";
 import {isArray} from "util";
+import {utils} from "../shared/utils";
 
 @Injectable()
 export class RegisteredApplicationService extends AbstractService {
@@ -124,13 +125,13 @@ export class RegisteredApplicationService extends AbstractService {
 
                 let promise = new Promise((resolve, reject) => {
                     this._multipartUploader.onCompleteItem = (item, response, status, headers) => {
-                        const responseJson = JSON.parse(response);
+                        let responseMessage = utils.parseServerResponse(response);
 
                         if (status == 200) {
-                            this.fireNewApplicationEvents(responseJson, project);
-                            responses.push(responseJson);
+                            this.fireNewApplicationEvents(responseMessage, project);
+                            responses.push(responseMessage);
                         } else {
-                            errors.push(responseJson);
+                            errors.push(responseMessage);
                         }
                     };
 
@@ -139,7 +140,8 @@ export class RegisteredApplicationService extends AbstractService {
                     };
 
                     this._multipartUploader.onErrorItem = (item, response, status, headers) => {
-                        reject(JSON.parse(response));
+                        let responseMessage = utils.parseServerResponse(response);
+                        reject(utils.getErrorMessage(responseMessage));
                     };
                 });
 
@@ -206,10 +208,12 @@ export class RegisteredApplicationService extends AbstractService {
 
                 let promise = new Promise((resolve, reject) => {
                     this._multipartUploader.onCompleteItem = (item, response, status, headers) => {
+                        const parsedResponse = utils.parseServerResponse(response);
+
                         if (status == 200) {
-                            responses.push(JSON.parse(response));
+                            responses.push(parsedResponse);
                         } else {
-                            errors.push(JSON.parse(response));
+                            errors.push(parsedResponse);
                         }
                     };
 
@@ -218,7 +222,8 @@ export class RegisteredApplicationService extends AbstractService {
                     };
 
                     this._multipartUploader.onErrorItem = (item, response, status, headers) => {
-                        reject(JSON.parse(response));
+                        let responseMessage = utils.parseServerResponse(response);
+                        reject(utils.getErrorMessage(responseMessage));
                     };
                 });
 

--- a/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.ts
+++ b/ui/src/main/webapp/src/app/shared/upload/alternative-upload-queue.component.ts
@@ -31,13 +31,12 @@ export class AlternativeUploadQueueComponent extends AbstractComponent implement
         }));
 
         this.subscriptions.push(this.uploader.observables.onErrorItem.subscribe(itemError => {
-            const response = JSON.parse(itemError.response);
+            let response = utils.parseServerResponse(itemError.response);
+
             const item = itemError.item;
 
             if (this.isFileExistsError(response)) {
                 this.uploadErrors.set(item, utils.getErrorMessage(response));
-            } else {
-                this._notificationService.error(utils.getErrorMessage(response));
             }
         }));
 

--- a/ui/src/main/webapp/src/app/shared/utils.ts
+++ b/ui/src/main/webapp/src/app/shared/utils.ts
@@ -4,6 +4,21 @@ export function substringAfterLast(str, delimiter) {
 
 export module utils {
 
+    export function parseServerResponse(response: string) {
+        let result;
+
+        try {
+            result = JSON.parse(response);
+        } catch (e) {
+            /**
+             * If not valid json, treat it as a string
+             */
+            result = response;
+        }
+
+        return result;
+    }
+
     export function getErrorMessage(error: any): string
     {
         if (error instanceof ProgressEvent) {


### PR DESCRIPTION
- improved parsing of server response - now it won't fail when response is not valid JSON
- improved exception handling on backend:
  - catch all exceptions in `UnhandledExceptionHandler`, not only `RuntimeException` (this should reduce number of situations when server responds with plaintext/html message instead of JSON) 
  - all exceptions are not considered `"Database constraints were not met."` anymore. (This was caused by bug in `findFirstOccurenceInExceptionChain` methods.