### PR TITLE
WINDUP-1586: On master, Active analysis bar is not working

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -202,6 +202,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-websockets-jsr</artifactId>
+            <version>1.4.0.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jpamodelgen</artifactId>
             <version>5.2.1.Final</version>


### PR DESCRIPTION
Retrieve the hostname from the socket itself. This method depends on undertow.

I tried this method first: https://webcache.googleusercontent.com/search?q=cache:uqS3eGVAcnoJ:https://java.net/jira/browse/WEBSOCKET_SPEC-235+&cd=1&hl=en&ct=clnk&gl=us

The method from java.net didn't work, though, as the thread can vary between the modifyHandshake call and the open call.