### PR TITLE
WINDUP-1584 Fix package discovering (never ending)

### DIFF
--- a/ui/src/main/webapp/tests/app/registeredapplication.service.spec.ts
+++ b/ui/src/main/webapp/tests/app/registeredapplication.service.spec.ts
@@ -22,6 +22,7 @@ import {SchedulerServiceMock} from "./mocks/scheduler-service.mock";
 import {Subject} from "rxjs";
 import createSpy = jasmine.createSpy;
 import {SchedulerService} from "../../src/app/shared/scheduler.service";
+import {NgZone} from "@angular/core";
 
 describe("Registered Application Service Test", () => {
     beforeEach(() => {
@@ -137,7 +138,7 @@ describe("Registered Application Service Test", () => {
 
             instance = new RegisteredApplicationService(null, null, jasmine.createSpyObj('multipartUploader', [
                 'setOptions'
-            ]), null, schedulerMock);
+            ]), null, schedulerMock, new NgZone(false));
             spyOn(RegisteredApplicationService.prototype, 'getPackageMetadata').and.callFake(getPackageMetadata);
         });
 


### PR DESCRIPTION
Fix a NgZone issue after #454 introduces [`zone.runOutsideAngular`](https://github.com/windup/windup-web/pull/454/files#diff-e40e9ff89e95fe20d6426ddb4f89dadeR11) for handling remote calls to get the packages list for every application.