### PR TITLE
WINDUP-1578 Dynamic EJB Report and 2nd level menu

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResource.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResource.java
@@ -1,0 +1,24 @@
+package org.jboss.windup.web.addons.websupport.rest.graph;
+
+import org.jboss.windup.web.addons.websupport.rest.FurnaceRESTGraphAPI;
+
+import javax.ws.rs.*;
+import java.util.Map;
+
+@Path("reports/{reportId}/ejb")
+@Consumes("application/json")
+@Produces("application/json")
+public interface EJBResource extends FurnaceRESTGraphAPI {
+
+    @POST
+    @Path("/mdb")
+    Object getMDB(@PathParam("reportId") final Long reportID, Map<String, Object> filterAsMap);
+
+    @POST
+    @Path("/ejb")
+    Object getEJB(@PathParam("reportId") final Long reportID, @QueryParam("sessionType") final String sessionType, Map<String, Object> filterAsMap);
+
+    @POST
+    @Path("/entity")
+    Object getEntity(@PathParam("reportId") final Long reportID, Map<String, Object> filterAsMap);
+}

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResourceImpl.java
@@ -3,12 +3,10 @@ package org.jboss.windup.web.addons.websupport.rest.graph;
 import java.util.*;
 
 import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.BelongsToProject;
 import org.jboss.windup.graph.model.ProjectModel;
 import org.jboss.windup.graph.service.GraphService;
-import org.jboss.windup.rules.apps.javaee.model.EjbBeanBaseModel;
-import org.jboss.windup.rules.apps.javaee.model.EjbEntityBeanModel;
-import org.jboss.windup.rules.apps.javaee.model.EjbMessageDrivenModel;
-import org.jboss.windup.rules.apps.javaee.model.EjbSessionBeanModel;
+import org.jboss.windup.rules.apps.javaee.model.*;
 import org.jboss.windup.web.addons.websupport.model.ReportFilterDTO;
 
 public class EJBResourceImpl extends AbstractGraphResource implements EJBResource
@@ -65,6 +63,12 @@ public class EJBResourceImpl extends AbstractGraphResource implements EJBResourc
             }
             else
             {
+                for (ProjectModel projectModel : projectModels)
+                {
+                    if (mdb.belongsToProject(projectModel))
+                        ejbMessageDrivenArrayList.add(mdb);
+                }
+/*
                 for (ProjectModel projectModel : mdb.getRootProjectModels())
                 {
                     if (projectModels.contains(projectModel))
@@ -73,6 +77,7 @@ public class EJBResourceImpl extends AbstractGraphResource implements EJBResourc
                         break;
                     }
                 }
+*/
             }
         }
 

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResourceImpl.java
@@ -1,0 +1,81 @@
+package org.jboss.windup.web.addons.websupport.rest.graph;
+
+import java.util.*;
+
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.service.GraphService;
+import org.jboss.windup.rules.apps.javaee.model.EjbBeanBaseModel;
+import org.jboss.windup.rules.apps.javaee.model.EjbEntityBeanModel;
+import org.jboss.windup.rules.apps.javaee.model.EjbMessageDrivenModel;
+import org.jboss.windup.rules.apps.javaee.model.EjbSessionBeanModel;
+import org.jboss.windup.web.addons.websupport.model.ReportFilterDTO;
+
+public class EJBResourceImpl extends AbstractGraphResource implements EJBResource
+{
+    @Override
+    public Object getMDB(Long reportID, Map<String, Object> filterAsMap)
+    {
+        return this.getFilteredData(reportID, null, filterAsMap, EjbMessageDrivenModel.class);
+    }
+
+    @Override
+    public Object getEJB(Long reportID, String sessionType, Map<String, Object> filterAsMap)
+    {
+        return this.getFilteredData(reportID, sessionType,  filterAsMap, EjbSessionBeanModel.class);
+    }
+
+    @Override
+    public Object getEntity(Long reportID, Map<String, Object> filterAsMap)
+    {
+        return this.getFilteredData(reportID, null, filterAsMap, EjbEntityBeanModel.class);
+    }
+
+    private <T extends EjbBeanBaseModel> Object getFilteredData(Long reportID, String sessionType, Map<String, Object> filterAsMap, Class<T> clazz) {
+        GraphContext graphContext = this.getGraph(reportID);
+
+        ReportFilterDTO filter = this.reportFilterService.getReportFilterFromMap(filterAsMap);
+        Set<String> includeTags = new HashSet<>();
+        Set<String> excludeTags = new HashSet<>();
+        Set<ProjectModel> projectModels = null;
+
+        if (filter.isEnabled())
+        {
+            includeTags.addAll(filter.getIncludeTags());
+            excludeTags.addAll(filter.getExcludeTags());
+            projectModels = this.getProjectModels(graphContext, filter);
+        }
+
+        List<T> ejbMessageDrivenArrayList = new ArrayList<>();
+        GraphService<T> ejbMessageDrivenModelService = new GraphService<>(graphContext, clazz);
+        Iterable<T> data;
+        if (sessionType != null)
+        {
+            data = ejbMessageDrivenModelService.findAllByProperties(new String[]{"sessionType"}, new String[]{sessionType});
+        } else
+        {
+            data = ejbMessageDrivenModelService.findAll();
+        }
+
+        for (T mdb : data)
+        {
+            if (projectModels == null)
+            {
+                ejbMessageDrivenArrayList.add(mdb);
+            }
+            else
+            {
+                for (ProjectModel projectModel : mdb.getRootProjectModels())
+                {
+                    if (projectModels.contains(projectModel))
+                    {
+                        ejbMessageDrivenArrayList.add(mdb);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return super.frameIterableToResult(reportID, ejbMessageDrivenArrayList, 1);
+    }
+}

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/EJBResourceImpl.java
@@ -44,43 +44,33 @@ public class EJBResourceImpl extends AbstractGraphResource implements EJBResourc
             projectModels = this.getProjectModels(graphContext, filter);
         }
 
-        List<T> ejbMessageDrivenArrayList = new ArrayList<>();
-        GraphService<T> ejbMessageDrivenModelService = new GraphService<>(graphContext, clazz);
+        List<T> result = new ArrayList<>();
+        GraphService<T> ejbService = new GraphService<>(graphContext, clazz);
         Iterable<T> data;
         if (sessionType != null)
         {
-            data = ejbMessageDrivenModelService.findAllByProperties(new String[]{"sessionType"}, new String[]{sessionType});
+            data = ejbService.findAllByProperties(new String[]{EjbBeanBaseModel.SESSION_TYPE}, new String[]{sessionType});
         } else
         {
-            data = ejbMessageDrivenModelService.findAll();
+            data = ejbService.findAll();
         }
 
-        for (T mdb : data)
+        for (T ejb : data)
         {
             if (projectModels == null)
             {
-                ejbMessageDrivenArrayList.add(mdb);
+                result.add(ejb);
             }
             else
             {
                 for (ProjectModel projectModel : projectModels)
                 {
-                    if (mdb.belongsToProject(projectModel))
-                        ejbMessageDrivenArrayList.add(mdb);
+                    if (ejb.belongsToProject(projectModel))
+                        result.add(ejb);
                 }
-/*
-                for (ProjectModel projectModel : mdb.getRootProjectModels())
-                {
-                    if (projectModels.contains(projectModel))
-                    {
-                        ejbMessageDrivenArrayList.add(mdb);
-                        break;
-                    }
-                }
-*/
             }
         }
 
-        return super.frameIterableToResult(reportID, ejbMessageDrivenArrayList, 1);
+        return super.frameIterableToResult(reportID, result, 1);
     }
 }

--- a/services/src/main/java/org/jboss/windup/web/services/rest/RestApplicationFurnace.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/RestApplicationFurnace.java
@@ -6,6 +6,7 @@ import org.jboss.windup.web.addons.websupport.rest.MigrationIssuesEndpoint;
 import org.jboss.windup.web.addons.websupport.rest.TagResource;
 import org.jboss.windup.web.addons.websupport.rest.graph.ClassificationResource;
 import org.jboss.windup.web.addons.websupport.rest.graph.DependenciesReportResource;
+import org.jboss.windup.web.addons.websupport.rest.graph.EJBResource;
 import org.jboss.windup.web.addons.websupport.rest.graph.HintResource;
 import org.jboss.windup.web.addons.websupport.rest.graph.LinkResource;
 import org.jboss.windup.web.addons.websupport.rest.graph.applicationDetails.ApplicationDetailsResource;
@@ -68,6 +69,9 @@ public class RestApplicationFurnace extends Application {
     @Inject @FromFurnace
     private DependenciesReportResource dependenciesReportResource;
 
+    @Inject @FromFurnace
+    private EJBResource ejbResource;
+
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -86,6 +90,7 @@ public class RestApplicationFurnace extends Application {
         addService(singletons, applicationDetailsResource);
         addService(singletons, tagResource);
         addService(singletons, dependenciesReportResource);
+        addService(singletons, ejbResource);
 
         return singletons;
     }

--- a/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-layout.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit, OnDestroy} from "@angular/core";
 import {ActivatedRoute, Router} from "@angular/router";
 
 import {RouteLinkProviderService} from "../core/routing/route-link-provider-service";
-import {ContextMenuItem, ReportMenuItem} from "../shared/navigation/context-menu-item.class";
+import {ContextMenuItem, ContextMenuItemInterface, ReportMenuItem} from "../shared/navigation/context-menu-item.class";
 import {WINDUP_WEB} from "../app.module";
 import {WindupExecution} from "../generated/windup-services";
 import {WindupService} from "../services/windup.service";
@@ -91,6 +91,62 @@ export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements
     }
 
     protected createContextMenuItems() {
+        this.submenuTechnologyItems = [
+            new ContextMenuItem(
+                'EJB',
+                null,
+                true,
+                'technology-report-ejb'
+            ),
+            new ContextMenuItem(
+                'JPA',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Server Resources',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Hardcoded IP',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Remote Services',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Spring Resources',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Hibernate',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Ignored Files',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Unparsable Files',
+                null,
+                false,
+                'technology-report-change-me'
+            )
+        ];
         this.menuItems = [
             new ReportMenuItem(
                 'Application List',
@@ -105,6 +161,14 @@ export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements
                 this.project,
                 this.execution,
                 'application-index'
+            ),
+            new ReportMenuItem(
+                'Technologies',
+                'fa-lightbulb-o',
+                this.project,
+                this.execution,
+                'technology-report',
+                this.submenuTechnologyItems
             ),
             new ReportMenuItem(
                 'Issues',
@@ -144,13 +208,6 @@ export class ExecutionsLayoutComponent extends ProjectLayoutComponent implements
             this.menuItems.splice(4, 0, reportFilterMenu);
 
             this.menuItems = [ ...this.menuItems,
-                new ReportMenuItem(
-                    'Technologies',
-                    'fa-cubes',
-                    this.project,
-                    this.execution,
-                    'technologies-report'
-                ),
                 new ReportMenuItem(
                     'Dependencies',
                     'fa-code-fork',

--- a/ui/src/main/webapp/src/app/project/project-layout.component.ts
+++ b/ui/src/main/webapp/src/app/project/project-layout.component.ts
@@ -23,6 +23,8 @@ export class ProjectLayoutComponent extends RoutedComponent implements OnInit, O
     menuItems: ContextMenuItemInterface[];
     hamburgerMenuItems: ContextMenuItemInterface[];
 
+    submenuTechnologyItems: ContextMenuItemInterface[];
+
     // TODO: Execution progress: Project Layout must be updated when execution state changes (is completed)
 
     constructor(

--- a/ui/src/main/webapp/src/app/reports/application-level-layout.component.ts
+++ b/ui/src/main/webapp/src/app/reports/application-level-layout.component.ts
@@ -77,6 +77,14 @@ export class ApplicationLevelLayoutComponent extends ExecutionsLayoutComponent {
                 'application-index'
             ),
             new ApplicationReportMenuItem(
+                'Technologies',
+                'fa-lightbulb-o',
+                this.project,
+                this.execution,
+                this.application,
+                'technology-report'
+            ),
+            new ApplicationReportMenuItem(
                 'Application Details',
                 'fa-list',
                 this.project,
@@ -107,14 +115,6 @@ export class ApplicationLevelLayoutComponent extends ExecutionsLayoutComponent {
             this.menuItems.splice(4, 0, reportFilterMenu);
 
             this.menuItems = [ ...this.menuItems,
-                new ApplicationReportMenuItem(
-                    'Technologies',
-                    'fa-cubes',
-                    this.project,
-                    this.execution,
-                    this.application,
-                    'technologies-report'
-                ),
                 new ApplicationReportMenuItem(
                     'Dependencies',
                     'fa-code-fork',

--- a/ui/src/main/webapp/src/app/reports/application-level-layout.component.ts
+++ b/ui/src/main/webapp/src/app/reports/application-level-layout.component.ts
@@ -8,7 +8,7 @@ import {MigrationProjectService} from "../project/migration-project.service";
 import {ActivatedRoute, Router} from "@angular/router";
 import {DatePipe} from "@angular/common";
 import {FlattenedRouteData, RouteFlattenerService} from "../core/routing/route-flattener.service";
-import {ApplicationReportMenuItem, ReportMenuItem} from "../shared/navigation/context-menu-item.class";
+import {ApplicationReportMenuItem, ContextMenuItem, ReportMenuItem} from "../shared/navigation/context-menu-item.class";
 import {WINDUP_WEB} from "../app.module";
 
 type Application = any; //RegisteredApplication|FilterApplication;
@@ -60,6 +60,62 @@ export class ApplicationLevelLayoutComponent extends ExecutionsLayoutComponent {
     }
 
     protected createContextMenuItems() {
+        this.submenuTechnologyItems = [
+            new ContextMenuItem(
+                'EJB',
+                null,
+                true,
+                'technology-report-ejb'
+            ),
+            new ContextMenuItem(
+                'JPA',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Server Resources',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Hardcoded IP',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Remote Services',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Spring Resources',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Hibernate',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Ignored Files',
+                null,
+                false,
+                'technology-report-change-me'
+            ),
+            new ContextMenuItem(
+                'Unparsable Files',
+                null,
+                false,
+                'technology-report-change-me'
+            )
+        ];
         this.menuItems = [
             new ReportMenuItem(
                 'Application List',
@@ -82,7 +138,8 @@ export class ApplicationLevelLayoutComponent extends ExecutionsLayoutComponent {
                 this.project,
                 this.execution,
                 this.application,
-                'technology-report'
+                'technology-report',
+                this.submenuTechnologyItems
             ),
             new ApplicationReportMenuItem(
                 'Application Details',

--- a/ui/src/main/webapp/src/app/reports/reports-routing.module.ts
+++ b/ui/src/main/webapp/src/app/reports/reports-routing.module.ts
@@ -22,10 +22,10 @@ export const executionLevelRoutes: Routes = [
     {path: 'dependencies-report', component: DependenciesReportComponent, data: {displayName: 'Dependency Report'}},
     {path: 'technology-report', component: TechnologiesReportComponent, data: {displayName: 'Technology Report'},
         children: [
-            {path: 'ejb', component: TechnologiesEJBReportComponent, data: {displayName: 'Technology EJB Report'}},
+            {path: 'ejb', component: TechnologiesEJBReportComponent, data: {displayName: 'EJB Report'}},
         ]
     },
-    {path: 'technology-report-ejb', component: TechnologiesEJBReportComponent, data: {displayName: 'Technology EJB Report'}},
+    {path: 'technology-report-ejb', component: TechnologiesEJBReportComponent, data: {displayName: 'EJB Report'}},
     {path: 'migration-issues',
         children: [
             {path: '', component: MigrationIssuesComponent, data: {displayName: 'Issues'}},

--- a/ui/src/main/webapp/src/app/reports/reports-routing.module.ts
+++ b/ui/src/main/webapp/src/app/reports/reports-routing.module.ts
@@ -15,11 +15,17 @@ import {ApplicationDetailsComponent} from "./application-details/application-det
 import {RuleProviderExecutionsComponent} from "../executions/rule-provider-executions/rule-provider-executions.component";
 import {FullFlattenedRoute} from "../core/routing/route-flattener.service";
 import {ExecutionDetailComponent} from "../executions/execution-detail.component";
+import {TechnologiesEJBReportComponent} from "./technologies/technologies-report-ejb.component";
 
 export const executionLevelRoutes: Routes = [
     {path: '', component: ExecutionApplicationListComponent, data: {displayName: 'Applications'}},
     {path: 'dependencies-report', component: DependenciesReportComponent, data: {displayName: 'Dependency Report'}},
-    {path: 'technology-report', component: TechnologiesReportComponent, data: {displayName: 'Technology Report'}},
+    {path: 'technology-report', component: TechnologiesReportComponent, data: {displayName: 'Technology Report'},
+        children: [
+            {path: 'ejb', component: TechnologiesEJBReportComponent, data: {displayName: 'Technology EJB Report'}},
+        ]
+    },
+    {path: 'technology-report-ejb', component: TechnologiesEJBReportComponent, data: {displayName: 'Technology EJB Report'}},
     {path: 'migration-issues',
         children: [
             {path: '', component: MigrationIssuesComponent, data: {displayName: 'Issues'}},

--- a/ui/src/main/webapp/src/app/reports/reports.module.ts
+++ b/ui/src/main/webapp/src/app/reports/reports.module.ts
@@ -29,6 +29,8 @@ import {NgxChartsModule} from "@swimlane/ngx-charts";
 import {PackageChartComponent} from "./package-chart/package-chart.component";
 import {ExecutionsModule} from "../executions/executions.module";
 import {SourceResolve} from "./source/source.resolve";
+import {TechnologiesEJBReportComponent} from "./technologies/technologies-report-ejb.component";
+
 
 @NgModule({
     imports: [
@@ -55,6 +57,7 @@ import {SourceResolve} from "./source/source.resolve";
 
         EffortLevelPipe,
         PrettyPathPipe,
+        TechnologiesEJBReportComponent,
     ],
     exports: [
         ApplicationDetailsComponent,
@@ -68,6 +71,7 @@ import {SourceResolve} from "./source/source.resolve";
 
         TechnologyTagComponent,
         ExecutionApplicationListComponent,
+        TechnologiesEJBReportComponent,
 
     ],
     providers: [

--- a/ui/src/main/webapp/src/app/reports/source/source-report.component.html
+++ b/ui/src/main/webapp/src/app/reports/source/source-report.component.html
@@ -1,6 +1,12 @@
-<div class="sourceReport  panel panel-primary">
+<div class="panel-body">
+
+    <ng-container>
+        <div class="header-bar">
+            <h2>Source code</h2>
+        </div>
+        <div class="sourceReport  panel panel-primary">
     <div class="panel-heading">
-        <h3 class="panel-title">Source of: {{fileModel?.fileName}}</h3>
+        <h3 class="panel-title">{{fileModel?.fileName}}</h3>
     </div>
     <div class="panel-body" style="overflow: auto;">
         <div class="points" style="text-align: center; color: #00254b; padding-bottom: 1ex;">
@@ -72,4 +78,6 @@
             </div>
         </div>
     </div>
+</div>
+    </ng-container>
 </div>

--- a/ui/src/main/webapp/src/app/reports/technologies/tech-report.service.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/tech-report.service.ts
@@ -6,6 +6,9 @@ import {ProjectTechnologiesStatsModel} from "../../generated/tsModels/ProjectTec
 import {GraphService} from "../../services/graph.service";
 import {GraphJSONToModelService} from "../../services/graph/graph-json-to-model.service";
 import {Cached} from "../../shared/cache.service";
+import {EjbMessageDrivenModel} from "../../generated/tsModels/EjbMessageDrivenModel";
+import {EjbEntityBeanModel} from "../../generated/tsModels/EjbEntityBeanModel";
+import {EjbSessionBeanModel} from "../../generated/tsModels/EjbSessionBeanModel";
 
 @Injectable()
 export class TechReportService extends GraphService
@@ -22,7 +25,26 @@ export class TechReportService extends GraphService
             includeInVertices: false
         });
     }
- }
+
+    getEjbMessageDrivenModel(execID: number): Observable<EjbMessageDrivenModel[]> {
+        return this.getTypeAsArray<EjbMessageDrivenModel>(EjbMessageDrivenModel.discriminator, execID, {
+            depth: 1
+        });
+    }
+
+    getEjbSessionBeanModel(execID: number, sessionType: string): Observable<EjbSessionBeanModel[]> {
+        return this.getTypeAsArray<EjbSessionBeanModel>(EjbSessionBeanModel.discriminator, execID, {
+            depth: 1
+        },'sessionType', sessionType);
+    }
+
+    getEjbEntityBeanModel(execID: number): Observable<EjbEntityBeanModel[]> {
+        return this.getTypeAsArray<EjbEntityBeanModel>(EjbEntityBeanModel.discriminator, execID, {
+            depth: 1
+        });
+    }
+
+}
 
 export class StatsItem {
     key: string;

--- a/ui/src/main/webapp/src/app/reports/technologies/tech-report.service.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/tech-report.service.ts
@@ -9,6 +9,7 @@ import {Cached} from "../../shared/cache.service";
 import {EjbMessageDrivenModel} from "../../generated/tsModels/EjbMessageDrivenModel";
 import {EjbEntityBeanModel} from "../../generated/tsModels/EjbEntityBeanModel";
 import {EjbSessionBeanModel} from "../../generated/tsModels/EjbSessionBeanModel";
+import {EjbBeanBaseModel} from "../../generated/tsModels/EjbBeanBaseModel";
 
 @Injectable()
 export class TechReportService extends GraphService
@@ -26,22 +27,96 @@ export class TechReportService extends GraphService
         });
     }
 
-    getEjbMessageDrivenModel(execID: number): Observable<EjbMessageDrivenModel[]> {
-        return this.getTypeAsArray<EjbMessageDrivenModel>(EjbMessageDrivenModel.discriminator, execID, {
-            depth: 1
-        });
+    getEjbMessageDrivenModel(execID: number): Observable<EJBStatDTO[]> {
+        return this.getTypeAsArray<EjbMessageDrivenModel>(
+            EjbMessageDrivenModel.discriminator,
+            execID,
+            {depth: 1}
+        ).map(value => {
+            return this.loadStats(value);
+            }
+        );
     }
 
-    getEjbSessionBeanModel(execID: number, sessionType: string): Observable<EjbSessionBeanModel[]> {
-        return this.getTypeAsArray<EjbSessionBeanModel>(EjbSessionBeanModel.discriminator, execID, {
-            depth: 1
-        },'sessionType', sessionType);
+    getEjbSessionBeanModel(execID: number, sessionType: string): Observable<EJBStatDTO[]> {
+        return this.getTypeAsArray<EjbSessionBeanModel>(
+            EjbSessionBeanModel.discriminator,
+            execID,
+            {depth: 1},
+            'sessionType',
+            sessionType
+        ).map(value => {
+                return this.loadStats(value);
+            }
+        );
     }
 
-    getEjbEntityBeanModel(execID: number): Observable<EjbEntityBeanModel[]> {
-        return this.getTypeAsArray<EjbEntityBeanModel>(EjbEntityBeanModel.discriminator, execID, {
-            depth: 1
+    getEjbEntityBeanModel(execID: number): Observable<EJBStatDTO[]> {
+        return this.getTypeAsArray<EjbEntityBeanModel>(
+            EjbEntityBeanModel.discriminator,
+            execID,
+            {depth: 1}
+            ).map(value => {
+                return this.loadStats(value);
+            }
+        );
+    }
+
+    private loadStats(values:EjbBeanBaseModel[]):EJBStatDTO[] {
+        let result = [];
+        values.forEach( mdb => {
+            let mdbStat: EJBStatDTO = {
+                name: '',
+                class: '',
+                location: '',
+                sourceVertexId: null,
+                interface: ''
+            };
+            mdbStat.name = mdb.beanName;
+
+            mdb.ejbClass.subscribe(clazz => {
+                mdbStat.class = clazz.qualifiedName;
+                clazz.decompiledSource.subscribe(source => {
+                    if (source) {
+                        mdbStat.sourceVertexId = source.vertexId;
+                    }
+                });
+            });
+
+            if (mdb instanceof EjbMessageDrivenModel) {
+                mdb.destination.subscribe(destination => {
+                    if (destination) {
+                        mdbStat.location = destination.jndiLocation;
+                    }
+                });
+            } else if (mdb instanceof EjbSessionBeanModel) {
+                mdb.globalJndiReference.subscribe(destination => {
+                    if (destination) {
+                        mdbStat.location = destination.jndiLocation;
+                    }
+                });
+
+                mdb.ejbLocal.subscribe(interfaze => {
+                    if (interfaze) {
+                        mdbStat.interface = interfaze.qualifiedName;
+                    } else {
+                        mdb.ejbRemote.subscribe(interfaze => {
+                            if (interfaze) {
+                                mdbStat.interface = interfaze.qualifiedName;
+                            }
+                        });
+                    }
+                });
+
+                mdb.ejbDeploymentDescriptor.subscribe(deploymentDescriptor => {
+                    if (deploymentDescriptor) {
+                        mdbStat.sourceVertexId = deploymentDescriptor.vertexId;
+                    }
+                });
+            }
+            result.push(mdbStat);
         });
+        return result;
     }
 
 }
@@ -50,4 +125,12 @@ export class StatsItem {
     key: string;
     quantity: number = 0;
     label: string;
+}
+
+export interface EJBStatDTO {
+    name: String,
+    class: String,
+    location: String,
+    sourceVertexId: number,
+    interface: String;
 }

--- a/ui/src/main/webapp/src/app/reports/technologies/tech-report.service.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/tech-report.service.ts
@@ -29,19 +29,19 @@ export class TechReportService extends GraphService
         });
     }
 
-    getEjbMessageDrivenModel(execID: number, filter?: ReportFilter): Observable<EJBStatDTO[]> {
+    getEjbMessageDrivenModel(execID: number, filter?: ReportFilter): Observable<EJBInformationDTO[]> {
         return this.getEJBs<EjbMessageDrivenModel>(execID, 'mdb', EjbMessageDrivenModel, filter);
     }
 
-    getEjbSessionBeanModel(execID: number, sessionType: string, filter?: ReportFilter): Observable<EJBStatDTO[]> {
+    getEjbSessionBeanModel(execID: number, sessionType: string, filter?: ReportFilter): Observable<EJBInformationDTO[]> {
         return this.getEJBs<EjbSessionBeanModel>(execID, 'ejb', EjbSessionBeanModel, filter, sessionType);
     }
 
-    getEjbEntityBeanModel(execID: number, filter?: ReportFilter): Observable<EJBStatDTO[]> {
+    getEjbEntityBeanModel(execID: number, filter?: ReportFilter): Observable<EJBInformationDTO[]> {
         return this.getEJBs<EjbEntityBeanModel>(execID, 'entity', EjbEntityBeanModel, filter);
     }
 
-    private getEJBs<T extends EjbBeanBaseModel>(execID: number, ejbType: string, clazz?: typeof EjbBeanBaseModel,  filter?: ReportFilter, sessionType?: string): Observable<EJBStatDTO[]> {
+    private getEJBs<T extends EjbBeanBaseModel>(execID: number, ejbType: string, clazz?: typeof EjbBeanBaseModel,  filter?: ReportFilter, sessionType?: string): Observable<EJBInformationDTO[]> {
         let serializedFilter = this.serializeFilter(filter);
         let url =`${Constants.GRAPH_REST_BASE}/reports/${execID}/ejb/${ejbType}`;
         if (sessionType) {
@@ -57,15 +57,15 @@ export class TechReportService extends GraphService
                 return <T[]>this._graphJsonToModelService.fromJSONarray(data, clazz);
             })
             .map(value => {
-                    return this.loadStats(value);
+                    return this.loadEJBInformation(value);
                 }
             );
     }
 
-    private loadStats(values:EjbBeanBaseModel[]):EJBStatDTO[] {
+    private loadEJBInformation(values:EjbBeanBaseModel[]):EJBInformationDTO[] {
         let result = [];
         values.forEach( mdb => {
-            let mdbStat: EJBStatDTO = {
+            let mdbStat: EJBInformationDTO = {
                 name: '',
                 class: '',
                 location: '',
@@ -127,7 +127,7 @@ export class StatsItem {
     label: string;
 }
 
-export interface EJBStatDTO {
+export interface EJBInformationDTO {
     name: String,
     class: String,
     location: String,

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
@@ -1,0 +1,189 @@
+<div class="panel-body">
+
+    <ng-container>
+        <div class="header-bar">
+            <h2>Technologies &gt; <span style="color: #39a5dc;">EJB Report</span> </h2>
+            <div class="search-and-create">
+                <div class="search-and-create"  *ngIf="true">
+                    <wu-search [(searchValue)]="searchText" (searchValueChange)="updateSearch()"></wu-search>
+                </div>
+            </div>
+        </div>
+
+        <div class="panel panel-default panel-primary wuTechnologies">
+            <div class="panel-heading">
+                <h3 class="panel-title">Message Driven Beans</h3>
+            </div>
+            <div class="panel-body">
+                <wu-all-data-filtered-message
+                        [filteredItems]="filteredEjbMessageDriven"
+                        [unfilteredItems]="ejbMessageDriven"
+                        (clearFilter)="clearSearch()">
+                    <table class="table table-bordered table-hover" *ngIf="filteredEjbMessageDriven.length > 0; else noDataAvailable">
+                        <thead wu-sortable-table
+                               [(sortedData)]="sortedEjbMessageDriven" [data]="filteredEjbMessageDriven"
+                               [tableHeaders]="[
+                            { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
+                            { title: 'Class', isSortable: true, sortBy: sortByQualifiedNameCallback},
+                            { title: 'JMS Destination', isSortable: false, sortBy: '' }
+                        ]">
+                        </thead>
+                        <tbody>
+                        <tr *ngFor="let mdb of this.sortedEjbMessageDriven">
+                            <td class="col-md-3">{{mdb?.beanName}}</td>
+                            <td class="col-md-7"><a [routerLink]="['../source/' + ((mdb?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(mdb?.ejbClass | async)?.qualifiedName}}</a></td>
+                            <td class="col-md-2">{{(mdb?.destination | async)?.jndiLocation}}</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </wu-all-data-filtered-message>
+            </div>
+        </div>
+
+        <!-- L&F "static report" -->
+        <!--            <div class="panel panel-primary">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">Message Driven Beans</h3>
+                        </div>
+                        <table class="table table-striped table-bordered" id="mdbTable">
+                            <thead wu-sortable-table [tableHeaders]="[
+                                        { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
+                                        { title: 'Class', isSortable: false, sortBy: 'ejbClass?.qualifiedName'},
+                                        { title: 'JMS Destination', isSortable: false, sortBy: '' }
+                                    ]">
+                            <tr>
+                                <th class="col-md-2">MDB Name</th>
+                                <th>Class</th>
+                                <th class="col-md-3">JMS Destination</th>
+                            </tr>
+                            </thead>
+                            <tr *ngFor="let value of this.filteredEjbMessageDriven">
+                                <td>{{value?.beanName}}</td>
+                                <td><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
+                                <td>{{(value?.destination | async)?.jndiLocation}}</td>
+                            </tr>
+                        </table>
+                    </div>-->
+
+        <!-- L&F "issues report" but with a full width table -->
+        <!--            <div class="panel panel-primary wuTechnologies">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">Message Driven Beans</h3>
+                        </div>
+                        <table class="table table-striped table-bordered" id="mdbTable">
+                            <thead wu-sortable-table [tableHeaders]="[
+                                        { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
+                                        { title: 'Class', isSortable: false, sortBy: 'ejbClass?.qualifiedName'},
+                                        { title: 'JMS Destination', isSortable: false, sortBy: '' }
+                                    ]">
+                            </thead>
+                            <tr *ngFor="let value of this.filteredEjbMessageDriven">
+                                <td>{{value?.beanName}}</td>
+                                <td><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
+                                <td>{{(value?.destination | async)?.jndiLocation}}</td>
+                            </tr>
+                        </table>
+                    </div>-->
+
+        <div class="panel panel-default panel-primary wuTechnologies">
+            <div class="panel-heading">
+                <h3 class="panel-title">Stateless Session Beans</h3>
+            </div>
+            <div class="panel-body">
+                <wu-all-data-filtered-message
+                        [filteredItems]="filteredEjbSessionStatelessBean"
+                        [unfilteredItems]="ejbSessionStatelessBean"
+                        (clearFilter)="clearSearch()">
+                    <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatelessBean.length > 0; else noDataAvailable">
+                        <thead wu-sortable-table
+                               [(sortedData)]="sortedEjbSessionStatelessBean" [data]="filteredEjbSessionStatelessBean"
+                               [tableHeaders]="[
+                                { title: 'Bean Name', isSortable: true, sortBy: 'beanName' },
+                                { title: 'Interface', isSortable: false, sortBy: ''},
+                                { title: 'Implementation', isSortable: false, sortBy: ''},
+                                { title: 'JNDI Location', isSortable: false, sortBy: '' }
+                            ]">
+                        </thead>
+                        <tbody>
+                            <tr *ngFor="let value of this.sortedEjbSessionStatelessBean">
+                                <td class="col-md-2"><a [routerLink]="['../source/' + (value?.ejbDeploymentDescriptor | async)?.vertexId]">{{value?.beanName}}</a></td>
+                                <td class="col-md-1">{{(value?.ejbLocal | async)?.qualifiedName}} {{(value?.ejbRemote | async)?.qualifiedName}}</td>
+                                <td class="col-md-7"><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
+                                <td class="col-md-2">{{(value?.globalJndiReference | async)?.jndiLocation}}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </wu-all-data-filtered-message>
+            </div>
+        </div>
+
+        <div class="panel panel-default panel-primary wuTechnologies">
+            <div class="panel-heading">
+                <h3 class="panel-title">Stateful Session Beans</h3>
+            </div>
+            <div class="panel-body">
+                <wu-all-data-filtered-message
+                        [filteredItems]="filteredEjbSessionStatefulBean"
+                        [unfilteredItems]="ejbSessionStatefulBean"
+                        (clearFilter)="clearSearch()">
+                    <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatefulBean.length > 0; else noDataAvailable">
+                        <thead wu-sortable-table
+                               [(sortedData)]="sortedEjbSessionStatefulBean" [data]="filteredEjbSessionStatefulBean"
+                               [tableHeaders]="[
+                                { title: 'Bean Name', isSortable: true, sortBy: 'beanName' },
+                                { title: 'Interface', isSortable: false, sortBy: ''},
+                                { title: 'Implementation', isSortable: false, sortBy: ''},
+                                { title: 'JNDI Location', isSortable: false, sortBy: '' }
+                            ]">
+                        </thead>
+                        <tbody>
+                        <tr *ngFor="let value of this.sortedEjbSessionStatefulBean">
+                            <td class="col-md-2"><a [routerLink]="['../source/' + (value?.ejbDeploymentDescriptor | async)?.vertexId]">{{value?.beanName}}</a></td>
+                            <td class="col-md-1">{{(value?.ejbLocal | async)?.qualifiedName}} {{(value?.ejbRemote | async)?.qualifiedName}}</td>
+                            <td class="col-md-7"><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
+                            <td class="col-md-2">{{(value?.globalJndiReference | async)?.jndiLocation}}</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </wu-all-data-filtered-message>
+            </div>
+        </div>
+
+        <div class="panel panel-default panel-primary wuTechnologies">
+            <div class="panel-heading">
+                <h3 class="panel-title">Entity Beans</h3>
+            </div>
+            <div class="panel-body">
+                <wu-all-data-filtered-message
+                        [filteredItems]="filteredEjbEntityBean"
+                        [unfilteredItems]="ejbEntityBean"
+                        (clearFilter)="clearSearch()">
+                    <table class="table table-bordered table-hover" *ngIf="filteredEjbEntityBean.length > 0; else noDataAvailable">
+                        <thead wu-sortable-table
+                               [(sortedData)]="sortedEjbEntityBean" [data]="filteredEjbEntityBean"
+                               [tableHeaders]="[
+                                { title: 'Bean Name', isSortable: true, sortBy: 'beanName' },
+                                { title: 'Interface', isSortable: false, sortBy: ''},
+                                { title: 'Implementation', isSortable: false, sortBy: ''},
+                                { title: 'JNDI Location', isSortable: false, sortBy: '' }
+                            ]">
+                        </thead>
+                        <tbody>
+                        <tr *ngFor="let value of this.sortedEjbEntityBean">
+                            <td class="col-md-2"><a [routerLink]="['../source/' + (value?.ejbDeploymentDescriptor | async)?.vertexId]">{{value?.beanName}}</a></td>
+                            <td class="col-md-1">{{(value?.ejbLocal | async)?.qualifiedName}} {{(value?.ejbRemote | async)?.qualifiedName}}</td>
+                            <td class="col-md-7"><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
+                            <td class="col-md-2">{{(value?.globalJndiReference | async)?.jndiLocation}}</td>
+                        </tr>
+                        </tbody>
+                    </table>
+
+                </wu-all-data-filtered-message>
+            </div>
+        </div>
+    </ng-container>
+</div>
+
+<ng-template #noDataAvailable>
+    <span>There are no beans of this type.</span>
+</ng-template>

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
@@ -23,16 +23,16 @@
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbMessageDriven" [data]="filteredEjbMessageDriven"
                                [tableHeaders]="[
-                            { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
-                            { title: 'Class', isSortable: true, sortBy: sortByQualifiedNameCallback},
-                            { title: 'JMS Destination', isSortable: false, sortBy: '' }
+                            { title: 'MDB Name', isSortable: true, sortBy: 'name' },
+                            { title: 'Class', isSortable: true, sortBy: 'class'},
+                            { title: 'JMS Destination', isSortable: true, sortBy: 'location'}
                         ]">
                         </thead>
                         <tbody>
                         <tr *ngFor="let mdb of this.sortedEjbMessageDriven">
-                            <td class="col-md-3">{{mdb?.beanName}}</td>
-                            <td class="col-md-7"><a [routerLink]="['../source/' + ((mdb?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(mdb?.ejbClass | async)?.qualifiedName}}</a></td>
-                            <td class="col-md-2">{{(mdb?.destination | async)?.jndiLocation}}</td>
+                            <td class="col-md-4">{{mdb.name}}</td>
+                            <td class="col-md-6"><a [routerLink]="['../source/' + mdb.sourceVertexId]">{{mdb.class}}</a></td>
+                            <td class="col-md-2">{{mdb.location}}</td>
                         </tr>
                         </tbody>
                     </table>
@@ -98,18 +98,18 @@
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbSessionStatelessBean" [data]="filteredEjbSessionStatelessBean"
                                [tableHeaders]="[
-                                { title: 'Bean Name', isSortable: true, sortBy: 'beanName' },
-                                { title: 'Interface', isSortable: false, sortBy: ''},
-                                { title: 'Implementation', isSortable: false, sortBy: ''},
-                                { title: 'JNDI Location', isSortable: false, sortBy: '' }
+                                { title: 'Bean Name', isSortable: true, sortBy: 'name' },
+                                { title: 'Interface', isSortable: true, sortBy: 'interface'},
+                                { title: 'Implementation', isSortable: true, sortBy: 'class'},
+                                { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
                             ]">
                         </thead>
                         <tbody>
                             <tr *ngFor="let value of this.sortedEjbSessionStatelessBean">
-                                <td class="col-md-2"><a [routerLink]="['../source/' + (value?.ejbDeploymentDescriptor | async)?.vertexId]">{{value?.beanName}}</a></td>
-                                <td class="col-md-1">{{(value?.ejbLocal | async)?.qualifiedName}} {{(value?.ejbRemote | async)?.qualifiedName}}</td>
-                                <td class="col-md-7"><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
-                                <td class="col-md-2">{{(value?.globalJndiReference | async)?.jndiLocation}}</td>
+                                <td class="col-md-2">{{value.name}}</td>
+                                <td class="col-md-2">{{value.interface}}</td>
+                                <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
+                                <td class="col-md-2">{{value.location}}</td>
                             </tr>
                         </tbody>
                     </table>
@@ -130,18 +130,18 @@
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbSessionStatefulBean" [data]="filteredEjbSessionStatefulBean"
                                [tableHeaders]="[
-                                { title: 'Bean Name', isSortable: true, sortBy: 'beanName' },
-                                { title: 'Interface', isSortable: false, sortBy: ''},
-                                { title: 'Implementation', isSortable: false, sortBy: ''},
-                                { title: 'JNDI Location', isSortable: false, sortBy: '' }
+                                { title: 'Bean Name', isSortable: true, sortBy: 'name' },
+                                { title: 'Interface', isSortable: true, sortBy: 'interface'},
+                                { title: 'Implementation', isSortable: true, sortBy: 'class'},
+                                { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
                             ]">
                         </thead>
                         <tbody>
                         <tr *ngFor="let value of this.sortedEjbSessionStatefulBean">
-                            <td class="col-md-2"><a [routerLink]="['../source/' + (value?.ejbDeploymentDescriptor | async)?.vertexId]">{{value?.beanName}}</a></td>
-                            <td class="col-md-1">{{(value?.ejbLocal | async)?.qualifiedName}} {{(value?.ejbRemote | async)?.qualifiedName}}</td>
-                            <td class="col-md-7"><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
-                            <td class="col-md-2">{{(value?.globalJndiReference | async)?.jndiLocation}}</td>
+                            <td class="col-md-2">{{value.name}}</td>
+                            <td class="col-md-2">{{value.interface}}</td>
+                            <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
+                            <td class="col-md-2">{{value.location}}</td>
                         </tr>
                         </tbody>
                     </table>
@@ -162,18 +162,18 @@
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbEntityBean" [data]="filteredEjbEntityBean"
                                [tableHeaders]="[
-                                { title: 'Bean Name', isSortable: true, sortBy: 'beanName' },
-                                { title: 'Interface', isSortable: false, sortBy: ''},
-                                { title: 'Implementation', isSortable: false, sortBy: ''},
-                                { title: 'JNDI Location', isSortable: false, sortBy: '' }
+                                { title: 'Bean Name', isSortable: true, sortBy: 'name' },
+                                { title: 'Interface', isSortable: true, sortBy: 'interface'},
+                                { title: 'Implementation', isSortable: true, sortBy: 'class'},
+                                { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
                             ]">
                         </thead>
                         <tbody>
                         <tr *ngFor="let value of this.sortedEjbEntityBean">
-                            <td class="col-md-2"><a [routerLink]="['../source/' + (value?.ejbDeploymentDescriptor | async)?.vertexId]">{{value?.beanName}}</a></td>
-                            <td class="col-md-1">{{(value?.ejbLocal | async)?.qualifiedName}} {{(value?.ejbRemote | async)?.qualifiedName}}</td>
-                            <td class="col-md-7"><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
-                            <td class="col-md-2">{{(value?.globalJndiReference | async)?.jndiLocation}}</td>
+                            <td class="col-md-2">{{value.name}}</td>
+                            <td class="col-md-2">{{value.interface}}</td>
+                            <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
+                            <td class="col-md-2">{{value.location}}</td>
                         </tr>
                         </tbody>
                     </table>

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
@@ -1,192 +1,190 @@
-<div class="panel-body">
-
-    <ng-container>
-        <div class="header-bar">
-            <h2>Technologies &gt; {{title}}</h2>
-            <div class="search-and-create">
-                <div class="search-and-create"  *ngIf="true">
-                    <wu-search [(searchValue)]="searchText" (searchValueChange)="updateSearch()"></wu-search>
-                </div>
+<ng-container>
+    <div class="header-bar">
+        <h2>Technologies &gt; {{title}}</h2>
+        <div class="search-and-create">
+            <div class="search-and-create"  *ngIf="true">
+                <wu-search [(searchValue)]="searchText" (searchValueChange)="updateSearch()"></wu-search>
             </div>
         </div>
+    </div>
 
-        <div class="panel panel-default panel-primary wuTechnologies">
-            <div class="panel-heading">
-                <h3 class="panel-title">Message Driven Beans</h3>
-            </div>
-            <div class="panel-body">
-                <wu-all-data-filtered-message
-                        [filteredItems]="filteredEjbMessageDriven"
-                        [unfilteredItems]="ejbMessageDriven"
-                        (clearFilter)="clearSearch()"
-                        *ngIf="!loadingMDB; else loadingData">
-                    <table class="table table-bordered table-hover" *ngIf="filteredEjbMessageDriven.length > 0; else noDataAvailable">
-                        <thead wu-sortable-table
-                               [(sortedData)]="sortedEjbMessageDriven" [data]="filteredEjbMessageDriven"
-                               [tableHeaders]="[
-                            { title: 'MDB Name', isSortable: true, sortBy: 'name' },
-                            { title: 'Class', isSortable: true, sortBy: 'class'},
-                            { title: 'JMS Destination', isSortable: true, sortBy: 'location'}
+    <div class="panel panel-default panel-primary wuTechnologies">
+        <div class="panel-heading">
+            <h3 class="panel-title">Message Driven Beans</h3>
+        </div>
+        <div class="panel-body">
+            <wu-all-data-filtered-message
+                    [filteredItems]="filteredEjbMessageDriven"
+                    [unfilteredItems]="ejbMessageDriven"
+                    (clearFilter)="clearSearch()"
+                    *ngIf="!loadingMDB; else loadingData">
+                <table class="table table-bordered table-hover" *ngIf="filteredEjbMessageDriven.length > 0; else noDataAvailable">
+                    <thead wu-sortable-table
+                           [(sortedData)]="sortedEjbMessageDriven" [data]="filteredEjbMessageDriven"
+                           [tableHeaders]="[
+                        { title: 'MDB Name', isSortable: true, sortBy: 'name' },
+                        { title: 'Class', isSortable: true, sortBy: 'class'},
+                        { title: 'JMS Destination', isSortable: true, sortBy: 'location'}
+                    ]">
+                    </thead>
+                    <tbody>
+                    <tr *ngFor="let mdb of this.sortedEjbMessageDriven">
+                        <td class="col-md-4">{{mdb.name}}</td>
+                        <td class="col-md-6"><a [routerLink]="['../source/' + mdb.sourceVertexId]">{{mdb.class}}</a></td>
+                        <td class="col-md-2">{{mdb.location}}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </wu-all-data-filtered-message>
+        </div>
+    </div>
+
+    <!-- L&F "static report" -->
+    <!--            <div class="panel panel-primary">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Message Driven Beans</h3>
+                    </div>
+                    <table class="table table-striped table-bordered" id="mdbTable">
+                        <thead wu-sortable-table [tableHeaders]="[
+                                    { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
+                                    { title: 'Class', isSortable: false, sortBy: 'ejbClass?.qualifiedName'},
+                                    { title: 'JMS Destination', isSortable: false, sortBy: '' }
+                                ]">
+                        <tr>
+                            <th class="col-md-2">MDB Name</th>
+                            <th>Class</th>
+                            <th class="col-md-3">JMS Destination</th>
+                        </tr>
+                        </thead>
+                        <tr *ngFor="let value of this.filteredEjbMessageDriven">
+                            <td>{{value?.beanName}}</td>
+                            <td><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
+                            <td>{{(value?.destination | async)?.jndiLocation}}</td>
+                        </tr>
+                    </table>
+                </div>-->
+
+    <!-- L&F "issues report" but with a full width table -->
+    <!--            <div class="panel panel-primary wuTechnologies">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">Message Driven Beans</h3>
+                    </div>
+                    <table class="table table-striped table-bordered" id="mdbTable">
+                        <thead wu-sortable-table [tableHeaders]="[
+                                    { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
+                                    { title: 'Class', isSortable: false, sortBy: 'ejbClass?.qualifiedName'},
+                                    { title: 'JMS Destination', isSortable: false, sortBy: '' }
+                                ]">
+                        </thead>
+                        <tr *ngFor="let value of this.filteredEjbMessageDriven">
+                            <td>{{value?.beanName}}</td>
+                            <td><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
+                            <td>{{(value?.destination | async)?.jndiLocation}}</td>
+                        </tr>
+                    </table>
+                </div>-->
+
+    <div class="panel panel-default panel-primary wuTechnologies">
+        <div class="panel-heading">
+            <h3 class="panel-title">Stateless Session Beans</h3>
+        </div>
+        <div class="panel-body">
+            <wu-all-data-filtered-message
+                    [filteredItems]="filteredEjbSessionStatelessBean"
+                    [unfilteredItems]="ejbSessionStatelessBean"
+                    (clearFilter)="clearSearch()"
+                    *ngIf="!loadingEJBStateless; else loadingData">
+                <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatelessBean.length > 0; else noDataAvailable">
+                    <thead wu-sortable-table
+                           [(sortedData)]="sortedEjbSessionStatelessBean" [data]="filteredEjbSessionStatelessBean"
+                           [tableHeaders]="[
+                            { title: 'Bean Name', isSortable: true, sortBy: 'name' },
+                            { title: 'Interface', isSortable: true, sortBy: 'interface'},
+                            { title: 'Implementation', isSortable: true, sortBy: 'class'},
+                            { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
                         ]">
-                        </thead>
-                        <tbody>
-                        <tr *ngFor="let mdb of this.sortedEjbMessageDriven">
-                            <td class="col-md-4">{{mdb.name}}</td>
-                            <td class="col-md-6"><a [routerLink]="['../source/' + mdb.sourceVertexId]">{{mdb.class}}</a></td>
-                            <td class="col-md-2">{{mdb.location}}</td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </wu-all-data-filtered-message>
-            </div>
-        </div>
-
-        <!-- L&F "static report" -->
-        <!--            <div class="panel panel-primary">
-                        <div class="panel-heading">
-                            <h3 class="panel-title">Message Driven Beans</h3>
-                        </div>
-                        <table class="table table-striped table-bordered" id="mdbTable">
-                            <thead wu-sortable-table [tableHeaders]="[
-                                        { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
-                                        { title: 'Class', isSortable: false, sortBy: 'ejbClass?.qualifiedName'},
-                                        { title: 'JMS Destination', isSortable: false, sortBy: '' }
-                                    ]">
-                            <tr>
-                                <th class="col-md-2">MDB Name</th>
-                                <th>Class</th>
-                                <th class="col-md-3">JMS Destination</th>
-                            </tr>
-                            </thead>
-                            <tr *ngFor="let value of this.filteredEjbMessageDriven">
-                                <td>{{value?.beanName}}</td>
-                                <td><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
-                                <td>{{(value?.destination | async)?.jndiLocation}}</td>
-                            </tr>
-                        </table>
-                    </div>-->
-
-        <!-- L&F "issues report" but with a full width table -->
-        <!--            <div class="panel panel-primary wuTechnologies">
-                        <div class="panel-heading">
-                            <h3 class="panel-title">Message Driven Beans</h3>
-                        </div>
-                        <table class="table table-striped table-bordered" id="mdbTable">
-                            <thead wu-sortable-table [tableHeaders]="[
-                                        { title: 'MDB Name', isSortable: true, sortBy: 'beanName' },
-                                        { title: 'Class', isSortable: false, sortBy: 'ejbClass?.qualifiedName'},
-                                        { title: 'JMS Destination', isSortable: false, sortBy: '' }
-                                    ]">
-                            </thead>
-                            <tr *ngFor="let value of this.filteredEjbMessageDriven">
-                                <td>{{value?.beanName}}</td>
-                                <td><a [routerLink]="['../source/' + ((value?.ejbClass | async)?.decompiledSource | async)?.vertexId]">{{(value?.ejbClass | async)?.qualifiedName}}</a></td>
-                                <td>{{(value?.destination | async)?.jndiLocation}}</td>
-                            </tr>
-                        </table>
-                    </div>-->
-
-        <div class="panel panel-default panel-primary wuTechnologies">
-            <div class="panel-heading">
-                <h3 class="panel-title">Stateless Session Beans</h3>
-            </div>
-            <div class="panel-body">
-                <wu-all-data-filtered-message
-                        [filteredItems]="filteredEjbSessionStatelessBean"
-                        [unfilteredItems]="ejbSessionStatelessBean"
-                        (clearFilter)="clearSearch()"
-                        *ngIf="!loadingEJBStateless; else loadingData">
-                    <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatelessBean.length > 0; else noDataAvailable">
-                        <thead wu-sortable-table
-                               [(sortedData)]="sortedEjbSessionStatelessBean" [data]="filteredEjbSessionStatelessBean"
-                               [tableHeaders]="[
-                                { title: 'Bean Name', isSortable: true, sortBy: 'name' },
-                                { title: 'Interface', isSortable: true, sortBy: 'interface'},
-                                { title: 'Implementation', isSortable: true, sortBy: 'class'},
-                                { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
-                            ]">
-                        </thead>
-                        <tbody>
-                            <tr *ngFor="let value of this.sortedEjbSessionStatelessBean">
-                                <td class="col-md-2">{{value.name}}</td>
-                                <td class="col-md-2">{{value.interface}}</td>
-                                <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
-                                <td class="col-md-2">{{value.location}}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </wu-all-data-filtered-message>
-            </div>
-        </div>
-
-        <div class="panel panel-default panel-primary wuTechnologies">
-            <div class="panel-heading">
-                <h3 class="panel-title">Stateful Session Beans</h3>
-            </div>
-            <div class="panel-body">
-                <wu-all-data-filtered-message
-                        [filteredItems]="filteredEjbSessionStatefulBean"
-                        [unfilteredItems]="ejbSessionStatefulBean"
-                        (clearFilter)="clearSearch()"
-                        *ngIf="!loadingEJBStateful; else loadingData">
-                    <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatefulBean.length > 0; else noDataAvailable">
-                        <thead wu-sortable-table
-                               [(sortedData)]="sortedEjbSessionStatefulBean" [data]="filteredEjbSessionStatefulBean"
-                               [tableHeaders]="[
-                                { title: 'Bean Name', isSortable: true, sortBy: 'name' },
-                                { title: 'Interface', isSortable: true, sortBy: 'interface'},
-                                { title: 'Implementation', isSortable: true, sortBy: 'class'},
-                                { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
-                            ]">
-                        </thead>
-                        <tbody>
-                        <tr *ngFor="let value of this.sortedEjbSessionStatefulBean">
+                    </thead>
+                    <tbody>
+                        <tr *ngFor="let value of this.sortedEjbSessionStatelessBean">
                             <td class="col-md-2">{{value.name}}</td>
                             <td class="col-md-2">{{value.interface}}</td>
                             <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
                             <td class="col-md-2">{{value.location}}</td>
                         </tr>
-                        </tbody>
-                    </table>
-                </wu-all-data-filtered-message>
-            </div>
+                    </tbody>
+                </table>
+            </wu-all-data-filtered-message>
         </div>
+    </div>
 
-        <div class="panel panel-default panel-primary wuTechnologies">
-            <div class="panel-heading">
-                <h3 class="panel-title">Entity Beans</h3>
-            </div>
-            <div class="panel-body">
-                <wu-all-data-filtered-message
-                        [filteredItems]="filteredEjbEntityBean"
-                        [unfilteredItems]="ejbEntityBean"
-                        (clearFilter)="clearSearch()"
-                        *ngIf="!loadingEntity; else loadingData">
-                    <table class="table table-bordered table-hover" *ngIf="filteredEjbEntityBean.length > 0; else noDataAvailable">
-                        <thead wu-sortable-table
-                               [(sortedData)]="sortedEjbEntityBean" [data]="filteredEjbEntityBean"
-                               [tableHeaders]="[
-                                { title: 'Bean Name', isSortable: true, sortBy: 'name' },
-                                { title: 'Interface', isSortable: true, sortBy: 'interface'},
-                                { title: 'Implementation', isSortable: true, sortBy: 'class'},
-                                { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
-                            ]">
-                        </thead>
-                        <tbody>
-                        <tr *ngFor="let value of this.sortedEjbEntityBean">
-                            <td class="col-md-2">{{value.name}}</td>
-                            <td class="col-md-2">{{value.interface}}</td>
-                            <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
-                            <td class="col-md-2">{{value.location}}</td>
-                        </tr>
-                        </tbody>
-                    </table>
-
-                </wu-all-data-filtered-message>
-            </div>
+    <div class="panel panel-default panel-primary wuTechnologies">
+        <div class="panel-heading">
+            <h3 class="panel-title">Stateful Session Beans</h3>
         </div>
-    </ng-container>
-</div>
+        <div class="panel-body">
+            <wu-all-data-filtered-message
+                    [filteredItems]="filteredEjbSessionStatefulBean"
+                    [unfilteredItems]="ejbSessionStatefulBean"
+                    (clearFilter)="clearSearch()"
+                    *ngIf="!loadingEJBStateful; else loadingData">
+                <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatefulBean.length > 0; else noDataAvailable">
+                    <thead wu-sortable-table
+                           [(sortedData)]="sortedEjbSessionStatefulBean" [data]="filteredEjbSessionStatefulBean"
+                           [tableHeaders]="[
+                            { title: 'Bean Name', isSortable: true, sortBy: 'name' },
+                            { title: 'Interface', isSortable: true, sortBy: 'interface'},
+                            { title: 'Implementation', isSortable: true, sortBy: 'class'},
+                            { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
+                        ]">
+                    </thead>
+                    <tbody>
+                    <tr *ngFor="let value of this.sortedEjbSessionStatefulBean">
+                        <td class="col-md-2">{{value.name}}</td>
+                        <td class="col-md-2">{{value.interface}}</td>
+                        <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
+                        <td class="col-md-2">{{value.location}}</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </wu-all-data-filtered-message>
+        </div>
+    </div>
+
+    <div class="panel panel-default panel-primary wuTechnologies">
+        <div class="panel-heading">
+            <h3 class="panel-title">Entity Beans</h3>
+        </div>
+        <div class="panel-body">
+            <wu-all-data-filtered-message
+                    [filteredItems]="filteredEjbEntityBean"
+                    [unfilteredItems]="ejbEntityBean"
+                    (clearFilter)="clearSearch()"
+                    *ngIf="!loadingEntity; else loadingData">
+                <table class="table table-bordered table-hover" *ngIf="filteredEjbEntityBean.length > 0; else noDataAvailable">
+                    <thead wu-sortable-table
+                           [(sortedData)]="sortedEjbEntityBean" [data]="filteredEjbEntityBean"
+                           [tableHeaders]="[
+                            { title: 'Bean Name', isSortable: true, sortBy: 'name' },
+                            { title: 'Interface', isSortable: true, sortBy: 'interface'},
+                            { title: 'Implementation', isSortable: true, sortBy: 'class'},
+                            { title: 'JNDI Location', isSortable: true, sortBy: 'location'}
+                        ]">
+                    </thead>
+                    <tbody>
+                    <tr *ngFor="let value of this.sortedEjbEntityBean">
+                        <td class="col-md-2">{{value.name}}</td>
+                        <td class="col-md-2">{{value.interface}}</td>
+                        <td class="col-md-6"><a [routerLink]="['../source/' + value.sourceVertexId]">{{value.class}}</a></td>
+                        <td class="col-md-2">{{value.location}}</td>
+                    </tr>
+                    </tbody>
+                </table>
+
+            </wu-all-data-filtered-message>
+        </div>
+    </div>
+</ng-container>
+
 
 <ng-template #loadingData>
     <span>Loading...</span>

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.html
@@ -2,7 +2,7 @@
 
     <ng-container>
         <div class="header-bar">
-            <h2>Technologies &gt; <span style="color: #39a5dc;">EJB Report</span> </h2>
+            <h2>Technologies &gt; {{title}}</h2>
             <div class="search-and-create">
                 <div class="search-and-create"  *ngIf="true">
                     <wu-search [(searchValue)]="searchText" (searchValueChange)="updateSearch()"></wu-search>
@@ -18,7 +18,8 @@
                 <wu-all-data-filtered-message
                         [filteredItems]="filteredEjbMessageDriven"
                         [unfilteredItems]="ejbMessageDriven"
-                        (clearFilter)="clearSearch()">
+                        (clearFilter)="clearSearch()"
+                        *ngIf="!loadingMDB; else loadingData">
                     <table class="table table-bordered table-hover" *ngIf="filteredEjbMessageDriven.length > 0; else noDataAvailable">
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbMessageDriven" [data]="filteredEjbMessageDriven"
@@ -93,7 +94,8 @@
                 <wu-all-data-filtered-message
                         [filteredItems]="filteredEjbSessionStatelessBean"
                         [unfilteredItems]="ejbSessionStatelessBean"
-                        (clearFilter)="clearSearch()">
+                        (clearFilter)="clearSearch()"
+                        *ngIf="!loadingEJBStateless; else loadingData">
                     <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatelessBean.length > 0; else noDataAvailable">
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbSessionStatelessBean" [data]="filteredEjbSessionStatelessBean"
@@ -125,7 +127,8 @@
                 <wu-all-data-filtered-message
                         [filteredItems]="filteredEjbSessionStatefulBean"
                         [unfilteredItems]="ejbSessionStatefulBean"
-                        (clearFilter)="clearSearch()">
+                        (clearFilter)="clearSearch()"
+                        *ngIf="!loadingEJBStateful; else loadingData">
                     <table class="table table-bordered table-hover" *ngIf="filteredEjbSessionStatefulBean.length > 0; else noDataAvailable">
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbSessionStatefulBean" [data]="filteredEjbSessionStatefulBean"
@@ -157,7 +160,8 @@
                 <wu-all-data-filtered-message
                         [filteredItems]="filteredEjbEntityBean"
                         [unfilteredItems]="ejbEntityBean"
-                        (clearFilter)="clearSearch()">
+                        (clearFilter)="clearSearch()"
+                        *ngIf="!loadingEntity; else loadingData">
                     <table class="table table-bordered table-hover" *ngIf="filteredEjbEntityBean.length > 0; else noDataAvailable">
                         <thead wu-sortable-table
                                [(sortedData)]="sortedEjbEntityBean" [data]="filteredEjbEntityBean"
@@ -183,6 +187,10 @@
         </div>
     </ng-container>
 </div>
+
+<ng-template #loadingData>
+    <span>Loading...</span>
+</ng-template>
 
 <ng-template #noDataAvailable>
     <span>There are no beans of this type.</span>

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.scss
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.scss
@@ -1,0 +1,48 @@
+.header-bar {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.button-container {
+    padding-top: 15px;
+}
+
+.search-and-create {
+    display: flex;
+    flex-direction: row;
+}
+.technologyItems {
+    font-size: 0;
+    width: 100%;
+    clear: both;
+}
+
+.technologyItem {
+    font-size: small;
+    font-weight: bold;
+    padding-left: 2em;
+    padding-right: 2em;
+    margin: auto;
+    border-top: solid 1px;
+    border-bottom: 3px solid #734d00;
+    display: inline-block;
+}
+
+.technologies-table {
+    margin-top: 10px;
+}
+
+.technologiesStats td {
+    text-transform: capitalize;
+}
+
+.panel-primary.wuTechnologies { border-color: #e7e7e7; }
+.panel-primary.wuTechnologies .panel-heading { background-color: white; padding: 15px 15px; border-bottom: 2px solid #e7e7e7; }
+.panel-primary.wuTechnologies .panel-heading .panel-title { color: black; font-size: 20px; font-weight: 500; }
+
+:host /deep/ {
+    .search-and-create .search-component {
+        padding-top: 20px;
+    }
+}

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from "@angular/core";
 import {ActivatedRoute, Params, Router} from '@angular/router';
 
-import {EJBStatDTO, TechReportService} from "./tech-report.service";
+import {EJBInformationDTO, TechReportService} from "./tech-report.service";
 import {NotificationService} from "../../core/notification/notification.service";
 import {utils} from '../../shared/utils';
 import {Observable} from "rxjs/Observable";
@@ -19,23 +19,30 @@ export class TechnologiesEJBReportComponent extends FilterableReportComponent im
     private execID: number;
     private reportId: Observable<string>;
 
-    public ejbMessageDriven: EJBStatDTO[] = [];
-    public filteredEjbMessageDriven : EJBStatDTO[] = [];
-    public sortedEjbMessageDriven : EJBStatDTO[] = [];
+    public ejbMessageDriven: EJBInformationDTO[] = [];
+    public filteredEjbMessageDriven : EJBInformationDTO[] = [];
+    public sortedEjbMessageDriven : EJBInformationDTO[] = [];
 
-    public ejbSessionStatelessBean: EJBStatDTO[] = [];
-    public filteredEjbSessionStatelessBean: EJBStatDTO[] = [];
-    public sortedEjbSessionStatelessBean: EJBStatDTO[] = [];
+    public ejbSessionStatelessBean: EJBInformationDTO[] = [];
+    public filteredEjbSessionStatelessBean: EJBInformationDTO[] = [];
+    public sortedEjbSessionStatelessBean: EJBInformationDTO[] = [];
 
-    public ejbSessionStatefulBean: EJBStatDTO[] = [];
-    public filteredEjbSessionStatefulBean: EJBStatDTO[] = [];
-    public sortedEjbSessionStatefulBean: EJBStatDTO[] = [];
+    public ejbSessionStatefulBean: EJBInformationDTO[] = [];
+    public filteredEjbSessionStatefulBean: EJBInformationDTO[] = [];
+    public sortedEjbSessionStatefulBean: EJBInformationDTO[] = [];
 
-    public ejbEntityBean: EJBStatDTO[] = [];
-    public filteredEjbEntityBean: EJBStatDTO[] = [];
-    public sortedEjbEntityBean: EJBStatDTO[] = [];
+    public ejbEntityBean: EJBInformationDTO[] = [];
+    public filteredEjbEntityBean: EJBInformationDTO[] = [];
+    public sortedEjbEntityBean: EJBInformationDTO[] = [];
 
     public searchText: string;
+
+    public title: string;
+
+    public loadingMDB: boolean = true;
+    public loadingEJBStateless: boolean = true;
+    public loadingEJBStateful: boolean = true;
+    public loadingEntity: boolean = true;
 
     constructor(
         private route: ActivatedRoute,
@@ -55,6 +62,10 @@ export class TechnologiesEJBReportComponent extends FilterableReportComponent im
         this.route.params.forEach((params: Params) => {
             this.reportId = params['report_id'];
         });
+
+        let flatRouteData = this._routeFlattener.getFlattenedRouteData(this._activatedRoute.snapshot);
+        if (flatRouteData.data['displayName'])
+            this.title = flatRouteData.data['displayName'];
     }
 
     fetchEJBData(): void {
@@ -66,6 +77,8 @@ export class TechnologiesEJBReportComponent extends FilterableReportComponent im
                     this.ejbMessageDriven = value;
                     this.filteredEjbMessageDriven = this.ejbMessageDriven;
                     this.sortedEjbMessageDriven = this.ejbMessageDriven;
+                    this.updateSearch();
+                    this.loadingMDB  = false;
                 },
                 error => {
                     this._notificationService.error(utils.getErrorMessage(error));
@@ -78,6 +91,8 @@ export class TechnologiesEJBReportComponent extends FilterableReportComponent im
                     this.ejbSessionStatelessBean = value;
                     this.filteredEjbSessionStatelessBean = this.ejbSessionStatelessBean;
                     this.sortedEjbSessionStatelessBean = this.ejbSessionStatelessBean;
+                    this.updateSearch();
+                    this.loadingEJBStateless = false;
 
                 },
                 error => {
@@ -91,6 +106,8 @@ export class TechnologiesEJBReportComponent extends FilterableReportComponent im
                     this.ejbSessionStatefulBean = value;
                     this.filteredEjbSessionStatefulBean = this.ejbSessionStatefulBean;
                     this.sortedEjbSessionStatefulBean = this.ejbSessionStatefulBean;
+                    this.updateSearch();
+                    this.loadingEJBStateful = false;
                 },
                 error => {
                     this._notificationService.error(utils.getErrorMessage(error));
@@ -103,6 +120,8 @@ export class TechnologiesEJBReportComponent extends FilterableReportComponent im
                     this.ejbEntityBean = value;
                     this.filteredEjbEntityBean = this.ejbEntityBean;
                     this.sortedEjbEntityBean = this.ejbEntityBean;
+                    this.updateSearch();
+                    this.loadingEntity = false;
                 },
                 error => {
                     this._notificationService.error(utils.getErrorMessage(error));
@@ -139,7 +158,7 @@ export class TechnologiesEJBReportComponent extends FilterableReportComponent im
         this.updateSearch();
     }
 
-    filter(item:EJBStatDTO): boolean {
+    filter(item:EJBInformationDTO): boolean {
         return (
             item.name.search(new RegExp(this.searchText, 'i')) !== -1 ||
             item.class.search(new RegExp(this.searchText, 'i')) !== -1 ||

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.ts
@@ -5,13 +5,16 @@ import {EJBStatDTO, TechReportService} from "./tech-report.service";
 import {NotificationService} from "../../core/notification/notification.service";
 import {utils} from '../../shared/utils';
 import {Observable} from "rxjs/Observable";
+import {FilterableReportComponent} from "../filterable-report.component";
+import {RouteFlattenerService} from "../../core/routing/route-flattener.service";
+import {ReportFilter} from "../../generated/windup-services";
 
 @Component({
     selector: 'wu-technologies-report-ejb',
     templateUrl: 'technologies-report-ejb.component.html',
     styleUrls: ['./technologies-report-ejb.component.scss']
 })
-export class TechnologiesEJBReportComponent implements OnInit {
+export class TechnologiesEJBReportComponent extends FilterableReportComponent implements OnInit {
 
     private execID: number;
     private reportId: Observable<string>;
@@ -38,8 +41,11 @@ export class TechnologiesEJBReportComponent implements OnInit {
         private route: ActivatedRoute,
         private techReportService: TechReportService,
         private _notificationService: NotificationService,
-        private _router: Router
-    ){}
+        _router: Router,
+        _routeFlattener: RouteFlattenerService
+    ){
+        super(_router, route, _routeFlattener);
+    }
 
     ngOnInit(): void {
         this.route.parent.params.forEach((params: Params) => {
@@ -53,55 +59,57 @@ export class TechnologiesEJBReportComponent implements OnInit {
 
     fetchEJBData(): void {
 
-        this.techReportService.getEjbMessageDrivenModel(this.execID).subscribe(
-            value => {
-                this.ejbMessageDriven = value;
-                this.filteredEjbMessageDriven = this.ejbMessageDriven;
-                this.sortedEjbMessageDriven = this.ejbMessageDriven;
-            },
-            error => {
-                this._notificationService.error(utils.getErrorMessage(error));
-                this._router.navigate(['']);
-            }
-        );
+        this.addSubscription(this.flatRouteLoaded.subscribe(flatRouteData => {
+            this.loadFilterFromRouteData(flatRouteData);
+            this.techReportService.getEjbMessageDrivenModel(this.execID, this.reportFilter).subscribe(
+                value => {
+                    this.ejbMessageDriven = value;
+                    this.filteredEjbMessageDriven = this.ejbMessageDriven;
+                    this.sortedEjbMessageDriven = this.ejbMessageDriven;
+                },
+                error => {
+                    this._notificationService.error(utils.getErrorMessage(error));
+                    this._router.navigate(['']);
+                }
+            );
 
-        this.techReportService.getEjbSessionBeanModel(this.execID, 'Stateless').subscribe(
-            value => {
-                this.ejbSessionStatelessBean = value;
-                this.filteredEjbSessionStatelessBean = this.ejbSessionStatelessBean;
-                this.sortedEjbSessionStatelessBean = this.ejbSessionStatelessBean;
+            this.techReportService.getEjbSessionBeanModel(this.execID, 'Stateless', this.reportFilter).subscribe(
+                value => {
+                    this.ejbSessionStatelessBean = value;
+                    this.filteredEjbSessionStatelessBean = this.ejbSessionStatelessBean;
+                    this.sortedEjbSessionStatelessBean = this.ejbSessionStatelessBean;
 
-            },
-            error => {
-                this._notificationService.error(utils.getErrorMessage(error));
-                this._router.navigate(['']);
-            }
-        );
+                },
+                error => {
+                    this._notificationService.error(utils.getErrorMessage(error));
+                    this._router.navigate(['']);
+                }
+            );
 
-        this.techReportService.getEjbSessionBeanModel(this.execID, 'Stateful').subscribe(
-            value => {
-                this.ejbSessionStatefulBean = value;
-                this.filteredEjbSessionStatefulBean = this.ejbSessionStatefulBean;
-                this.sortedEjbSessionStatefulBean = this.ejbSessionStatefulBean;
-            },
-            error => {
-                this._notificationService.error(utils.getErrorMessage(error));
-                this._router.navigate(['']);
-            }
-        );
+            this.techReportService.getEjbSessionBeanModel(this.execID, 'Stateful', this.reportFilter).subscribe(
+                value => {
+                    this.ejbSessionStatefulBean = value;
+                    this.filteredEjbSessionStatefulBean = this.ejbSessionStatefulBean;
+                    this.sortedEjbSessionStatefulBean = this.ejbSessionStatefulBean;
+                },
+                error => {
+                    this._notificationService.error(utils.getErrorMessage(error));
+                    this._router.navigate(['']);
+                }
+            );
 
-        this.techReportService.getEjbEntityBeanModel(this.execID).subscribe(
-            value => {
-                this.ejbEntityBean = value;
-                this.filteredEjbEntityBean = this.ejbEntityBean;
-                this.sortedEjbEntityBean = this.ejbEntityBean;
-            },
-            error => {
-                this._notificationService.error(utils.getErrorMessage(error));
-                this._router.navigate(['']);
-            }
-        );
-
+            this.techReportService.getEjbEntityBeanModel(this.execID, this.reportFilter).subscribe(
+                value => {
+                    this.ejbEntityBean = value;
+                    this.filteredEjbEntityBean = this.ejbEntityBean;
+                    this.sortedEjbEntityBean = this.ejbEntityBean;
+                },
+                error => {
+                    this._notificationService.error(utils.getErrorMessage(error));
+                    this._router.navigate(['']);
+                }
+            );
+        }));
     }
 
     updateSearch() {

--- a/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.ts
+++ b/ui/src/main/webapp/src/app/reports/technologies/technologies-report-ejb.component.ts
@@ -1,0 +1,156 @@
+import {Component, OnInit} from "@angular/core";
+import {ActivatedRoute, Params, Router}   from '@angular/router';
+
+import {TechReportService, StatsItem} from "./tech-report.service";
+import {NotificationService} from "../../core/notification/notification.service";
+import {utils} from '../../shared/utils';
+import {ProjectTechnologiesStatsModel} from "../../generated/tsModels/ProjectTechnologiesStatsModel";
+import {forkJoin} from "rxjs/observable/forkJoin";
+import {ProjectModel} from "../../generated/tsModels/ProjectModel";
+import {FileModel} from "../../generated/tsModels/FileModel";
+import {TechnologyKeyValuePairModel} from "../../generated/tsModels/TechnologyKeyValuePairModel";
+import {FilterApplication, RegisteredApplication} from "../../generated/windup-services";
+import {EjbMessageDrivenModel} from "../../generated/tsModels/EjbMessageDrivenModel";
+import {Observable} from "rxjs/Observable";
+import {JavaClassFileModel} from "../../generated/tsModels/JavaClassFileModel";
+import {JavaClassModel} from "../../generated/tsModels/JavaClassModel";
+import {EjbSessionBeanModel} from "../../generated/tsModels/EjbSessionBeanModel";
+import {EjbEntityBeanModel} from "../../generated/tsModels/EjbEntityBeanModel";
+
+@Component({
+    selector: 'wu-technologies-report-ejb',
+    templateUrl: 'technologies-report-ejb.component.html',
+    styleUrls: ['./technologies-report-ejb.component.scss']
+})
+export class TechnologiesEJBReportComponent implements OnInit {
+
+    private execID: number;
+    private reportId: Observable<string>;
+
+    private ejbMessageDriven: EjbMessageDrivenModel[] = [];
+    private filteredEjbMessageDriven : EjbMessageDrivenModel[] = [];
+    private sortedEjbMessageDriven : EjbMessageDrivenModel[] = [];
+
+    private ejbSessionStatelessBean: EjbSessionBeanModel[] = [];
+    private filteredEjbSessionStatelessBean: EjbSessionBeanModel[] = [];
+    private sortedEjbSessionStatelessBean: EjbSessionBeanModel[] = [];
+
+    private ejbSessionStatefulBean: EjbSessionBeanModel[] = [];
+    private filteredEjbSessionStatefulBean: EjbSessionBeanModel[] = [];
+    private sortedEjbSessionStatefulBean: EjbSessionBeanModel[] = [];
+
+    private ejbEntityBean: EjbEntityBeanModel[] = [];
+    private filteredEjbEntityBean: EjbEntityBeanModel[] = [];
+    private sortedEjbEntityBean: EjbEntityBeanModel[] = [];
+
+    public searchText: string;
+
+    private fake: number = 0;
+
+    constructor(
+        private route: ActivatedRoute,
+        private techReportService: TechReportService,
+        private _notificationService: NotificationService,
+        private _router: Router
+    ){}
+
+    ngOnInit(): void {
+        this.route.parent.params.forEach((params: Params) => {
+            this.execID = +params['executionId'];
+            this.fetchEJBData();
+        });
+        this.route.params.forEach((params: Params) => {
+            this.reportId = params['report_id'];
+        });
+    }
+
+    fetchEJBData(): void {
+        this.techReportService.getEjbMessageDrivenModel(this.execID).subscribe(
+            value => {
+                this.ejbMessageDriven = value;
+                this.filteredEjbMessageDriven = this.ejbMessageDriven;
+                this.sortedEjbMessageDriven = this.ejbMessageDriven;
+            },
+            error => {
+                this._notificationService.error(utils.getErrorMessage(error));
+                this._router.navigate(['']);
+            }
+        );
+
+        this.techReportService.getEjbSessionBeanModel(this.execID, 'Stateless').subscribe(
+            value => {
+                this.ejbSessionStatelessBean = value;
+                this.filteredEjbSessionStatelessBean = this.ejbSessionStatelessBean;
+                this.sortedEjbSessionStatelessBean = this.ejbSessionStatelessBean;
+
+            },
+            error => {
+                this._notificationService.error(utils.getErrorMessage(error));
+                this._router.navigate(['']);
+            }
+        );
+
+        this.techReportService.getEjbSessionBeanModel(this.execID, 'Stateful').subscribe(
+            value => {
+                this.ejbSessionStatefulBean = value;
+                this.filteredEjbSessionStatefulBean = this.ejbSessionStatefulBean;
+                this.sortedEjbSessionStatefulBean = this.ejbSessionStatefulBean;
+            },
+            error => {
+                this._notificationService.error(utils.getErrorMessage(error));
+                this._router.navigate(['']);
+            }
+        );
+
+        this.techReportService.getEjbEntityBeanModel(this.execID).subscribe(
+            value => {
+                this.ejbEntityBean = value;
+                this.filteredEjbEntityBean = this.ejbEntityBean;
+                this.sortedEjbEntityBean = this.ejbEntityBean;
+            },
+            error => {
+                this._notificationService.error(utils.getErrorMessage(error));
+                this._router.navigate(['']);
+            }
+        );
+
+    }
+
+    updateSearch() {
+        if (this.searchText && this.searchText.length > 0) {
+            this.filteredEjbMessageDriven = this.ejbMessageDriven.filter(mdb => (
+                mdb.beanName.search(new RegExp(this.searchText, 'i')) !== -1)
+            );
+            this.filteredEjbSessionStatelessBean = this.ejbSessionStatelessBean.filter(ejb => (
+                ejb.beanName.search(new RegExp(this.searchText, 'i')) !== -1)
+            );
+            this.filteredEjbSessionStatefulBean = this.ejbSessionStatefulBean.filter(ejb => (
+                ejb.beanName.search(new RegExp(this.searchText, 'i')) !== -1)
+            );
+            this.filteredEjbEntityBean = this.ejbEntityBean.filter(ejb => (
+                ejb.beanName.search(new RegExp(this.searchText, 'i')) !== -1)
+            );
+        } else {
+            this.filteredEjbMessageDriven = this.ejbMessageDriven;
+            this.filteredEjbSessionStatelessBean = this.ejbSessionStatelessBean;
+            this.filteredEjbSessionStatefulBean = this.ejbSessionStatefulBean;
+            this.filteredEjbEntityBean = this.ejbEntityBean;
+        }
+    }
+
+    clearSearch() {
+        this.searchText = '';
+        this.updateSearch();
+    }
+
+
+
+    sortByQualifiedNameCallback = (item: EjbMessageDrivenModel) : string => {
+/*        item.ejbClass.subscribe( clazz => {
+            let qualifiedName = clazz.qualifiedName;
+            console.log(qualifiedName);
+            return qualifiedName;
+        });*/
+        return (this.fake++).toString();
+    };
+}

--- a/ui/src/main/webapp/src/app/services/graph.service.ts
+++ b/ui/src/main/webapp/src/app/services/graph.service.ts
@@ -29,10 +29,10 @@ export class GraphService extends AbstractService {
             .catch(this.handleError);
     }
 
-    protected getTypeAsArray<T extends BaseModel>(type: string, execID: number, options?: GraphEndpointOptions): Observable<T[]> {
+    protected getTypeAsArray<T extends BaseModel>(type: string, execID: number, options?: GraphEndpointOptions, propertyName?: string, propertyValue?: string, ): Observable<T[]> {
         let service = this._graphJsonToModelService;
 
-        return this.prepareGetRequest(type,execID, options)
+        return this.prepareGetRequest(type, execID, options, propertyName, propertyValue)
             .map(data => {
                 if (!Array.isArray(data)) {
                     throw new Error("No items returned");
@@ -42,11 +42,14 @@ export class GraphService extends AbstractService {
             });
     }
 
-    protected prepareGetRequest(type: string, execID: number, options?: GraphEndpointOptions): Observable<any> {
+    protected prepareGetRequest(type: string, execID: number, options?: GraphEndpointOptions, propertyName?: string, propertyValue?: string): Observable<any> {
         let params: URLSearchParams = new URLSearchParams();
         let url = GraphService.GRAPH_ENDPOINT_URL
             .replace('{execID}', execID.toString())
             .replace('{type}', type);
+        if (propertyName) {
+            url += '/' + propertyName + '=' + propertyValue;
+        }
 
         Object.keys(options).forEach(key => {
             params.set(key, options[key]);

--- a/ui/src/main/webapp/src/app/services/graph.service.ts
+++ b/ui/src/main/webapp/src/app/services/graph.service.ts
@@ -11,7 +11,7 @@ export class GraphService extends AbstractService {
     private static WINDUP_REST_URL = Constants.GRAPH_REST_BASE;
     private static GRAPH_ENDPOINT_URL = `${GraphService.WINDUP_REST_URL}/graph/{execID}/by-type/{type}`;
 
-    constructor(private _http: Http, private _graphJsonToModelService: GraphJSONToModelService<any>) {
+    constructor(protected _http: Http, protected _graphJsonToModelService: GraphJSONToModelService<any>) {
         super();
     }
 

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu-item.class.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu-item.class.ts
@@ -138,10 +138,12 @@ export class ApplicationReportMenuItem extends ReportMenuItem {
         project: MigrationProject,
         execution: WindupExecution,
         application: any,
-        report: string
+        report: string,
+        innerMenuItem?: ContextMenuItemInterface[]
     ) {
         super(label, icon, project, execution, report);
         this.application = application;
+        this._innerMenuItem = innerMenuItem;
     }
 
     get link(): string {

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu-item.class.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu-item.class.ts
@@ -11,6 +11,7 @@ export interface ContextMenuItemInterface {
     target?: string;
     absolute?: boolean;
     isActive?: any|boolean|Function;
+    innerMenuItem?: ContextMenuItemInterface[];
 }
 
 export class ContextMenuItem implements ContextMenuItemInterface {
@@ -22,6 +23,7 @@ export class ContextMenuItem implements ContextMenuItemInterface {
     protected _data?: any;
     protected _target?: string;
     protected _absolute?: boolean;
+    protected _innerMenuItem?: ContextMenuItemInterface[];
 
     constructor(label: string,
                 icon: string,
@@ -29,7 +31,8 @@ export class ContextMenuItem implements ContextMenuItemInterface {
                 link?: string, action?:Function,
                 data?: any,
                 target?: string,
-                absolute?: boolean)
+                absolute?: boolean,
+                innerMenuItem?: ContextMenuItemInterface[])
     {
         this._label = label;
         this._link = link;
@@ -39,6 +42,7 @@ export class ContextMenuItem implements ContextMenuItemInterface {
         this._data = data;
         this._target = target;
         this._absolute = (typeof absolute == "undefined") ? false : absolute;
+        this._innerMenuItem = innerMenuItem;
     }
 
     get label(): string {
@@ -79,6 +83,10 @@ export class ContextMenuItem implements ContextMenuItemInterface {
     get absolute(): boolean {
         return this._absolute;
     }
+
+    get innerMenuItem(): ContextMenuItemInterface[] {
+        return this._innerMenuItem;
+    }
 }
 
 export class ReportMenuItem extends ContextMenuItem {
@@ -86,11 +94,12 @@ export class ReportMenuItem extends ContextMenuItem {
     protected execution: WindupExecution;
     protected report: string;
 
-    constructor(label: string, icon: string, project: MigrationProject, execution: WindupExecution, report: string) {
+    constructor(label: string, icon: string, project: MigrationProject, execution: WindupExecution, report: string, innerMenuItem?: ContextMenuItemInterface[]) {
         super(label, icon);
         this.project = project;
         this.execution = execution;
         this.report = report;
+        this._innerMenuItem = innerMenuItem;
     }
 
     protected getExecutionLink(): any[] {

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu-link.component.ts
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu-link.component.ts
@@ -21,11 +21,32 @@ import {ContextMenuItemInterface} from "./context-menu-item.class";
     template: `
             <a *ngIf="item.action" (click)="click(item)"><ng-content></ng-content></a>
             <a *ngIf="!item.absolute" [routerLink]="getLink(item)"><ng-content select="[router-mode]"></ng-content></a>
+            <div *ngIf="!item.absolute && item.innerMenuItem && item.innerMenuItem.length > 0" id="-secondary" class="nav-pf-secondary-nav">
+                <div class="nav-item-pf-header">
+                    <a class="secondary-collapse-toggle-pf"></a>
+                    <span>{{item.label}}</span>
+                </div>
+                <ul class="list-group">
+                    <li *ngFor="let secondLevelMenuItem of getEnabled(item.innerMenuItem)"
+                        class="list-group-item" >
+                        <a [routerLink]="[secondLevelMenuItem.link]">
+                            <span class="list-group-item-value">{{secondLevelMenuItem.label}}</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
             <a *ngIf="item.absolute" [href]="item.link" [target]="item.target"><ng-content select="[absolute-mode]"></ng-content></a>`,
     selector: '[wu-context-menu-link]',
     changeDetection: ChangeDetectionStrategy.OnPush,
     styles: [
-        `a:focus { text-decoration: none; }`
+        `a:focus { text-decoration: none; }
+
+        /deep/ .nav-pf-vertical .list-group-item:hover .nav-pf-secondary-nav{
+            opacity: 0.97;
+            visibility: visible;
+            left: 239px;
+            top: 121px;
+        }`
     ]
 })
 export class ContextMenuLinkComponent {
@@ -44,6 +65,10 @@ export class ContextMenuLinkComponent {
         } else {
             return item.link;
         }
+    }
+
+    getEnabled(items: ContextMenuItemInterface[]) : ContextMenuItemInterface[] {
+        return items.filter(item => item.isEnabled);
     }
 
 }

--- a/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
+++ b/ui/src/main/webapp/src/app/shared/navigation/context-menu.component.html
@@ -7,6 +7,7 @@
             [activeClasses]="['active']"
             [wuRouterLink]="item.link"
             [wuContextMenuItem]="item"
+            [ngClass]="{'secondary-nav-item-pf': (item.innerMenuItem && item.innerMenuItem.length > 0)}"
         >
             <span class="fa" ngClass="{{item.icon}}" data-toggle="tooltip" title="" [attr.data-original-title]="item.label" router-mode></span>
             <span class="list-group-item-value" router-mode>{{item.label}}</span>


### PR DESCRIPTION
**Changes**
* enable `Tecnologies` entry in left nav bar both at analysis and application level
* add 2nd level menu on left nav bar (`isEnable` field is working for showing/hiding entries)
* add `EJB report` (with [other table layouts commented](https://github.com/windup/windup-web/compare/master...mrizzi:JIRA_WINDUP-1578?expand=1#diff-ef17ccf18496515ea6cd211fe828e92fR43)) with new dedicated methods in `tech-report.service.ts` to retrieve data from graph
* add in `graph.service.ts` the property name and value handling to call the `/{executionID}/by-type/{vertexType}/{propertyName}={propertyValue}` service to retrieve separately `Stateless` and `Stateful` EJBs
* change `Source code` page to have the standard layout for header and spacing from nav bars

**To fix**
- [x] source link for XML is in the `Bean Name` column (solved in 0732c34)
- [x] search in all the columns (solved in 0732c34)
- [x] `EJB report` not working at application level
- [ ] `Technologies` entry in nav bar is not `active` when EJB report is displayed
- [x] sorting by function is not working yet (see commented code in [`sortByQualifiedNameCallback`](https://github.com/windup/windup-web/pull/496/files#diff-6d5fc7cbe640ea91cc67c46e1c6376e9R148))
- [ ] URL `/technology-report/ejb` in `reports-routing.module.ts` is not working (`Error: Cannot find primary outlet to load 'TechnologiesEJBReportComponent'
Error: Cannot find primary outlet to load 'TechnologiesEJBReportComponent'`)

**To discuss**
* does search in source code make sense?