### PR TITLE
WINDUP-1598 - Fix execution id NaN exceptions.

### DIFF
--- a/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.ts
+++ b/ui/src/main/webapp/src/app/reports/execution-application-list/execution-application-list.component.ts
@@ -19,7 +19,7 @@ import {utils} from "../../shared/utils";
         '../../../../css/tables.scss'
     ]
 })
-export class ExecutionApplicationListComponent extends RoutedComponent implements OnInit, OnDestroy
+export class ExecutionApplicationListComponent extends RoutedComponent implements OnInit
 {
     private projectID: number;
     private execID: number;
@@ -71,9 +71,6 @@ export class ExecutionApplicationListComponent extends RoutedComponent implement
             },
             error => this._notificationService.error(utils.getErrorMessage(error))
         );
-    }
-
-    ngOnDestroy() {
     }
 
     updateSearch() {


### PR DESCRIPTION
Problem was with `ExecutionApplicationListComponent` making requests after route-change event received on `this.flatRouteLoaded.subscribe` Observable. 

When leaving this component, route events should not be received anymore. Cause was empty `ngOnDestroy` method which shadowed inherited one.