### PR TITLE
WINDUP-1558: adding findbugs profile to check staticaly java source code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
                 <plugin>
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
-                    <version>1.1.0.Final</version>
+                    <version>1.2.0.Final</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
-
+        <version.findbugs.plugin>3.0.5</version.findbugs.plugin>
         <version.forge>3.6.0.Final</version.forge>
         <version.furnace>2.25.4.Final</version.furnace>
         <version.windup>4.0.0-SNAPSHOT</version.windup>
@@ -243,5 +243,48 @@
                 <module>tools/graph-tool</module>
             </modules>
         </profile>
+
+        <!-- profile primary for CI, but using locally is good too -->
+        <profile>
+            <id>findbugs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <version>${version.findbugs.plugin}</version>
+                        <configuration>
+                            <!--
+                                Enables analysis which takes more memory but finds more bugs.
+                                If you run out of memory, changes the value of the effort element
+                                to 'Low'.
+                            -->
+                            <effort>Max</effort>
+                            <!-- Build doesn't fail if problems are found -->
+                            <failOnError>false</failOnError>
+                            <!-- Reports all bugs (other values are medium and max) -->
+                            <threshold>Low</threshold>
+                            <!-- Produces XML report -->
+                            <xmlOutput>true</xmlOutput>
+                            <!-- Configures the directory in which the XML report is created -->
+                            <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
+                            <onlyAnalyze>org.jboss.windup.*</onlyAnalyze>
+                            <maxHeap>1024</maxHeap>
+                        </configuration>
+                        <executions>
+                            <!-- Ensures that FindBugs inspects source code when project is compiled.-->
+                            <execution>
+                                <id>analyze-compile</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 </project>

--- a/tests/e2e/pom.xml
+++ b/tests/e2e/pom.xml
@@ -13,13 +13,11 @@
     </parent>
 
     <artifactId>windup-tests-e2e</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
 
     <name>Windup Web - Tests E2E</name>
     <packaging>pom</packaging>
 
     <properties>
-        <version.wildfly.maven.plugin>1.1.0.Beta1</version.wildfly.maven.plugin>
         <wildfly.directory>wildfly-10.1.0.Final</wildfly.directory>
         <wildfly.port>10090</wildfly.port>
     </properties>
@@ -55,11 +53,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
                     <version>1.6.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.wildfly.plugins</groupId>
-                    <artifactId>wildfly-maven-plugin</artifactId>
-                    <version>${version.wildfly.maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -159,6 +152,7 @@
                             <goal>execute-commands</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <jbossHome>${project.build.directory}/${wildfly.directory}</jbossHome>
                             <serverConfig>standalone-full.xml</serverConfig>
                             <stdout>${project.build.directory}/jboss.stdout</stdout>
@@ -181,6 +175,7 @@
                             <goal>shutdown</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <port>${wildfly.port}</port>
                             <jbossHome>${project.build.directory}/${wildfly.directory}</jbossHome>
                             <serverConfig>standalone-full.xml</serverConfig>
@@ -201,6 +196,7 @@
                         </goals>
 
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <executable>yarn</executable>
                             <workingDirectory>${project.build.directory}/npm</workingDirectory>
                             <arguments>
@@ -225,6 +221,7 @@
                         </goals>
 
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <executable>yarn</executable>
                             <workingDirectory>${project.build.directory/npm}</workingDirectory>
                             <arguments>
@@ -246,6 +243,7 @@
 
 
                         <configuration>
+                            <skip>${skipTests}</skip>
                             <executable>./node_modules/protractor/bin/protractor</executable>
                             <workingDirectory>${project.build.directory}/npm</workingDirectory>
                             <arguments>

--- a/tsmodelsgen-invocation/pom.xml
+++ b/tsmodelsgen-invocation/pom.xml
@@ -8,6 +8,7 @@
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
         <version>22</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.jboss.windup.web.ui</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-1558

some conflicts between xml-maven-plugin and wildfly-maven-plugin in e2e tests - so commented the html report generation for now