### PR TITLE
WINDUP-1661: Analysis details disabled progress bar when analysis is queued

### DIFF
--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -4,7 +4,7 @@
 <div *ngIf="execution">
     <h2 i18n="Heading|Analysis Page">Analysis #{{execution.id}}</h2>
 
-    <div *ngIf="execution.state === 'QUEUED' || execution.state === 'STARTED'">
+    <div *ngIf="execution.state === 'STARTED'">
         <wu-progress-bar
                 [taskName]="execution.currentTask"
                 [currentValue]="execution.workCompleted"
@@ -12,6 +12,9 @@
                 [maxValue]="execution.totalWork"
                 [activeExecutionId]="execution.id">
         </wu-progress-bar>
+    </div>
+    <div *ngIf="execution.state === 'QUEUED'">
+        The analysis is queued for {{currentTime - execution.timeStarted | wuDuration}}
     </div>
 
     <wu-tab-container>

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
@@ -22,6 +22,8 @@ export class ExecutionDetailComponent extends RoutedComponent implements OnInit 
     execution: WindupExecution;
     logLines: string[];
     phases: ExecutionPhaseModel[];
+    private currentTimeTimer: number;
+    currentTime: number = new Date().getTime();
 
     hideUnfinishedFeatures: boolean = WINDUP_WEB.config.hideUnfinishedFeatures;
 
@@ -57,6 +59,10 @@ export class ExecutionDetailComponent extends RoutedComponent implements OnInit 
                     });
             });
         }));
+
+        this.currentTimeTimer = <any> setInterval(() => {
+            this.currentTime = new Date().getTime();
+        }, 5000);
     }
 
     get loglines(): Observable<string[]> {


### PR DESCRIPTION
Now, in the analysis details page, when the analysis is queued, for consistency with analysis list page, there's no more the progress bar but a label indicating how long the analysis is queued.