### PR TITLE
Fix active execution monitoring

### DIFF
--- a/ui/src/main/webapp/src/app/executions/all-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/all-executions.component.ts
@@ -24,6 +24,7 @@ export class AllExecutionsComponent extends ExecutionsMonitoringComponent implem
     }
 
     ngOnInit(): void {
+        super.ngOnInit();
         this.loadExecutions();
 
         this.addSubscription(this._eventBus.onEvent.filter(event => event.isTypeOf(ExecutionEvent))

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
@@ -10,12 +10,13 @@ import {ExecutionEvent} from "../core/events/windup-event";
 import {Observable} from "rxjs";
 import {RuleProviderExecutionsService} from "./rule-provider-executions/rule-provider-executions.service";
 import {ExecutionPhaseModel} from "../generated/tsModels/ExecutionPhaseModel";
+import {ExecutionsMonitoringComponent} from "./executions-monitoring.component";
 
 @Component({
     templateUrl: './execution-detail.component.html',
     styleUrls: ['./execution-detail.component.scss']
 })
-export class ExecutionDetailComponent implements OnInit {
+export class ExecutionDetailComponent extends ExecutionsMonitoringComponent implements OnInit {
 
     execution: WindupExecution;
     logLines: string[];
@@ -23,10 +24,18 @@ export class ExecutionDetailComponent implements OnInit {
 
     hideUnfinishedFeatures: boolean = WINDUP_WEB.config.hideUnfinishedFeatures;
 
-    constructor(private _activatedRoute: ActivatedRoute, private _eventBus: EventBusService, private _windupService: WindupService, private _ruleProviderExecutionsService: RuleProviderExecutionsService) {
+    constructor(
+        private _activatedRoute: ActivatedRoute,
+        private _eventBus: EventBusService,
+        private _windupService: WindupService,
+        private _ruleProviderExecutionsService: RuleProviderExecutionsService,
+        _windupExecutionService: WindupExecutionService) {
+        super(_windupExecutionService);
     }
 
     ngOnInit(): void {
+        super.ngOnInit();
+
         this._activatedRoute.params.subscribe((params: {executionId: number}) => {
             let executionId = +params.executionId;
 

--- a/ui/src/main/webapp/src/app/executions/executions-monitoring.component.ts
+++ b/ui/src/main/webapp/src/app/executions/executions-monitoring.component.ts
@@ -2,14 +2,19 @@ import {MigrationProject, WindupExecution} from "../generated/windup-services";
 import {AbstractComponent} from "../shared/AbstractComponent";
 import {WindupExecutionService} from "../services/windup-execution.service";
 import {ExecutionEvent} from "../core/events/windup-event";
+import {OnDestroy, OnInit} from "@angular/core";
 
-export abstract class ExecutionsMonitoringComponent extends AbstractComponent {
+export abstract class ExecutionsMonitoringComponent extends AbstractComponent implements OnDestroy, OnInit {
     protected activeExecutionsMap: Map<number, WindupExecution> = new Map<number, WindupExecution>();
     activeExecutions: WindupExecution[];
     public project: MigrationProject;
 
     public constructor(protected _windupExecutionService: WindupExecutionService) {
         super();
+    }
+
+    ngOnInit(): void {
+        this._windupExecutionService.startMonitoring();
     }
 
     protected loadActiveExecutions(executions: WindupExecution[]) {
@@ -38,5 +43,10 @@ export abstract class ExecutionsMonitoringComponent extends AbstractComponent {
             this.activeExecutionsMap.delete(event.execution.id);
             this.updateActiveExecutions();
         }
+    }
+
+    ngOnDestroy(): void {
+        super.ngOnDestroy();
+        this._windupExecutionService.stopMonitoring();
     }
 }

--- a/ui/src/main/webapp/src/app/executions/project-executions.component.ts
+++ b/ui/src/main/webapp/src/app/executions/project-executions.component.ts
@@ -33,6 +33,8 @@ export class ProjectExecutionsComponent extends ExecutionsMonitoringComponent im
     }
 
     ngOnInit(): void {
+        super.ngOnInit();
+
         this._activatedRoute.parent.data.subscribe((data: {project: MigrationProject}) => {
             this.project = data.project;
 

--- a/ui/src/main/webapp/src/app/registered-application/application-list.component.ts
+++ b/ui/src/main/webapp/src/app/registered-application/application-list.component.ts
@@ -22,7 +22,7 @@ import {WindupService} from "../services/windup.service";
         './application-list.component.scss'
     ]
 })
-export class ApplicationListComponent extends ExecutionsMonitoringComponent implements OnInit, OnDestroy, AfterViewInit
+export class ApplicationListComponent extends ExecutionsMonitoringComponent implements OnInit, AfterViewInit
 {
     public filteredApplications: RegisteredApplication[] = [];
     public sortedApplications: RegisteredApplication[] = [];
@@ -93,9 +93,6 @@ export class ApplicationListComponent extends ExecutionsMonitoringComponent impl
         this.project.applications = this.project.applications.filter(app => {
            return !event.applications.includes(app);
         });
-    }
-
-    ngOnDestroy() {
     }
 
     registerApplication() {


### PR DESCRIPTION
Stop monitoring when user leaves analysis list page.

This should fix WINDUP-1664 https://issues.jboss.org/browse/WINDUP-1664

Note: Relevant only for 4.0.x branch, since in master we already use websockets.