### PR TITLE
Fix for issue with exceptions after deleting a closed graph

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphCache.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphCache.java
@@ -1,0 +1,30 @@
+package org.jboss.windup.web.addons.websupport.rest.graph;
+
+import org.jboss.windup.graph.GraphContext;
+
+import java.nio.file.Path;
+
+/**
+ *
+ * Maintains a graph connection pool.
+ *
+ * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
+ */
+public interface GraphCache {
+    /**
+     * Gets the given graph from the cache, opening it if needed.
+     *
+     * @param graphPath
+     * @param create
+     * @return
+     */
+    GraphContext getGraph(Path graphPath, boolean create);
+
+    /**
+     * Closes the specified graph.
+     *
+     * @param graphPath
+     */
+    void closeGraph(Path graphPath);
+
+}

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphCacheImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphCacheImpl.java
@@ -27,7 +27,7 @@ import org.jboss.windup.graph.GraphListener;
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
 @Singleton
-public class GraphCache
+public class GraphCacheImpl implements GraphCache
 {
     protected static final long MAX_AGE = 1000L * 60L * 10L;
     private static Logger LOG = Logger.getLogger(GraphCache.class.getName());
@@ -71,7 +71,7 @@ public class GraphCache
             @Override
             public void beforeStop(Furnace furnace) throws ContainerException
             {
-                GraphCache.this.cleanup();
+                GraphCacheImpl.this.cleanup();
             }
 
             @Override
@@ -107,6 +107,7 @@ public class GraphCache
      * Gets the graph at the given {@link Path}. This will be from the cache if possible. If a cached entry is not available, then a new one will be
      * loaded.
      */
+    @Override
     public GraphContext getGraph(Path graphPath, boolean create)
     {
         GraphCacheEntry graphCacheEntry = graphCacheEntryMap.get(graphPath);
@@ -126,6 +127,7 @@ public class GraphCache
     /**
      * If a graph is open for this path, insure that it is closed.
      */
+    @Override
     public void closeGraph(Path graphPath)
     {
         GraphCacheEntry cacheEntry = graphCacheEntryMap.get(graphPath);

--- a/addons/web-support/impl/src/test/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphCacheTest.java
+++ b/addons/web-support/impl/src/test/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphCacheTest.java
@@ -50,9 +50,9 @@ public class GraphCacheTest
         return this.graphContextFactory;
     }
 
-    private GraphCache getGraphCache()
+    private GraphCacheImpl getGraphCache()
     {
-        GraphCache graphCache = new GraphCache();
+        GraphCacheImpl graphCache = new GraphCacheImpl();
 
         GraphContextFactory graphContextFactory = getGraphContextFactory();
         graphCache.graphContextFactory = graphContextFactory;
@@ -84,14 +84,14 @@ public class GraphCacheTest
     @Test
     public void testPurgeFromCache()
     {
-        GraphCache cache = getGraphCache();
+        GraphCacheImpl cache = getGraphCache();
         GraphContext graph1 = cache.getGraph(Paths.get("/path1"), false);
         Assert.assertTrue(getGraphContext1() == graph1);
 
         GraphContext graph2 = cache.getGraph(Paths.get("/path2"), false);
         Assert.assertTrue(getGraphContext2() == graph2);
 
-        cache.graphCacheEntryMap.get(Paths.get("/path1")).lastUsageTime = System.currentTimeMillis() - (2*GraphCache.MAX_AGE);
+        cache.graphCacheEntryMap.get(Paths.get("/path1")).lastUsageTime = System.currentTimeMillis() - (2*GraphCacheImpl.MAX_AGE);
         cache.purgeOldCachedGraphs();
 
         // Confirm that this grabs the cached one


### PR DESCRIPTION
Steps to reproduce the bug on master:

- Run an analysis
- Delete the analysis
- Observe the server log - within a minute or two exceptions should start to repeatedly appear

If this doesn't work, then view a dynamic report between steps 1 and 2.