### PR TITLE
prepare for next release

### DIFF
--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.windup.web.addons</groupId>

--- a/addons/web-support/addon/pom.xml
+++ b/addons/web-support/addon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web.addons</groupId>
         <artifactId>windup-web-support-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-support</artifactId>

--- a/addons/web-support/api/pom.xml
+++ b/addons/web-support/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web.addons</groupId>
         <artifactId>windup-web-support-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-support-api</artifactId>

--- a/addons/web-support/impl/pom.xml
+++ b/addons/web-support/impl/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web.addons</groupId>
         <artifactId>windup-web-support-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-support-impl</artifactId>

--- a/addons/web-support/pom.xml
+++ b/addons/web-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web.addons</groupId>
         <artifactId>windup-web-addons</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-support-parent</artifactId>

--- a/addons/web-support/tests/pom.xml
+++ b/addons/web-support/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web.addons</groupId>
         <artifactId>windup-web-support-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-support-tests</artifactId>

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>rhamt-ear</artifactId>

--- a/furnace-service-provider/pom.xml
+++ b/furnace-service-provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>furnace-service-provider</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.jboss.windup.web</groupId>
     <artifactId>windup-web-parent</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Windup Web - Parent</name>
@@ -24,7 +24,7 @@
 
         <version.forge>3.6.0.Final</version.forge>
         <version.furnace>2.25.4.Final</version.furnace>
-        <version.windup>4.1.0-SNAPSHOT</version.windup>
+        <version.windup>4.0.1-SNAPSHOT</version.windup>
         <version.keycloak>2.1.0.Final</version.keycloak>
         <version.resteasy>3.0.19.Final</version.resteasy>
         <version.jboss.javaee>1.0.3.Final</version.jboss.javaee>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-tests-parent</artifactId>

--- a/tests/test-authentication-client/pom.xml
+++ b/tests/test-authentication-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-tests-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-authentication-client</artifactId>

--- a/tests/wildfly-dist/pom.xml
+++ b/tests/wildfly-dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-tests-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-tests-wildfly-dist</artifactId>

--- a/tsmodelsgen-invocation/pom.xml
+++ b/tsmodelsgen-invocation/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.jboss.windup.web.ui</groupId>
     <artifactId>windup-web-ui-tsmodels</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
 
     <name>Windup Web - Generate TS Models</name>
 
@@ -33,7 +33,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <version.windup.core>4.1.0-SNAPSHOT</version.windup.core>
+        <version.windup.core>4.0.1-SNAPSHOT</version.windup.core>
         <!-- For now, we need to pass this to the Mojo explicitly (through META-INF/versions.properties),
              but it should be possible to figure that out from the Windup POM. -->
         <version.forge>3.6.0.Final</version.forge>

--- a/tsmodelsgen-maven-plugin/pom.xml
+++ b/tsmodelsgen-maven-plugin/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.jboss.windup.web.plugin</groupId>
     <artifactId>windup-tsmodelsgen-maven-plugin</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Windup Web - TS Model Generator Maven Plugin</name>
@@ -28,7 +28,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <version.windup.core>4.1.0-SNAPSHOT</version.windup.core>
+        <version.windup.core>4.0.1-SNAPSHOT</version.windup.core>
         <!-- this property is used in the code too, DO NOT REMOVE IT! -->
         <version.windup.web>${project.version}</version.windup.web>
         <!-- For now, we need to pass this to the Mojo explicitly (through META-INF/versions.properties),

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss.windup.web</groupId>
         <artifactId>windup-web-parent</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>windup-web-ui</artifactId>


### PR DESCRIPTION
changed artifact version from `4.1.0-SNAPSHOT` to `4.0.1-SNAPSHOT` and consistently also `<version.windup>` tag.
done using `mvn --batch-mode release:update-versions -DdevelopmentVersion=4.0.1-SNAPSHOT` command from the [maven-release-plugin](http://maven.apache.org/maven-release/maven-release-plugin/examples/update-versions.html#)