### PR TITLE
WINDUP-1894: unable to delete project with analysis context referring…

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/service/MigrationProjectService.java
+++ b/services/src/main/java/org/jboss/windup/web/services/service/MigrationProjectService.java
@@ -151,7 +151,11 @@ public class MigrationProjectService
         // removing all packages from packageMetadata due FK
 
         // First, clear them from the analysis contexts
-        this.getAnalysisContexts(project).forEach(context -> context.setApplications(Collections.emptySet()));
+        this.getAnalysisContexts(project).forEach(context -> {
+            context.setApplications(Collections.emptySet());
+            context.setIncludePackages(Collections.emptySet());
+            context.setExcludePackages(Collections.emptySet());
+        });
         project.getApplications().forEach( application -> {
             application.getPackageMetadata().setPackages(Collections.emptySet());
             entityManager.remove(application);


### PR DESCRIPTION
… to path in pre-deleted application

This is the 4.0.x backport of: https://github.com/windup/windup-web/pull/560
