### PR TITLE
WINDUP-1676 Log to web ui when rule providers fails to load a rule

### DIFF
--- a/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/MessagingProgressMonitor.java
+++ b/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/MessagingProgressMonitor.java
@@ -5,7 +5,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
-import javax.persistence.Column;
 
 import org.jboss.windup.exec.WindupProgressMonitor;
 import org.jboss.windup.web.services.model.ExecutionState;

--- a/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/MessagingProgressMonitor.java
+++ b/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/MessagingProgressMonitor.java
@@ -5,6 +5,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.inject.Inject;
+import javax.persistence.Column;
 
 import org.jboss.windup.exec.WindupProgressMonitor;
 import org.jboss.windup.web.services.model.ExecutionState;
@@ -116,6 +117,7 @@ public class MessagingProgressMonitor implements WindupProgressMonitor
     @Override
     public void setTaskName(String name)
     {
+        if (name.length() > 1024) name = name.substring(0, 1024);
         execution.setCurrentTask(name);
         sendUpdate(execution);
 

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/services/WindupExecutorServiceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/services/WindupExecutorServiceImpl.java
@@ -124,6 +124,11 @@ public class WindupExecutorServiceImpl implements WindupExecutorService
 
             processor.execute(configuration);
         }
+        catch (Exception ex)
+        {
+            progressMonitor.setTaskName("Exception during processing - " + ex.getMessage());
+            throw ex;
+        }
         finally
         {
             graphCache.closeGraph(graphPath);

--- a/model/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
@@ -80,7 +80,7 @@ public class WindupExecution implements Serializable
     @Column(name = "work_completed")
     private int workCompleted;
 
-    @Column(name = "current_task")
+    @Column(name = "current_task", length = 1024)
     private String currentTask;
 
     @Column(name = "last_modified")


### PR DESCRIPTION
When rule provider fails to load a rule, the message is displayed in the execution log tab in the analysis details.

![screenshot from 2018-03-16 19-37-23](https://user-images.githubusercontent.com/7288588/37538971-9b965360-2952-11e8-92f2-6f88c4e6f56e.png)
