### PR TITLE
WINDUP-1670: Handle non-existent routes

### DIFF
--- a/ui/src/main/webapp/src/app/app-routing.module.ts
+++ b/ui/src/main/webapp/src/app/app-routing.module.ts
@@ -21,6 +21,7 @@ import {ProjectExecutionsComponent} from "./executions/project-executions.compon
 import {WizardLayoutComponent} from "./shared/layout/wizard-layout.component";
 import {AboutPageComponent} from "./misc/about.component";
 import {LogoutGuard} from "./core/authentication/logout.guard";
+import {NgModule} from "@angular/core";
 
 export const appRoutes: Routes = [
     // Authenticated routes
@@ -128,6 +129,10 @@ export const appRoutes: Routes = [
         path: 'logout',
         canActivate: [LogoutGuard],
         component: DefaultLayoutComponent
+    },
+    {
+        path: '**',  // The wildcard route pushes the user to the main page if there is no match
+        redirectTo: '/project-list'
     }
 ];
 
@@ -135,12 +140,15 @@ export function getProjectBreadcrumbTitle(route: FullFlattenedRoute) {
     return `Project ${route.data['project'].title}`;
 }
 
-export const appRoutingProviders: any[] = [
-
-];
-
-export const routing = RouterModule.forRoot(appRoutes);
-
-export function getWizardStepUrl() {
-
-}
+@NgModule({
+    imports: [
+        RouterModule.forRoot(
+            appRoutes,
+            { enableTracing: false } // <-- Set to true to debug routing
+        )
+    ],
+    exports: [
+        RouterModule
+    ]
+})
+export class AppRoutingModule {}

--- a/ui/src/main/webapp/src/app/app.module.ts
+++ b/ui/src/main/webapp/src/app/app.module.ts
@@ -5,7 +5,7 @@ import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {DatePipe} from "@angular/common";
 
 import {AppComponent} from "./components/app.component";
-import {appRoutingProviders, routing} from "./app.routing";
+import {AppRoutingModule} from "./app-routing.module";
 
 import {MomentModule} from "angular2-moment";
 import {FileUploader, FileUploadModule} from "ng2-file-upload";
@@ -46,7 +46,7 @@ initializeModelMappingData();
         BrowserModule,
         FormsModule,
         ReactiveFormsModule,
-        routing,
+        AppRoutingModule,
 
         FileUploadModule,
 
@@ -72,7 +72,6 @@ initializeModelMappingData();
         AboutPageComponent
     ],
     providers: [
-        appRoutingProviders,
         ClassificationService,
         FileModelService,
         FileService,

--- a/ui/src/main/webapp/src/app/core/core.module.ts
+++ b/ui/src/main/webapp/src/app/core/core.module.ts
@@ -11,7 +11,7 @@ import {NotificationService} from "./notification/notification.service";
 import {LoggedInGuard} from "./authentication/logged-in.guard";
 import {EventBusService} from "./events/event-bus.service";
 import {RouteLinkProviderService} from "./routing/route-link-provider-service";
-import {appRoutes} from '../app.routing';
+import {appRoutes} from '../app-routing.module';
 import {RouteHistoryService} from "./routing/route-history.service";
 import {RouteFlattenerService} from "./routing/route-flattener.service";
 import {LogoutGuard} from "./authentication/logout.guard";


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-1670

This just redirects back to the project-list if there is no route available for the url. This should really only happen if the user manually puts in a url.