### PR TITLE
WINDUP-1973 Fix Rules Configuration link in Analysis Configuration

### DIFF
--- a/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
+++ b/ui/src/main/webapp/src/app/analysis-context/analysis-context-form.component.html
@@ -120,7 +120,7 @@
                         (selectedRulePathsChanged)="rulesPathsChanged($event)">
                 </wu-custom-rule-selection>
                 <p class="help-block">
-                    Adding a ruleset is possible on <a href='configuration'>Rules Configuration</a>.
+                    Adding a ruleset is possible on <a [routerLink]="['/configuration']">Rules Configuration</a>.
                 </p>
             </div>
         </wu-expand-collapse>


### PR DESCRIPTION
Now you can browse to `Rules Configuration` from `Analysis Configuration` wizard and then go successfully back to `Analysis Configuration`