### PR TITLE
WINDUP-1975 Analysis progress bar sometimes fails to update

### DIFF
--- a/ui/src/main/webapp/src/app/services/windup-execution.service.ts
+++ b/ui/src/main/webapp/src/app/services/windup-execution.service.ts
@@ -55,8 +55,7 @@ export class WindupExecutionService extends AbstractService {
 
     public watchExecutionUpdates(execution: WindupExecution, project: MigrationProject) {
         const url = WindupExecutionService.EXECUTION_PROGRESS_URL
-            .replace('https', 'wss')
-            .replace('http', 'ws')
+            .replace(/^http/, 'ws')
             .replace('{executionId}', execution.id.toString());
 
         if (!this.executionSocket.has(execution.id)) {


### PR DESCRIPTION
Now the pattern `http` is replaced only if at the beginning of the URL (and no matter if then followed by the "secure" `s` or not)