### PR TITLE
WINDUP-1985 Removing dynamic reports link

### DIFF
--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -82,9 +82,11 @@
                     <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
                         <i class="fa fa-times fa-fw"></i>
                     </a>
+                    <!-- Uncomment to have the link to dynamic reports backonly locallyy
                     <a class="link" *ngIf="execution.state == 'COMPLETED'"
                        [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">View Reports
                     </a>
+                    -->
                     <span *ngIf="execution.state == 'COMPLETED' && execution?.analysisContext?.generateStaticReports">
                         <a  class="pointer link" target="_blank" href="{{formatStaticReportUrl(execution)}}" title="Show reports"> <i class="fa fa-bar-chart fa-fw"></i></a>
                         &nbsp;

--- a/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/executions/executions-list.component.spec.ts
@@ -46,9 +46,9 @@ const COL_ACTIONS = 4;
 const COUNT_COLUMNS = 5;
 
 const ACTION_DETAIL = 0;
-const ACTION_DYNAMIC_REPORT = 1;
-const ACTION_STATIC_REPORT = 2;
-const ACTION_DELETE = 3;
+// const ACTION_DYNAMIC_REPORT = 1;
+const ACTION_STATIC_REPORT = 1;
+const ACTION_DELETE = 2;
 
 let mockProjects = [
     { id: 1, title: 'Dummy project' }
@@ -169,11 +169,11 @@ describe('ExecutionsListComponent', () => {
 
             if (stateText.startsWith("Completed")) {
                 // details, view static report, view dynamic report, delete
-                expect(el.children[COL_ACTIONS].children.length).toBe(4);
+                expect(el.children[COL_ACTIONS].children.length).toBe(3);
                 expect(el.children[COL_ACTIONS].children[ACTION_DETAIL].title).toEqual('Details');
                 expect(el.children[COL_ACTIONS].children[ACTION_STATIC_REPORT].children[0].title).toEqual('Show reports');
                 expect(el.children[COL_ACTIONS].children[ACTION_DELETE].title).toEqual('Delete');
-                expect(el.children[COL_ACTIONS].children[ACTION_DYNAMIC_REPORT].text.trim()).toEqual('View Reports');
+                // expect(el.children[COL_ACTIONS].children[ACTION_DYNAMIC_REPORT].text.trim()).toEqual('View Reports');
             } else {
                 expect(el.children[COL_ACTIONS].children.length).toBe(2);
                 expect(el.children[COL_ACTIONS].textContent.trim()).toEqual('');


### PR DESCRIPTION
Commenting (again) the "View Report" link for accessing the dynamic reports.
I also commented the code in tests so that once we will have the dynamic reports back, we will have the test already there.