### PR TITLE
WINDUP-1984 Execution Details - Rules tab fix

### DIFF
--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResource.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.DefaultValue;
+import javax.ws.rs.core.Response;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -96,14 +97,15 @@ public interface GraphResource extends FurnaceRESTGraphAPI
      */
     @GET
     @Path("/{executionID}/by-type/{vertexType}")
-    List<Map<String, Object>> getByType(
+    Response getByType(
         @PathParam("executionID") Long executionID,
         @PathParam("vertexType") String vertexType,
         @QueryParam("depth") Integer depth,
         @QueryParam("dedup") @DefaultValue("false") Boolean dedup,
         @QueryParam("in") String inEdges,
         @QueryParam("out") String outEdges,
-        @QueryParam("includeInVertices") @DefaultValue("true") Boolean includeInVertices
+        @QueryParam("includeInVertices") @DefaultValue("true") Boolean includeInVertices,
+        @QueryParam("blacklistProperties") String blacklistProperties
     );
 
 

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/AbstractGraphResource.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/AbstractGraphResource.java
@@ -178,7 +178,7 @@ public abstract class AbstractGraphResource implements FurnaceRESTGraphAPI
                 linkedVertices = (List<Map<String, Object>>) edgeDetails.get(GraphResource.VERTICES);
             }
 
-            Vertex otherVertex = direction == Direction.OUT ? edge.outVertex() : edge.inVertex();
+            Vertex otherVertex = direction == Direction.OUT ? edge.inVertex() : edge.outVertex();
 
             // Recursion
             ctx.remainingDepth--;

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/rest/graph/GraphResourceImpl.java
@@ -76,18 +76,19 @@ public class GraphResourceImpl extends AbstractGraphResource implements GraphRes
     }
 
     @Override
-    public List<Map<String, Object>> getByType(Long executionID, String vertexType, Integer depth, Boolean dedup, String inEdges, String outEdges, Boolean includeInVertices)
+    public Response getByType(Long executionID, String vertexType, Integer depth, Boolean dedup, String inEdges, String outEdges, Boolean includeInVertices, String blacklistProperties)
     {
         List<String> inEdges_ = inEdges == null ? Collections.emptyList() : Arrays.asList(StringUtils.split(inEdges, ','));
         List<String> outEdges_ = outEdges == null ? Collections.emptyList() : Arrays.asList(StringUtils.split(outEdges, ','));
+        List<String> blacklistProperties_ = blacklistProperties == null ? Collections.emptyList() : Arrays.asList(StringUtils.split(blacklistProperties, ','));
 
         GraphContext graphContext = getGraph(executionID);
         List<Map<String, Object>> vertices = new ArrayList<>();
         for (Vertex v : graphContext.getGraph().traversal().V().has(WindupVertexFrame.TYPE_PROP, vertexType).toSet())
         {
-            vertices.add(convertToMap(new GraphMarshallingContext(executionID, v, depth, dedup, outEdges_, inEdges_, null, includeInVertices), v));
+            vertices.add(convertToMap(new GraphMarshallingContext(executionID, v, depth, dedup, outEdges_, inEdges_, blacklistProperties_, includeInVertices), v));
         }
-        return vertices;
+        return Response.status(Response.Status.OK).entity(vertices).build();
     }
 
     @Override

--- a/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
+++ b/services/src/test/java/org/jboss/windup/web/services/rest/graph/GraphResourceTest.java
@@ -1,5 +1,6 @@
 package org.jboss.windup.web.services.rest.graph;
 
+import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 
@@ -13,11 +14,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.json.*;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 /**
@@ -53,11 +56,12 @@ public class GraphResourceTest extends AbstractGraphResourceTest
     @RunAsClient
     public void testQueryByType()
     {
-        List<Map<String, Object>> fileModels = graphResource.getByType(execution.getId(), FileModel.TYPE, 1, false, null, null, true);
-        Assert.assertNotNull(fileModels);
+        Response response = graphResource.getByType(execution.getId(), FileModel.TYPE, 1, false, null, null, true, null);
+        Assert.assertNotNull(response);
+        JsonArray fileModels = Json.createReader(new StringReader(response.readEntity(String.class))).readArray();
         Assert.assertTrue(fileModels.size() > 1);
 
-        for (Map<String, Object> fileModel : fileModels)
+        for (JsonValue fileModel : fileModels)
         {
             System.out.println("FileModel: " + fileModel);
         }

--- a/ui/src/main/webapp/src/app/executions/executions-list.component.html
+++ b/ui/src/main/webapp/src/app/executions/executions-list.component.html
@@ -82,7 +82,7 @@
                     <a class="pointer link cancel" *ngIf="canCancel(execution)" (click)="cancelExecution(execution)" title="Cancel">
                         <i class="fa fa-times fa-fw"></i>
                     </a>
-                    <!-- Uncomment to have the link to dynamic reports backonly locallyy
+                    <!-- Uncomment to have the link to dynamic reports back
                     <a class="link" *ngIf="execution.state == 'COMPLETED'"
                        [routerLink]="['/projects', execution.projectId, 'reports', execution.id]">View Reports
                     </a>

--- a/ui/src/main/webapp/src/app/executions/rule-provider-executions/rule-provider-executions.service.ts
+++ b/ui/src/main/webapp/src/app/executions/rule-provider-executions/rule-provider-executions.service.ts
@@ -18,7 +18,9 @@ export class RuleProviderExecutionsService extends GraphService {
     @Cached('ruleProviderExecutions', null, true)
     getPhases(execID: number): Observable<ExecutionPhaseModel[]> {
         return this.getTypeAsArray<ExecutionPhaseModel>(ExecutionPhaseModel.discriminator, execID, {
-            depth: 2
+            depth: 2,
+            includeInVertices: false,
+            blacklistProperties: ['ruleContents', 'countRemovedEdges', 'countAddedVertices', 'countAddedEdges', 'countRemovedVertices']
         });
     }
 


### PR DESCRIPTION
The issue is fixed by [this single change](https://github.com/windup/windup-web/compare/master...mrizzi:WINDUP-1984?expand=1#diff-4940c966aeb3a065b8a4be389fddb007R181) to set the right edge traversal order.
As requested in the issue [WINDUP-1984](https://issues.jboss.org/browse/WINDUP-1984), all the other changes address a better performance for the service:

- taking away `vertices_in` and `ruleContents` (together with other unused fields) has slimmed the response for about 760 rules executed from ~1MB to ~200KB
- [return Response](https://github.com/windup/windup-web/compare/master...mrizzi:WINDUP-1984?expand=1#diff-6099b4355e63519c046530a5ebb619fcR91) has improved the marshalling of the response with a gain of other ~2 seconds

So from the ~7 seconds for the 4.0.1.Final release, now it takes about 200 ms to get the executed rules for an analysis (it takes a little bit longer the first time to load the graph).