### PR TITLE
WINDUP-2059 fixing some versions after Alpha releases

### DIFF
--- a/addons/messaging-executor/addon/pom.xml
+++ b/addons/messaging-executor/addon/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.jboss.windup</groupId>
             <artifactId>windup-server-provider-spi</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/addons/messaging-executor/api/pom.xml
+++ b/addons/messaging-executor/api/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.jboss.windup</groupId>
             <artifactId>windup-server-provider-spi</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/addons/messaging-executor/impl/pom.xml
+++ b/addons/messaging-executor/impl/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.jboss.windup</groupId>
             <artifactId>windup-server-provider-spi</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Need to fix some versions to `${project.version}` value after they became wrong in this commit https://github.com/windup/windup-web/commit/3736afa56131de8fbd8874e64805ab783b93b213#diff-57f9528e5593bfeefff2c70e004f39d5