### PR TITLE
WINDUP-2113 Upgrade wildfly-maven-plugin to 1.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
                 <plugin>
                     <groupId>org.wildfly.plugins</groupId>
                     <artifactId>wildfly-maven-plugin</artifactId>
-                    <version>1.2.0.Final</version>
+                    <version>1.2.2.Final</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
It works with:
* Apache Maven 3.5.2 (Red Hat 3.5.2-5)
* Java version: 1.8.0_172

Related to https://github.com/windup/windup-web-distribution/pull/52 and due to https://issues.jboss.org/browse/WFMP-94