### PR TITLE
WINDUP-2101 Removing version for windup-server-provider-spi artifact

### DIFF
--- a/addons/messaging-executor/addon/pom.xml
+++ b/addons/messaging-executor/addon/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>org.jboss.windup</groupId>
             <artifactId>windup-server-provider-spi</artifactId>
-            <version>${project.version}</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/addons/messaging-executor/api/pom.xml
+++ b/addons/messaging-executor/api/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>org.jboss.windup</groupId>
             <artifactId>windup-server-provider-spi</artifactId>
-            <version>${project.version}</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>

--- a/addons/messaging-executor/impl/pom.xml
+++ b/addons/messaging-executor/impl/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>org.jboss.windup</groupId>
             <artifactId>windup-server-provider-spi</artifactId>
-            <version>${project.version}</version>
             <classifier>forge-addon</classifier>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
After https://github.com/windup/windup/pull/1328 has been merged, the `<version>${project.version}</version>` for `windup-server-provider-spi` can be removed, allowing the execution of automated releases