### PR TITLE
WINDUP-2154: need to click cancel button twice on new project page

### DIFF
--- a/ui/src/main/webapp/src/app/project/migration-project-form.component.html
+++ b/ui/src/main/webapp/src/app/project/migration-project-form.component.html
@@ -39,7 +39,7 @@
         </div>
 
         <div class="form-group pull-right">
-            <button (click)="cancel()" type="button" class="btn btn-default" i18n="Cancel button">Cancel</button>
+            <button (mousedown)="cancel()" type="button" class="btn btn-default" i18n="Cancel button">Cancel</button>
             <button tabindex="3" class="btn btn-primary" type="submit" [disabled]="!projectForm.form.pending && !projectForm.form.valid">
                 <ng-template [ngIf]="isInWizard">
                     Next


### PR DESCRIPTION
this was caused by validation being triggered by loss of focus event on the project name field firing before the button click event. Solved this by using mousedown event on cancle button instead, which fires before blur event