### PR TITLE
WINDUP-2258 Enhancements to work with NFS shared storage

### DIFF
--- a/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/AbstractSerializer.java
+++ b/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/AbstractSerializer.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.logging.Logger;
 
 /**
  * Provides baseline functionality for serializing and deserializing {@link WindupExecution}
@@ -23,6 +24,9 @@ import java.util.Arrays;
  */
 public abstract class AbstractSerializer implements ExecutionSerializer
 {
+    private static Logger LOG = Logger.getLogger(AbstractSerializer.class.getName());
+    public final static String FULL_TAR_ARCHIVE = "FULL_TAR_ARCHIVE";
+
     @Override
     public Message serializeExecutionRequest(JMSContext context, WindupExecution execution)
     {
@@ -107,7 +111,16 @@ public abstract class AbstractSerializer implements ExecutionSerializer
         {
             Files.createDirectories(outputDirectory);
             Path tempFile = outputDirectory.resolve("report_files.tar");
-            TarUtil.tarDirectory(tempFile, Paths.get(execution.getOutputPath()), Arrays.asList(UnzipArchiveToOutputFolder.ARCHIVES));
+            boolean fullTarArchive = Boolean.valueOf(System.getenv(FULL_TAR_ARCHIVE));
+            if (fullTarArchive)
+            {
+                LOG.info("Required full archive creation");
+                TarUtil.tarDirectory(tempFile, Paths.get(execution.getOutputPath()));
+            }
+            else
+            {
+                TarUtil.tarDirectory(tempFile, Paths.get(execution.getOutputPath()), Arrays.asList(UnzipArchiveToOutputFolder.ARCHIVES));
+            }
             return tempFile;
         }
         catch (IOException e)

--- a/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/AbstractSerializer.java
+++ b/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/AbstractSerializer.java
@@ -1,5 +1,6 @@
 package org.jboss.windup.web.messaging.executor;
 
+import org.jboss.windup.rules.apps.java.scan.operation.UnzipArchiveToOutputFolder;
 import org.jboss.windup.util.TarUtil;
 import org.jboss.windup.web.services.json.WindupExecutionJSONUtil;
 import org.jboss.windup.web.services.model.WindupExecution;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 /**
  * Provides baseline functionality for serializing and deserializing {@link WindupExecution}
@@ -105,7 +107,7 @@ public abstract class AbstractSerializer implements ExecutionSerializer
         {
             Files.createDirectories(outputDirectory);
             Path tempFile = outputDirectory.resolve("report_files.tar");
-            TarUtil.tarDirectory(tempFile, Paths.get(execution.getOutputPath()));
+            TarUtil.tarDirectory(tempFile, Paths.get(execution.getOutputPath()), Arrays.asList(UnzipArchiveToOutputFolder.ARCHIVES));
             return tempFile;
         }
         catch (IOException e)

--- a/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/HttpPostSerializer.java
+++ b/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/HttpPostSerializer.java
@@ -1,6 +1,7 @@
 package org.jboss.windup.web.messaging.executor;
 
 import java.io.BufferedOutputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -88,10 +89,11 @@ public class HttpPostSerializer extends AbstractSerializer implements ExecutionS
             LOG.info("Completed generating result archive, posting results to the server...");
 
             // Send the post data to the rhamt core service
-            try (FileInputStream fileInputStream = new FileInputStream(resultsArchivePath.toFile()))
+            File resultsArchivePathFile = resultsArchivePath.toFile();
+            try (FileInputStream fileInputStream = new FileInputStream(resultsArchivePathFile))
             {
                 sendResults(execution.getId(), fileInputStream);
-                LOG.info("Results posted, analysis is now complete!");
+                LOG.info("Results posted (" + resultsArchivePathFile.length() + " bytes), analysis is now complete!");
             }
             catch (Throwable e)
             {

--- a/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/HttpPostSerializer.java
+++ b/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/HttpPostSerializer.java
@@ -86,14 +86,14 @@ public class HttpPostSerializer extends AbstractSerializer implements ExecutionS
             Path analysisDirectory = outputDirectory.getParent();
 
             Path resultsArchivePath = this.createResultArchive(projectId, execution, outputDirectory);
-            LOG.info("Completed generating result archive, posting results to the server...");
+            File resultsArchivePathFile = resultsArchivePath.toFile();
+            LOG.info("Completed generating result archive (" + resultsArchivePathFile.length() + " bytes), posting results to the server...");
 
             // Send the post data to the rhamt core service
-            File resultsArchivePathFile = resultsArchivePath.toFile();
             try (FileInputStream fileInputStream = new FileInputStream(resultsArchivePathFile))
             {
                 sendResults(execution.getId(), fileInputStream);
-                LOG.info("Results posted (" + resultsArchivePathFile.length() + " bytes), analysis is now complete!");
+                LOG.info("Results posted, analysis is now complete!");
             }
             catch (Throwable e)
             {

--- a/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/HttpPostSerializer.java
+++ b/addons/messaging-executor/impl/src/main/java/org/jboss/windup/web/messaging/executor/HttpPostSerializer.java
@@ -87,7 +87,7 @@ public class HttpPostSerializer extends AbstractSerializer implements ExecutionS
 
             Path resultsArchivePath = this.createResultArchive(projectId, execution, outputDirectory);
             File resultsArchivePathFile = resultsArchivePath.toFile();
-            LOG.info("Completed generating result archive (" + resultsArchivePathFile.length() + " bytes), posting results to the server...");
+            LOG.info("Completed generating result archive (" + (resultsArchivePathFile.length() / 1048576) + " MB), posting results to the server...");
 
             // Send the post data to the rhamt core service
             try (FileInputStream fileInputStream = new FileInputStream(resultsArchivePathFile))

--- a/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/WebPathUtil.java
+++ b/addons/web-support/api/src/main/java/org/jboss/windup/web/addons/websupport/WebPathUtil.java
@@ -20,6 +20,11 @@ public interface WebPathUtil
     Path createWindupReportOutputPath(String projectPath, String name);
 
     /**
+     * Creates an output path for the graph for the given project and group and name.
+     */
+    Path createWindupGraphOutputPath(Path outputPath);
+
+    /**
      * Creates an output path for the given project path.
      */
     Path createMigrationProjectPath(String projectPath);

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/WebPathUtilImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/WebPathUtilImpl.java
@@ -7,6 +7,7 @@ import java.util.TreeSet;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jboss.windup.graph.GraphContextFactory;
 
 /**
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
@@ -19,6 +20,7 @@ public class WebPathUtilImpl implements WebPathUtil
     private static final String REPORT_DIR = "reports";
     private static final String APPS_DIR = "apps";
     private static final String RULES_DIR = "rules";
+    private static final String GRAPH_BASE_OUTPUT_PATH = "GRAPH_BASE_OUTPUT_PATH";
 
     @Override
     public Path createWindupReportOutputPath(String name)
@@ -34,6 +36,22 @@ public class WebPathUtilImpl implements WebPathUtil
         return this.createMigrationProjectPath(projectPath)
                 .resolve("reports")
                 .resolve(reportPath);
+    }
+
+    @Override
+    public Path createWindupGraphOutputPath(Path outputPath)
+    {
+        String graphBaseOutputPath = System.getenv(GRAPH_BASE_OUTPUT_PATH);
+        Path graphPath;
+        if (graphBaseOutputPath != null)
+        {
+            graphPath = Paths.get(outputPath.toString().replace(getGlobalWindupDataPath().toString(), graphBaseOutputPath), GraphContextFactory.DEFAULT_GRAPH_SUBDIRECTORY);
+        }
+        else
+        {
+            graphPath = outputPath.resolve(GraphContextFactory.DEFAULT_GRAPH_SUBDIRECTORY);
+        }
+        return graphPath;
     }
 
     @Override

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/services/WindupExecutorServiceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/services/WindupExecutorServiceImpl.java
@@ -27,6 +27,7 @@ import org.jboss.windup.graph.GraphContextFactory;
 import org.jboss.windup.rules.apps.java.config.ExcludePackagesOption;
 import org.jboss.windup.rules.apps.java.config.ScanPackagesOption;
 import org.jboss.windup.util.exception.WindupException;
+import org.jboss.windup.web.addons.websupport.WebPathUtil;
 import org.jboss.windup.web.addons.websupport.rest.graph.GraphCache;
 
 /**
@@ -43,12 +44,15 @@ public class WindupExecutorServiceImpl implements WindupExecutorService
     @Inject
     private GraphCache graphCache;
 
+    @Inject
+    private WebPathUtil webPathUtil;
+
     @Override
     public void execute(WindupProgressMonitor progressMonitor, Collection<Path> rulesPaths, List<Path> inputPaths, Path outputPath,
                 List<String> packages,
                 List<String> excludePackages, String source, List<String> targets, Map<String, Object> otherOptions, boolean generateStaticReports)
     {
-        Path graphPath = outputPath.resolve(GraphContextFactory.DEFAULT_GRAPH_SUBDIRECTORY);
+        Path graphPath = webPathUtil.createWindupGraphOutputPath(outputPath);
         // Close it here, since we will be deleting the old one and rewriting
         graphCache.closeGraph(graphPath);
 

--- a/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/services/WindupExecutorServiceImpl.java
+++ b/addons/web-support/impl/src/main/java/org/jboss/windup/web/addons/websupport/services/WindupExecutorServiceImpl.java
@@ -90,7 +90,7 @@ public class WindupExecutorServiceImpl implements WindupExecutorService
         }
 
         configuration.setOptionValue(OverwriteOption.NAME, true);
-        configuration.setOptionValue(KeepWorkDirsOption.NAME, true);
+        configuration.setOptionValue(KeepWorkDirsOption.NAME, false);
 
         for (Map.Entry<String, Object> optionEntry : otherOptions.entrySet())
         {

--- a/model/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
@@ -245,6 +245,14 @@ public class AnalysisContext implements Serializable
     }
 
     /**
+     * Add an advanced configuration options (eg, csv export).
+     */
+    public void addAdvancedOption(AdvancedOption advancedOption)
+    {
+        this.advancedOptions.add(advancedOption);
+    }
+
+    /**
      * Contains the applications associated with this group.
      */
     public Set<RegisteredApplication> getApplications()

--- a/model/src/main/java/org/jboss/windup/web/services/model/Package.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/Package.java
@@ -19,9 +19,13 @@ import javax.validation.constraints.Size;
  */
 @Entity
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Table(
+        indexes = @Index(columnList = Package.PARENT_PACKAGE_ID, unique = false)
+)
 public class Package implements Serializable
 {
     public static final String PACKAGE_ID = "package_id";
+    public static final String PARENT_PACKAGE_ID = "parent_package_id";
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -43,6 +47,7 @@ public class Package implements Serializable
 
     @ManyToOne()
     @JsonIgnore
+    @JoinColumn(name = PARENT_PACKAGE_ID)
     private Package parent;
 
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "parent")

--- a/model/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/WindupExecution.java
@@ -205,6 +205,26 @@ public class WindupExecution implements Serializable
     }
 
     /**
+     * Gets the relative path to the rule providers report in a format suitable for a URL.
+     */
+    public String getRuleProvidersExecutionOverviewRelativePath()
+    {
+        String directoryName = getOutputDirectoryName();
+        if (directoryName == null)
+            return null;
+
+        return directoryName + "/reports/windup_ruleproviders.html";
+    }
+
+    /**
+     * This should never be called directory (it is only here to aid in Jackson serialization).
+     */
+    public void setRuleProvidersExecutionOverviewRelativePath(String path)
+    {
+        // nooop
+    }
+
+    /**
      * Contains the time at which this analysis was put into the analysis queue.
      */
     public Calendar getTimeQueued()

--- a/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
+++ b/services/src/test/java/org/jboss/windup/web/services/data/WindupExecutionUtil.java
@@ -4,6 +4,8 @@ import java.io.InputStream;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.windup.config.KeepWorkDirsOption;
+import org.jboss.windup.web.services.model.AdvancedOption;
 import org.jboss.windup.web.services.model.AnalysisContext;
 import org.jboss.windup.web.services.model.ExecutionState;
 import org.jboss.windup.web.services.model.MigrationProject;
@@ -46,8 +48,9 @@ public class WindupExecutionUtil
 
             // Refresh it, as adding the app may have caused changes
             context = this.analysisContextEndpoint.get(context.getId());
+            context.addAdvancedOption(new AdvancedOption(KeepWorkDirsOption.NAME, "true"));
 
-            this.analysisContextEndpoint.saveAsProjectDefault(context, project.getId());
+            context = this.analysisContextEndpoint.saveAsProjectDefault(context, project.getId());
         }
 
         System.out.println("Setup Graph test, registered application and ready to start Windup analysis...");

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -102,7 +102,7 @@
                 Loading rules...
             </span>
             <span *ngIf="phases != null">
-                <table class="table table-bordered table-hover table-mobile executions-list-table">
+                <table *ngIf="phases.length > 0" class="table table-bordered table-hover table-mobile executions-list-table">
                     <thead wu-sortable-table
                            [data]="phases"
                            [tableHeaders]="[
@@ -129,6 +129,9 @@
                     </ng-template>
                     <tbody>
                 </table>
+                <ng-container *ngIf="phases.length == 0">
+                    <span>Rules details available in <a class="link" target="_blank" href="{{formatStaticRuleProviderReportUrl(execution)}}">Rule Providers Execution Overview <i class="fa fa-external-link"></i></a></span>
+                </ng-container>
             </span>
         </wu-tab>
         <wu-tab [tabTitle]="'Logs'">

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.html
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.html
@@ -129,7 +129,7 @@
                     </ng-template>
                     <tbody>
                 </table>
-                <ng-container *ngIf="phases.length == 0">
+                <ng-container *ngIf="execution.state == 'COMPLETED' && phases.length == 0">
                     <span>Rules details available in <a class="link" target="_blank" href="{{formatStaticRuleProviderReportUrl(execution)}}">Rule Providers Execution Overview <i class="fa fa-external-link"></i></a></span>
                 </ng-container>
             </span>

--- a/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
+++ b/ui/src/main/webapp/src/app/executions/execution-detail.component.ts
@@ -59,6 +59,8 @@ export class ExecutionDetailComponent extends RoutedComponent implements OnInit,
                 this._ruleProviderExecutionsService.getPhases(executionId)
                     .subscribe(phases => {
                         this.phases = phases;
+                    }, error => {
+                        this.phases = [];
                     });
             });
         }));
@@ -86,6 +88,10 @@ export class ExecutionDetailComponent extends RoutedComponent implements OnInit,
 
     formatStaticReportUrl(execution: WindupExecution): string {
         return WindupExecutionService.formatStaticReportUrl(execution);
+    }
+
+    formatStaticRuleProviderReportUrl(execution: WindupExecution): string {
+        return WindupExecutionService.formatStaticRuleProviderReportUrl(execution);
     }
 
     private loadLogData() {

--- a/ui/src/main/webapp/src/app/services/graph.service.ts
+++ b/ui/src/main/webapp/src/app/services/graph.service.ts
@@ -39,7 +39,8 @@ export class GraphService extends AbstractService {
                 }
 
                 return <T[]>service.fromJSONarray(data);
-            });
+            })
+            .catch(this.handleError);
     }
 
     protected prepareGetRequest(type: string, execID: number, options?: GraphEndpointOptions): Observable<any> {

--- a/ui/src/main/webapp/src/app/services/windup-execution.service.ts
+++ b/ui/src/main/webapp/src/app/services/windup-execution.service.ts
@@ -125,4 +125,11 @@ export class WindupExecutionService extends AbstractService {
     public static formatStaticReportUrl(execution: WindupExecution): string {
         return Constants.STATIC_REPORTS_BASE + "/" + execution.applicationListRelativePath;
     }
+
+    /**
+     * @returns {string} An URL to the static rule provider report of the given execution.
+     */
+    public static formatStaticRuleProviderReportUrl(execution: WindupExecution): string {
+        return Constants.STATIC_REPORTS_BASE + "/" + execution.ruleProvidersExecutionOverviewRelativePath;
+    }
 }


### PR DESCRIPTION
Depends on https://github.com/windup/windup/pull/1342

- exclusion of the `archives` folder from the tar archive sent from the executor to the web console at the end of an analysis when RHAMT is executed on OpenShift
- added information in the log about the quantity of data sent
- added the ability to persist the graph outside of the standard analysis output folder (useful in an OCP installation with an NFS shared storage where BerkeleyDB can not persist data)