### PR TITLE
WINDUP-README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Running the webapp
 - Follow the steps for deploying keycloak in [Keycloak Setup](./KEYCLOAK-SETUP.md)
 - Access the webapp: <http://localhost:8080/rhamt-web>
 
-Watch your changes while coding
+Deploy your changes while coding
 ------------------
 - Follow the previous step (use the 3rd way of running the webapp: edit `standalone-full.xml`) 
 - Install webpack: `sudo npm install --global webpack@3.4.1`

--- a/README.md
+++ b/README.md
@@ -179,3 +179,11 @@ Running the webapp
 
 - Follow the steps for deploying keycloak in [Keycloak Setup](./KEYCLOAK-SETUP.md)
 - Access the webapp: <http://localhost:8080/rhamt-web>
+
+Watch your changes while coding
+------------------
+- Follow the previous step (use the 3rd way of running the webapp: edit `standalone-full.xml`) 
+- Install webpack: `sudo npm install --global webpack@3.4.1`
+- Move to webapp folder: `cd windup-web/ui/src/main/webapp`
+- Execute `webpack -w`
+

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Environment setup
     >       sudo npm install -g phantomjs-prebuilt
     >
     > Or
-    >
+    > 
     >       sudo npm install -g phantomjs-prebuilt --unsafe-perm
     
     > 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Environment setup
 2. [Install NodeJS Package Manager (npm)](https://nodejs.org/en/download/package-manager/)
    * _Debian/Ubuntu_: `sudo apt-get install npm`
    * _RHEL 7_: 1) Install [EPEL](https://fedoraproject.org/wiki/EPEL/FAQ#How_can_I_install_the_packages_from_the_EPEL_software_repository.3F)  2) `sudo yum install npm`
+   * _Fedora_: `sudo dnf install npm`
 
    > NOTE: If npm is version is less than 3.8.8, try the following to force an update:
    >
@@ -44,6 +45,10 @@ Environment setup
     
     > 
     > if phantomjs is not installed yet, run 
+    >    
+    >       sudo npm install -g phantomjs-prebuilt
+    >
+    > Or
     >
     >       sudo npm install -g phantomjs-prebuilt --unsafe-perm
     

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Running the webapp
 
         ```xml
         <deployments>
-            <deployment name="rhamt-web/api" runtime-name="rhamt-web/api.war">
+            <deployment name="rhamt-web/api" runtime-name="api.war">
                 <fs-exploded path=".../windup-web/services/target/rhamt-web/api"/>
             </deployment>
             <deployment name="rhamt-web" runtime-name="rhamt-web.war">


### PR DESCRIPTION
I had some problems following the instructions of the README file so I thought it would be good to add some information to the README file:
- I added the command for Fedora OS, to install npm `sudo dnf install npm`
- I changed `<deployment name="rhamt-web/api" runtime-name="rhamt-web/api.war">` to `<deployment name="rhamt-web/api" runtime-name="api.war">` in order to allow readers just to copy and paste the instructions of the README file. Otherwise is allways necessary to change it manually.
- I added a block of text called **Watch your changes while coding** at the end of the README file. The text contains information about how to start webpack in order to watch changes while coding. It also contains the specific version of webpack that developeres must use **(webpack@3.4.1)**. **Note:** latest version of webpack doesn't work.

