### PR TITLE
Swagger: compile and runtime files generation, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,18 @@ Deploy your changes while coding
 - Move to webapp folder: `cd windup-web/ui/src/main/webapp`
 - Execute `webpack -w`
 
+Adding Swagging Core
+------------------
+[Swagger Core](https://github.com/swagger-api/swagger-core) is an open source Java implementation of Swagger/OpenAPI.  
+It resolves JAX-RS annotated resources and Java annotated POJOs into OpenAPI schemas, handles serialization/deserialization and provides an integration mechanism.
+
+To get the OpenAPI specifications file, you can compile this project enabling the `swagger` profile:
+
+- from `windup-web/services` folder execute the command `mvn clean compile -Pswagger`
+- in `windup-web/services/target/swagger` folder you'll find `openapi.json` and `openapi.yaml` files with the OpenAPI specifications
+
+If you want to create a RHAMT Web application that provides the `openapi.json` and `openapi.yaml` files at runtime:
+
+- build this project enabling the `swagger` profile, executing -from `windup-web` folder- the `mvn -DskipTests clean install -Pswagger` command  
+- the files will be available at <http://localhost:8080/rhamt-web/api/openapi.json> and <http://localhost:8080/rhamt-web/api/openapi.yaml>
+

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -550,6 +550,47 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>swagger</id>
+            <dependencies>
+                <dependency>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-jaxrs2</artifactId>
+                    <version>2.0.7</version>
+                </dependency>
+                <dependency>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-jaxrs2-servlet-initializer</artifactId>
+                    <version>2.0.7</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.swagger.core.v3</groupId>
+                        <artifactId>swagger-maven-plugin</artifactId>
+                        <version>2.0.7</version>
+                        <configuration>
+                            <outputFileName>openapi</outputFileName>
+                            <outputPath>${project.build.directory}/swagger</outputPath>
+                            <outputFormat>JSONANDYAML</outputFormat>
+                            <resourcePackages>
+                                <package>org.jboss.windup.web.services.rest</package>
+                            </resourcePackages>
+                            <prettyPrint>TRUE</prettyPrint>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>resolve</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencyManagement>


### PR DESCRIPTION
The `swagger` profile can be used to create the OpenAPI/Swagger specifications file both at compile time and at runtime.