### PR TITLE
WINDUP-2490: userLabelsPath appearing in Advanced options

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/ConfigurationOptionsEndpointImpl.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/ConfigurationOptionsEndpointImpl.java
@@ -5,6 +5,7 @@ import org.jboss.windup.config.ValidationResult;
 import org.jboss.windup.exec.configuration.options.InputPathOption;
 import org.jboss.windup.exec.configuration.options.OutputPathOption;
 import org.jboss.windup.exec.configuration.options.OverwriteOption;
+import org.jboss.windup.exec.configuration.options.UserLabelsDirectoryOption;
 import org.jboss.windup.exec.configuration.options.UserRulesDirectoryOption;
 import org.jboss.windup.rules.apps.java.config.ExcludePackagesOption;
 import org.jboss.windup.rules.apps.java.config.ScanPackagesOption;
@@ -31,7 +32,8 @@ public class ConfigurationOptionsEndpointImpl implements ConfigurationOptionsEnd
             OverwriteOption.NAME,
             ScanPackagesOption.NAME,
             ExcludePackagesOption.NAME,
-            UserRulesDirectoryOption.NAME
+            UserRulesDirectoryOption.NAME,
+            UserLabelsDirectoryOption.NAME
     ));
 
     @Inject


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2490

Removed the `UserLabelsDirectoryOption` option from the advanced options