### PR TITLE
Windup 2505 migrate windup web libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </properties>
 
     <scm>
-        <tag>4.3.0-SNAPSHOT</tag>
+        <tag>4.3.1-SNAPSHOT</tag>
         <connection>${windup.web.scm.connection}</connection>
         <developerConnection>${windup.web.developer.connection}</developerConnection>
         <url>${windup.web.scm.url}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <version.forge>3.9.2.Final</version.forge>
         <version.furnace>2.28.2.Final</version.furnace>
         <version.windup>4.3.0-SNAPSHOT</version.windup>
-        <version.keycloak>4.8.3.Final</version.keycloak>
-        <version.wildfly>15.0.1.Final</version.wildfly>
+        <version.keycloak>4.8.15.Final-redhat-00001</version.keycloak>
+        <version.wildfly>18.0.1.Final</version.wildfly>
         <version.resteasy>3.0.19.Final</version.resteasy>
         <version.jboss.javaee>1.0.3.Final</version.jboss.javaee>
 
@@ -35,7 +35,7 @@
         <windup.web.scm.url>http://github.com/windup/windup-web</windup.web.scm.url>
 
         <windup.distribution.name>rhamt-cli</windup.distribution.name>
-        <version.hibernate>5.3.7.Final</version.hibernate>
+        <version.hibernate>5.3.14.Final</version.hibernate>
         <version.undertow>2.0.15.Final</version.undertow>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <version.findbugs.plugin>3.0.5</version.findbugs.plugin>
         <version.forge>3.9.2.Final</version.forge>
-        <version.furnace>2.28.2.Final</version.furnace>
+        <version.furnace>2.28.4.Final</version.furnace>
         <version.windup>4.3.1-SNAPSHOT</version.windup>
         <version.keycloak>8.0.1</version.keycloak>
         <version.wildfly>18.0.1.Final</version.wildfly>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <version.forge>3.9.2.Final</version.forge>
         <version.furnace>2.28.2.Final</version.furnace>
         <version.windup>4.3.0-SNAPSHOT</version.windup>
-        <version.keycloak>4.8.15.Final-redhat-00001</version.keycloak>
+        <version.keycloak>8.0.1</version.keycloak>
         <version.wildfly>18.0.1.Final</version.wildfly>
         <version.resteasy>3.0.19.Final</version.resteasy>
         <version.jboss.javaee>1.0.3.Final</version.jboss.javaee>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -505,8 +505,9 @@
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>org.jboss.arquillian.protocol</groupId>
-                    <artifactId>arquillian-protocol-servlet</artifactId>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+                    <version>2.2.0.Final</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -271,7 +271,7 @@
 
     <build>
         <finalName>rhamt-web/api</finalName>
-        
+
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -501,13 +501,33 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>2.1.1.Final</version>
+                    <version>2.2.0.Final</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.arquillian.protocol</groupId>
                     <artifactId>arquillian-protocol-servlet</artifactId>
                     <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-controller-client</artifactId>
+                    <version>10.0.3.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-server</artifactId>
+                    <version>10.0.3.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-jmx</artifactId>
+                    <version>10.0.3.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.core</groupId>
+                    <artifactId>wildfly-launcher</artifactId>
+                    <version>10.0.3.Final</version>
                 </dependency>
             </dependencies>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -510,26 +510,6 @@
                     <version>2.2.0.Final</version>
                     <scope>test</scope>
                 </dependency>
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-controller-client</artifactId>
-                    <version>10.0.3.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-server</artifactId>
-                    <version>10.0.3.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-jmx</artifactId>
-                    <version>10.0.3.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.core</groupId>
-                    <artifactId>wildfly-launcher</artifactId>
-                    <version>10.0.3.Final</version>
-                </dependency>
             </dependencies>
 
             <build>

--- a/tsmodelsgen-invocation/pom.xml
+++ b/tsmodelsgen-invocation/pom.xml
@@ -38,7 +38,7 @@
         <!-- For now, we need to pass this to the Mojo explicitly (through META-INF/versions.properties),
              but it should be possible to figure that out from the Windup POM. -->
         <version.forge>3.9.2.Final</version.forge>
-        <version.furnace>2.28.2.Final</version.furnace>
+        <version.furnace>2.28.4.Final</version.furnace>
     </properties>
 
     <distributionManagement>

--- a/tsmodelsgen-maven-plugin/pom.xml
+++ b/tsmodelsgen-maven-plugin/pom.xml
@@ -35,7 +35,7 @@
         <!-- For now, we need to pass this to the Mojo explicitly (through META-INF/versions.properties),
              but it should be possible to figure that out from the Windup POM. -->
         <version.forge>3.9.2.Final</version.forge>
-        <version.furnace>2.28.2.Final</version.furnace>
+        <version.furnace>2.28.4.Final</version.furnace>
     </properties>
 
     <distributionManagement>

--- a/ui/src/main/webapp/package.json
+++ b/ui/src/main/webapp/package.json
@@ -64,7 +64,7 @@
     "jquery-match-height": "0.7.0",
     "jstree": "3.3.7",
     "karma-junit-reporter": "^1.1.0",
-    "keycloak-js": "^4.8.3",
+    "keycloak-js": "^8.0.1",
     "material-design-icons": "^3.0.1",
     "moment": "^2.24.0",
     "ng2-file-upload": "^1.2.1",


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2505
Modified versions of :
* Keycloak   -> from 4.8.3   to  8.0.1
* Wildfly       -> from 15.0.1.Final to 18.0.1.Final
* Hibernate  -> from 5.3.7 to 5.3.14