### PR TITLE
WINDUP-2566: RHAMT Rebranding - windup-web

### DIFF
--- a/tools/graph-tool/src/main/webapp/messages.xlf
+++ b/tools/graph-tool/src/main/webapp/messages.xlf
@@ -316,7 +316,7 @@
       </trans-unit>
       <trans-unit id="e8f808887b0e059a2c5c94e12612d84ec037ec50" datatype="html">
         <source>
-        Welcome to the Red Hat Application Migration Toolkit Web Console.
+        Welcome to the Migration Toolkit for Applications Web Console.
     </source>
         <target/>
         <note priority="1" from="description">Header</note>
@@ -332,7 +332,7 @@
         <note priority="1" from="description">Intro text, 1st part</note>
       </trans-unit>
       <trans-unit id="be4447ba967dd93b3fe55e4f2e58d1cbe312b2b6" datatype="html">
-        <source>Red Hat Application Migration Toolkit Web Console Documentation</source>
+        <source>Migration Toolkit for Applications Web Console Documentation</source>
         <target/>
         <note priority="1" from="description">Intro text, 2nd part</note>
       </trans-unit>

--- a/ui/src/main/webapp/messages.xlf
+++ b/ui/src/main/webapp/messages.xlf
@@ -316,7 +316,7 @@
       </trans-unit>
       <trans-unit id="e8f808887b0e059a2c5c94e12612d84ec037ec50" datatype="html">
         <source>
-        Welcome to the Red Hat Application Migration Toolkit Web Console.
+        Welcome to the Migration Toolkit for Applications Web Console.
     </source>
         <target/>
         <note priority="1" from="description">Header</note>
@@ -332,7 +332,7 @@
         <note priority="1" from="description">Intro text, 1st part</note>
       </trans-unit>
       <trans-unit id="be4447ba967dd93b3fe55e4f2e58d1cbe312b2b6" datatype="html">
-        <source>Red Hat Application Migration Toolkit Web Console Documentation</source>
+        <source>Migration Toolkit for Applications Web Console Documentation</source>
         <target/>
         <note priority="1" from="description">Intro text, 2nd part</note>
       </trans-unit>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2566

Change the files `**/messages.xlf`

Note: the files `messages.xlf` are used for localization and translation using Angular Tools. Windup-web don't really use this at the moment. For more info about `messages.xlf` we can take a look to:
- https://angular.io/guide/i18n
- https://www.youtube.com/watch?v=3QR8p03eKAk