### PR TITLE
WINDUP-2675: RFE :Web-Console UI : any xml file can be uploaded in rules like pom.xml or label.xml

### DIFF
--- a/ui/src/main/webapp/src/app/shared/add-labels-path-modal/add-labels-path-modal.component.ts
+++ b/ui/src/main/webapp/src/app/shared/add-labels-path-modal/add-labels-path-modal.component.ts
@@ -116,7 +116,7 @@ export class AddLabelsPathModalComponent extends FormComponent implements OnInit
             this.handleError(msg);
         }));
 
-        let suffixes = ['.xml'];
+        let suffixes = ['.windup.label.xml', '.rhamt.label.xml', '.mta.label.xml'];
         this.multipartUploader.options.filters.push(<FilterFunction>{
             name: "invalidLabelProvider",
             fn: (item?: FileLikeObject, options?: FileUploaderOptions) => {

--- a/ui/src/main/webapp/src/app/shared/add-rules-path-modal/add-rules-path-modal.component.ts
+++ b/ui/src/main/webapp/src/app/shared/add-rules-path-modal/add-rules-path-modal.component.ts
@@ -116,7 +116,7 @@ export class AddRulesPathModalComponent extends FormComponent implements OnInit,
             this.handleError(msg);
         }));
 
-        let suffixes = ['.xml'];
+        let suffixes = ['.windup.xml', '.rhamt.xml', '.mta.xml'];
         this.multipartUploader.options.filters.push(<FilterFunction>{
             name: "invalidRuleProvider",
             fn: (item?: FileLikeObject, options?: FileUploaderOptions) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2675

The "Add Rule/Label Modal" should only accept valid files. Valid files are verified only based on its name.
- Valid rule files: "*.windup.xml", "*.rhamt.xml", "*.mta.xml"
- Valid label files: "*.windup.label.xml", "*.rhamt.label.xml", "*.mta.label.xml"

![Screenshot from 2020-07-02 11-40-56](https://user-images.githubusercontent.com/2582866/86343654-8b18f000-bc59-11ea-90aa-11676a8912da.png)
