### PR TITLE
WINDUP-2830: Validation error if the first letter of project name is a number

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/project-details-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/project-details-form/schema.ts
@@ -22,7 +22,7 @@ export const projectDetailsFormSchema = (project?: MigrationProject) => {
       .min(3, "The project name must contain at least 3 characters.")
       .max(120, "The project name must contain fewer than 120 characters.")
       .matches(
-        /^(?:[A-Za-z]+)(?:[A-Za-z0-9 _]*)$/,
+        /\s*[- \w]+\s*/,
         "The project name must contain only alphanumeric characters."
       )
       .test("uniqueValue", "The entered name is already in use.", (value) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2830

Using exactly the same regex used in Hibernate https://github.com/windup/windup-web/blob/60ee612fbfc4c6dd1d1a8492d3f08dc298f721cb/model/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java#L70