### PR TITLE
WINDUP-2821: Show errow messages when trying to upload file types not supported

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/upload-files-dropzone/upload-files-dropzone.tsx
+++ b/ui-pf4/src/main/webapp/src/components/upload-files-dropzone/upload-files-dropzone.tsx
@@ -26,6 +26,7 @@ import "./upload-files-dropzone.scss";
 import { getMapKeys } from "utils/utils";
 import { formatBytes } from "utils/format";
 import BackendAPIClient from "api/apiClient";
+import { getAxiosErrorMessage } from "utils/modelUtils";
 
 const CANCEL_MESSAGE = "cancelled";
 
@@ -295,7 +296,13 @@ export const UploadFilesDropzone: React.FC<UploadFilesDropzoneProps> = ({
                       <SplitItem isFilled>
                         <Progress
                           title={`${file.name} (${formatBytes(file.size)})`}
-                          label={upload.wasCancelled ? "Cancelled" : undefined}
+                          label={
+                            upload.wasCancelled
+                              ? "Cancelled"
+                              : upload.error
+                              ? getAxiosErrorMessage(upload.error)
+                              : undefined
+                          }
                           size={ProgressSize.sm}
                           value={upload.progress}
                           variant={


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2821

Add error message when uploading files. The message comes directly from the Backend.

![Screenshot from 2020-11-09 10-27-54](https://user-images.githubusercontent.com/2582866/98523713-82bf6a00-2276-11eb-8af8-980b1f7c9e07.png)
