### PR TITLE
WINDUP-2843: Improve warning message for project name

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/project-details-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/project-details-form/schema.ts
@@ -5,6 +5,8 @@ import { getProjectIdByName } from "api/api";
 
 import { ProjectDetailsFormValues } from "./project-details-form";
 
+export const PROJECT_NAME_REGEX = /^[- \w]+$/;
+
 export const projectDetailsFormInitialValue = (
   project?: MigrationProject
 ): ProjectDetailsFormValues => {
@@ -22,7 +24,7 @@ export const projectDetailsFormSchema = (project?: MigrationProject) => {
       .min(3, "The project name must contain at least 3 characters.")
       .max(120, "The project name must contain fewer than 120 characters.")
       .matches(
-        /\s*[- \w]+\s*/,
+        PROJECT_NAME_REGEX,
         "The project name must contain only alphanumeric characters."
       )
       .test("uniqueValue", "The entered name is already in use.", (value) => {

--- a/ui-pf4/src/main/webapp/src/components/project-details-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/project-details-form/schema.ts
@@ -25,7 +25,7 @@ export const projectDetailsFormSchema = (project?: MigrationProject) => {
       .max(120, "The project name must contain fewer than 120 characters.")
       .matches(
         PROJECT_NAME_REGEX,
-        "The project name must contain only alphanumeric characters."
+        "The project name must contain only alphanumeric characters including underscore."
       )
       .test("uniqueValue", "The entered name is already in use.", (value) => {
         return getProjectIdByName(value!)

--- a/ui-pf4/src/main/webapp/src/components/project-details-form/tests/project-details-form.test.tsx
+++ b/ui-pf4/src/main/webapp/src/components/project-details-form/tests/project-details-form.test.tsx
@@ -5,6 +5,7 @@ import { Form } from "@patternfly/react-core";
 import {
   projectDetailsFormInitialValue,
   projectDetailsFormSchema,
+  PROJECT_NAME_REGEX,
 } from "../schema";
 import { ProjectDetailsForm } from "../project-details-form";
 
@@ -26,5 +27,17 @@ describe("ProjectDetailsForm", () => {
       </Formik>
     );
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it("Verify ProjectName regex", () => {
+    expect(PROJECT_NAME_REGEX.test("myProject")).toEqual(true);
+    expect(PROJECT_NAME_REGEX.test("my_project")).toEqual(true);
+    expect(PROJECT_NAME_REGEX.test("my project")).toEqual(true);
+    expect(PROJECT_NAME_REGEX.test("my project 123")).toEqual(true);
+    expect(PROJECT_NAME_REGEX.test(" my project 123 ")).toEqual(true);
+    expect(PROJECT_NAME_REGEX.test("123 my project")).toEqual(true);
+    expect(PROJECT_NAME_REGEX.test("_ 123 MY PROJECT")).toEqual(true);
+
+    expect(PROJECT_NAME_REGEX.test("myProject!")).toEqual(false);
   });
 });


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2843

Changed the error message for "Project name" and also changed the regex which validates it since the previous was catching special characters as valid characters.

![Screenshot from 2020-11-12 10-51-50](https://user-images.githubusercontent.com/2582866/98924536-39b92100-24d5-11eb-8e66-7a1dd4e80150.png)
