### PR TITLE
WINDUP-2857: Fix PF3 UI : space beetween navbar and main content is too small

### DIFF
--- a/ui/src/main/webapp/css/windup-web.css
+++ b/ui/src/main/webapp/css/windup-web.css
@@ -15,7 +15,7 @@
 }
 
 .container-fluid {
-    padding-top: 60px;
+    padding-top: 80px;
 }
 
 .wizard-content .container-fluid {
@@ -155,7 +155,7 @@ fieldset.fields-section-pf {
 .wu-horizontal-nav-content {
 /*    margin-top: 122px; */
     padding-top: 122px;
-    margin-top: 0;
+/*    margin-top: 0; */
 }
 
 /*


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2857

Fix css for correct spaces between content and navbar. The bugs were originated when the "green" bar with the link for the new UI was introduced.

![2](https://user-images.githubusercontent.com/2582866/98970848-b6b5bc00-2510-11eb-8a5e-efb3d5fc94d5.png)

![1](https://user-images.githubusercontent.com/2582866/98970825-af8eae00-2510-11eb-8b16-404130ecc9b6.png)
