### PR TITLE
WINDUP-2854: New PF4 UI : Add "source" field to the review page and "none" if field is empty

### DIFF
--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
@@ -40,6 +40,18 @@ import { AxiosError } from "axios";
 import { getAxiosErrorMessage } from "utils/modelUtils";
 import { ConditionalRender } from "components";
 
+const nullabeContent = (value: any) => {
+  return value ? (
+    value
+  ) : (
+    <span className="pf-c-content">
+      <i>
+        <small>none</small>
+      </i>
+    </span>
+  );
+};
+
 interface ReviewProps extends RouteComponentProps<ProjectRoute> {}
 
 export const Review: React.FC<ReviewProps> = ({ match, history: { push } }) => {
@@ -174,7 +186,7 @@ export const Review: React.FC<ReviewProps> = ({ match, history: { push } }) => {
                 <DescriptionListGroup>
                   <DescriptionListTerm>Description</DescriptionListTerm>
                   <DescriptionListDescription>
-                    {project.description}
+                    {nullabeContent(project.description)}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
@@ -192,12 +204,19 @@ export const Review: React.FC<ReviewProps> = ({ match, history: { push } }) => {
                       .join(", ")}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
-                {/* <DescriptionListGroup>
-                  <DescriptionListTerm>Annotation</DescriptionListTerm>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Source(s)</DescriptionListTerm>
                   <DescriptionListDescription>
-                    2 Annotations
+                    {nullabeContent(
+                      analysisContext.advancedOptions
+                        .filter(
+                          (f) => f.name === AdvancedOptionsFieldKey.SOURCE
+                        )
+                        .map((f) => f.value)
+                        .join(", ")
+                    )}
                   </DescriptionListDescription>
-                </DescriptionListGroup> */}
+                </DescriptionListGroup>
               </DescriptionList>
             </StackItem>
           )}

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
@@ -196,15 +196,6 @@ export const Review: React.FC<ReviewProps> = ({ match, history: { push } }) => {
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
-                  <DescriptionListTerm>Target(s)</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {analysisContext.advancedOptions
-                      .filter((f) => f.name === AdvancedOptionsFieldKey.TARGET)
-                      .map((f) => f.value)
-                      .join(", ")}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
                   <DescriptionListTerm>Source(s)</DescriptionListTerm>
                   <DescriptionListDescription>
                     {nullabeContent(
@@ -215,6 +206,15 @@ export const Review: React.FC<ReviewProps> = ({ match, history: { push } }) => {
                         .map((f) => f.value)
                         .join(", ")
                     )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Target(s)</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {analysisContext.advancedOptions
+                      .filter((f) => f.name === AdvancedOptionsFieldKey.TARGET)
+                      .map((f) => f.value)
+                      .join(", ")}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               </DescriptionList>

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
@@ -196,6 +196,15 @@ export const Review: React.FC<ReviewProps> = ({ match, history: { push } }) => {
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
+                  <DescriptionListTerm>Target(s)</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {analysisContext.advancedOptions
+                      .filter((f) => f.name === AdvancedOptionsFieldKey.TARGET)
+                      .map((f) => f.value)
+                      .join(", ")}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
                   <DescriptionListTerm>Source(s)</DescriptionListTerm>
                   <DescriptionListDescription>
                     {nullabeContent(
@@ -206,15 +215,6 @@ export const Review: React.FC<ReviewProps> = ({ match, history: { push } }) => {
                         .map((f) => f.value)
                         .join(", ")
                     )}
-                  </DescriptionListDescription>
-                </DescriptionListGroup>
-                <DescriptionListGroup>
-                  <DescriptionListTerm>Target(s)</DescriptionListTerm>
-                  <DescriptionListDescription>
-                    {analysisContext.advancedOptions
-                      .filter((f) => f.name === AdvancedOptionsFieldKey.TARGET)
-                      .map((f) => f.value)
-                      .join(", ")}
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               </DescriptionList>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2854

Added nullable function to replace possible empty React nodes with `none`.

![Screenshot from 2020-11-13 11-06-24](https://user-images.githubusercontent.com/2582866/99060472-5ec69600-25a0-11eb-8654-116972db5081.png)
