### PR TITLE
WINDUP-2824: About page: change git revision labels' style

### DIFF
--- a/ui-pf4/src/main/webapp/src/layout/ButtonAboutApp/ButtonAboutApp.scss
+++ b/ui-pf4/src/main/webapp/src/layout/ButtonAboutApp/ButtonAboutApp.scss
@@ -3,4 +3,8 @@
     margin-top: 10px;
     margin-bottom: 20px;
   }
+
+  .dt {
+    font-weight: var(--pf-c-content--dt--FontWeight);
+  }
 }

--- a/ui-pf4/src/main/webapp/src/layout/ButtonAboutApp/ButtonAboutApp.tsx
+++ b/ui-pf4/src/main/webapp/src/layout/ButtonAboutApp/ButtonAboutApp.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useState } from "react";
 import {
   AboutModal,
   TextContent,
-  TextList,
-  TextListItem,
   Button,
   ButtonVariant,
   List,
   ListItem,
   Flex,
   FlexItem,
+  Grid,
+  GridItem,
 } from "@patternfly/react-core";
 import {
   HelpIcon,
@@ -79,11 +79,13 @@ export const ButtonAboutApp: React.FC = () => {
           </p>
         </TextContent>
         <TextContent className="pf-u-py-xl">
-          <TextList component="dl">
-            <TextListItem component="dt">
-              Migration Toolkit for Applications Core
-            </TextListItem>
-            <TextListItem component="dd">
+          <Grid hasGutter>
+            <GridItem lg={7}>
+              <span className="dt">
+                Migration Toolkit for Applications Core
+              </span>
+            </GridItem>
+            <GridItem lg={5}>
               {windupVersion.version}
               {windupVersion.version.indexOf("SNAPSHOT") !== -1 && (
                 <>
@@ -98,11 +100,13 @@ export const ButtonAboutApp: React.FC = () => {
                   {")"}
                 </>
               )}
-            </TextListItem>
-            <TextListItem component="dt">
-              Migration Toolkit for Applications Web Console
-            </TextListItem>
-            <TextListItem component="dd">
+            </GridItem>
+            <GridItem lg={7}>
+              <span className="dt">
+                Migration Toolkit for Applications Web Console
+              </span>
+            </GridItem>
+            <GridItem lg={5}>
               {WINDUP_WEB_VERSION}
               {WINDUP_WEB_VERSION.indexOf("SNAPSHOT") !== -1 && (
                 <>
@@ -117,8 +121,8 @@ export const ButtonAboutApp: React.FC = () => {
                   {")"}
                 </>
               )}
-            </TextListItem>
-          </TextList>
+            </GridItem>
+          </Grid>
         </TextContent>
         <TextContent>
           <h4>Links</h4>

--- a/ui-pf4/src/main/webapp/src/layout/ButtonAboutApp/__tests__/__snapshots__/ButtonAboutApp.test.tsx.snap
+++ b/ui-pf4/src/main/webapp/src/layout/ButtonAboutApp/__tests__/__snapshots__/ButtonAboutApp.test.tsx.snap
@@ -47,28 +47,36 @@ exports[`Test snapshot :: open modal 1`] = `
     <TextContent
       className="pf-u-py-xl"
     >
-      <TextList
-        component="dl"
+      <Grid
+        hasGutter={true}
       >
-        <TextListItem
-          component="dt"
+        <GridItem
+          lg={7}
         >
-          Migration Toolkit for Applications Core
-        </TextListItem>
-        <TextListItem
-          component="dd"
+          <span
+            className="dt"
+          >
+            Migration Toolkit for Applications Core
+          </span>
+        </GridItem>
+        <GridItem
+          lg={5}
         >
           (loading)
-        </TextListItem>
-        <TextListItem
-          component="dt"
+        </GridItem>
+        <GridItem
+          lg={7}
         >
-          Migration Toolkit for Applications Web Console
-        </TextListItem>
-        <TextListItem
-          component="dd"
+          <span
+            className="dt"
+          >
+            Migration Toolkit for Applications Web Console
+          </span>
+        </GridItem>
+        <GridItem
+          lg={5}
         />
-      </TextList>
+      </Grid>
     </TextContent>
     <TextContent>
       <h4>
@@ -237,28 +245,36 @@ exports[`Test snapshot 1`] = `
     <TextContent
       className="pf-u-py-xl"
     >
-      <TextList
-        component="dl"
+      <Grid
+        hasGutter={true}
       >
-        <TextListItem
-          component="dt"
+        <GridItem
+          lg={7}
         >
-          Migration Toolkit for Applications Core
-        </TextListItem>
-        <TextListItem
-          component="dd"
+          <span
+            className="dt"
+          >
+            Migration Toolkit for Applications Core
+          </span>
+        </GridItem>
+        <GridItem
+          lg={5}
         >
           (loading)
-        </TextListItem>
-        <TextListItem
-          component="dt"
+        </GridItem>
+        <GridItem
+          lg={7}
         >
-          Migration Toolkit for Applications Web Console
-        </TextListItem>
-        <TextListItem
-          component="dd"
+          <span
+            className="dt"
+          >
+            Migration Toolkit for Applications Web Console
+          </span>
+        </GridItem>
+        <GridItem
+          lg={5}
         />
-      </TextList>
+      </Grid>
     </TextContent>
     <TextContent>
       <h4>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2824

Replaced <dt/> by <grid> to allow MTA version labels to be splitted in when md, sm, xs