### PR TITLE
WINDUP-2869: PF4 Web UI - Red Hat Runtimes - change transformation path

### DIFF
--- a/ui-pf4/src/main/webapp/cypress/integration/new-project.spec.js
+++ b/ui-pf4/src/main/webapp/cypress/integration/new-project.spec.js
@@ -63,7 +63,7 @@ context("New Project", () => {
     /**
      * Step 3: Transformation path
      */
-    cy.contains("Select transformation path");
+    cy.contains("Select transformation target");
     verifyActionButtonsEnabled();
 
     cy.get(".pf-c-card.pf-m-selectable").first().click({ force: true });

--- a/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
+++ b/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
@@ -76,7 +76,7 @@ const options: TransformationPathOption[] = [
     iconSrc: quarkusLogo,
   },
   {
-    label: "Red Hat Runtimes",
+    label: "Spring Boot on Red Hat Runtimes",
     description:
       "A set of rules for assessing the compatibility of applications against the versions of Spring Boot libraries supported by Red Hat Runtimes.",
     options: "rhr",

--- a/ui-pf4/src/main/webapp/src/components/transformation-path/transformation-path.tsx
+++ b/ui-pf4/src/main/webapp/src/components/transformation-path/transformation-path.tsx
@@ -38,7 +38,7 @@ export const TransformationPath: React.FC<TransformationPathProps> = ({
           <StackItem>
             <TextContent>
               <Title headingLevel="h5" size={TitleSizes["lg"]}>
-                Select transformation path
+                Select transformation target
               </Title>
               <Text component="small">
                 Select one or more targets by clicking on the icons below.

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/wizard/project-wizard.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/wizard/project-wizard.tsx
@@ -96,7 +96,7 @@ export const NewProjectWizard: React.FC<NewProjectWizardProps> = ({
       steps: [
         {
           id: WizardStepIds.SET_TRANSFORMATION_PATH,
-          name: "Set transformation path",
+          name: "Set transformation target",
           component: undefined,
           canJumpTo:
             WizardStepIds.SET_TRANSFORMATION_PATH <= stepId || hasMinData,


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2869

- Changed `transformation path` by `transformation target`
- Changed `Red Hat Runtimes` by `Spring Boot on Red Hat Runtimes`


![Screenshot from 2020-11-19 09-15-49](https://user-images.githubusercontent.com/2582866/99639535-008a2f00-2a48-11eb-9767-2972072bed54.png)
