### PR TITLE
WINDUP-2873: MTA Web UI - PF4 - Hide include Tags Advanced Option

### DIFF
--- a/ui-pf4/src/main/webapp/src/Constants.tsx
+++ b/ui-pf4/src/main/webapp/src/Constants.tsx
@@ -47,7 +47,7 @@ export enum AdvancedOptionsFieldKey {
   // Dropdowns
   TARGET = "target",
   SOURCE = "source",
-  INCLUDE_TAGS = "includeTags",
+  // INCLUDE_TAGS = "includeTags",
   EXCLUDE_TAGS = "excludeTags",
 
   // Input texts

--- a/ui-pf4/src/main/webapp/src/components/advanced-options-form/advanced-options-form.tsx
+++ b/ui-pf4/src/main/webapp/src/components/advanced-options-form/advanced-options-form.tsx
@@ -39,7 +39,7 @@ const tooltipTextFrom = (info: IFieldInfo, config: ConfigurationOption) => {
 interface FormValues {
   [AdvancedOptionsFieldKey.TARGET]: string[];
   [AdvancedOptionsFieldKey.SOURCE]?: string[];
-  [AdvancedOptionsFieldKey.INCLUDE_TAGS]?: string[];
+  // [AdvancedOptionsFieldKey.INCLUDE_TAGS]?: string[];
   [AdvancedOptionsFieldKey.EXCLUDE_TAGS]?: string[];
 
   [AdvancedOptionsFieldKey.ADDITIONAL_CLASSPATH]?: string;

--- a/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
@@ -50,14 +50,14 @@ export const Fields: Map<AdvancedOptionsFieldKey, IFieldInfo> = new Map([
         'The source server/technology/framework to migrate from. This could include multiple items (e.g., "eap" and "spring") separated by a space.',
     },
   ],
-  [
-    AdvancedOptionsFieldKey.INCLUDE_TAGS,
-    {
-      label: "Include tags",
-      type: "dropdown",
-      placeholder: "Select tags",
-    },
-  ],
+  // [
+  //   AdvancedOptionsFieldKey.INCLUDE_TAGS,
+  //   {
+  //     label: "Include tags",
+  //     type: "dropdown",
+  //     placeholder: "Select tags",
+  //   },
+  // ],
   [
     AdvancedOptionsFieldKey.EXCLUDE_TAGS,
     {


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2873

- Removed "Included tags" from the advanced options.
- The "Excluded tags" won't be removed since it does not generate any bug, only "Include tags" does.

![Screenshot from 2020-11-19 11-24-12](https://user-images.githubusercontent.com/2582866/99653832-d3467c80-2a59-11eb-8818-332dbf3eea4d.png)
