### PR TITLE
WINDUP-2829: MTA 5.1.0 alpha build : Tattletale report links are broken

### DIFF
--- a/ui-pf4/src/main/webapp/src/Constants.tsx
+++ b/ui-pf4/src/main/webapp/src/Constants.tsx
@@ -58,7 +58,7 @@ export enum AdvancedOptionsFieldKey {
 
   // Switch
   EXPORT_CSV = "exportCSV",
-  TATTLETALE = "enableTattletale",
+  TATTLETALE = "disableTattletale",
   CLASS_NOT_FOUND_ANALYSIS = "enableClassNotFoundAnalysis",
   COMPATIBLE_FILES_REPORT = "enableCompatibleFilesReport",
   EXPLODED_APP = "explodedApp",

--- a/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
@@ -111,7 +111,7 @@ export const Fields: Map<AdvancedOptionsFieldKey, IFieldInfo> = new Map([
       label: "Disable Tattletale",
       type: "switch",
       description:
-        "Use this option to disable the Tattle reports, which are enabled by default.",
+        "Use this option to disable the Tattletale reports, which are enabled by default.",
     },
   ],
   [

--- a/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
@@ -108,7 +108,7 @@ export const Fields: Map<AdvancedOptionsFieldKey, IFieldInfo> = new Map([
   [
     AdvancedOptionsFieldKey.TATTLETALE,
     {
-      label: "Disable tattletale",
+      label: "Disable Tattletale",
       type: "switch",
       description:
         "Use this option to disable the Tattle reports, which are enabled by default.",

--- a/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
@@ -108,8 +108,10 @@ export const Fields: Map<AdvancedOptionsFieldKey, IFieldInfo> = new Map([
   [
     AdvancedOptionsFieldKey.TATTLETALE,
     {
-      label: "Tattletale",
+      label: "Disable tattletale",
       type: "switch",
+      description:
+        "Use this option to disable the Tattle reports, which are enabled by default.",
     },
   ],
   [


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2829

- Changed label "Tattletale" by "Disable Tattletale"
- Changed the default tooltip of "Disable Tattletale"
- Changed the CLI property used for "Disabled Tattletale"

![Screenshot from 2020-11-19 16-20-31](https://user-images.githubusercontent.com/2582866/99685705-2b45a900-2a83-11eb-8773-c91180a790af.png)

