### PR TITLE
WINDUP-2877: MTA Web UI - PF4 - Applications page - info alert doesn't disappear

### DIFF
--- a/ui-pf4/src/main/webapp/src/pages/applications/application-list/application-list.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/applications/application-list/application-list.tsx
@@ -59,11 +59,7 @@ const columns: ICell[] = [
   { title: "Date added", transforms: [sortable] },
 ];
 
-const compareProject = (
-  a: Application,
-  b: Application,
-  columnIndex?: number
-) => {
+const compareFn = (a: Application, b: Application, columnIndex?: number) => {
   switch (columnIndex) {
     case 0: // Application
       return a.title.localeCompare(b.title);
@@ -74,7 +70,7 @@ const compareProject = (
   }
 };
 
-const filterProject = (filterText: string, application: Application) => {
+const filterFn = (filterText: string, application: Application) => {
   return (
     application.title.toLowerCase().indexOf(filterText.toLowerCase()) !== -1
   );
@@ -125,12 +121,9 @@ export const ApplicationList: React.FC<ApplicationListProps> = ({ match }) => {
   );
 
   const activeExecutions = (executions || [])
-    .map((f) => {
-      const wsExecution = wsExecutions.find((element) => element.id === f.id);
-      return wsExecution || f;
-    })
-    .filter((f) => f.projectId === parseInt(match.params.project))
-    .filter((f) => isExecutionActive(f));
+    .filter((e) => isExecutionActive(e))
+    .map((e) => wsExecutions.find((w) => w.id === e.id) || e)
+    .filter((e) => isExecutionActive(e));
 
   const actionResolver = (): (IAction | ISeparator)[] => {
     return [
@@ -238,8 +231,8 @@ export const ApplicationList: React.FC<ApplicationListProps> = ({ match }) => {
             loadingVariant="skeleton"
             isLoadingData={isFetching}
             loadingDataError={fetchError}
-            compareItem={compareProject}
-            filterItem={filterProject}
+            compareItem={compareFn}
+            filterItem={filterFn}
             mapToIRow={applicationToIRow}
             toolbar={
               <ToolbarGroup variant="button-group">


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2877

This PR fixes the way to check "Active analysis" from a Project.
The way of detecting the number of active analysis is based on 2 data sources:

- The list of executions coming from the endpoint `/mta-web/api/windup/by-project/{projectId}` which returns a static list of executions from a project.
- The list of executing coming from the websocket.

The first data source has more priority over the second; the second source of data will be used only for the "active" elements of the first data source, in short words: "Only check the Websocket if the analysis is running or waiting in a queue"

![Screenshot from 2020-11-20 15-25-34](https://user-images.githubusercontent.com/2582866/99810890-acb14000-2b44-11eb-90b2-5c20343ec7d9.png)
