### PR TITLE
WINDUP-2878, WINDUP-2880: Advanced Options tooltips change

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
+++ b/ui-pf4/src/main/webapp/src/components/advanced-options-form/schema.ts
@@ -47,7 +47,7 @@ export const Fields: Map<AdvancedOptionsFieldKey, IFieldInfo> = new Map([
       type: "dropdown",
       placeholder: "Select sources",
       description:
-        'The source server/technology/framework to migrate from. This could include multiple items (e.g., "eap" and "spring") separated by a space.',
+        'The source server/technology/framework to migrate from. This could include multiple items (e.g., "eap" and "springboot") separated by a space.',
     },
   ],
   [
@@ -73,6 +73,7 @@ export const Fields: Map<AdvancedOptionsFieldKey, IFieldInfo> = new Map([
     {
       label: "Additional classpath",
       type: "input",
+      description: "Adds additional files or directories to the classpath.",
     },
   ],
   [
@@ -166,6 +167,8 @@ export const Fields: Map<AdvancedOptionsFieldKey, IFieldInfo> = new Map([
     {
       label: "Source mode",
       type: "switch",
+      description:
+        "Indicates whether the input file or directory is a source code or compiled binaries (default).",
     },
   ],
 ]);


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2878
https://issues.redhat.com/browse/WINDUP-2880

This PR contains 3 changes in the "Advanced options" page:
- Change "spring" to "springboot" in the tooltip of the field "**Source**".
- Set a description, which ends with a period, to the field "**Additional classpath**"
- Set a description to the switch "**Source mode**" 