### PR TITLE
Remove virtualizacion of tree and set height

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/package-dual-list/package-dual-list.tsx
+++ b/ui-pf4/src/main/webapp/src/components/package-dual-list/package-dual-list.tsx
@@ -7,6 +7,8 @@ import "antd/lib/tree/style/index.css";
 
 import { Package } from "models/api";
 
+const TRANSFER_TREE_HEIGHT = 400;
+
 interface TreeNode {
   key: string;
   title: string;
@@ -118,13 +120,17 @@ export const PackageDualList: React.FC<PackageDualListProps> = ({
           showSelectAll={true}
           onChange={handleTransferChange}
           targetKeys={targetKeys} // A set of keys of elements that are listed on the right column
+          listStyle={{
+            height: TRANSFER_TREE_HEIGHT + 40, // We need to add the size of the header
+          }}
         >
           {({ direction, onItemSelect, selectedKeys }) => {
             if (direction === "left") {
               const checkedKeys = [...selectedKeys, ...targetKeys];
               return (
                 <Tree
-                  height={350}
+                  virtual={false}
+                  height={TRANSFER_TREE_HEIGHT}
                   blockNode // Whether treeNode fill remaining horizontal space
                   checkable // Add a Checkbox before the treeNodes
                   checkStrictly // Check treeNode precisely; parent treeNode and children treeNodes are not associated


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2881

Changes:

- Removed virtualization of the tree (virtualization enhances the performance in the case of thousands of nodes in the tree). Even though virtualization is a good feature, it makes the scroll to disappear unless the user moves the scroll and makes the UX poor so I think it is good to remove it.
- Set a static heigh size to the tree.

To test this PR use the application linked in this [JIRA comment](https://issues.redhat.com/browse/WINDUP-2881?focusedCommentId=15512746&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15512746)

![Screenshot from 2020-11-23 16-29-18](https://user-images.githubusercontent.com/2582866/99981421-a96abe00-2da9-11eb-9749-2ff4ae6b00e0.png)
