### PR TITLE
WINDUP-2899: Link to download "server path" application is not working

### DIFF
--- a/ui-pf4/src/main/webapp/src/pages/applications/application-list/application-list.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/applications/application-list/application-list.tsx
@@ -168,7 +168,9 @@ export const ApplicationList: React.FC<ApplicationListProps> = ({ match }) => {
         },
         cells: [
           {
-            title: (
+            title: item.exploded ? (
+              item.title
+            ) : (
               <a href={getDownloadRegisteredApplicationURL(item.id)}>
                 {item.title}
               </a>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2899

If the application is "exploded" then the link for downloading the file will disappear and just the title of the file will appear