### PR TITLE
WINDUP-2913: Allow user to delete an application if app upload failed

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/add-applications-form/add-applications-uploadfiles-form.tsx
+++ b/ui-pf4/src/main/webapp/src/components/add-applications-form/add-applications-uploadfiles-form.tsx
@@ -41,6 +41,7 @@ export const AddApplicationsUploadFilesForm: React.FC<AddApplicationsUploadFiles
       accept=".ear,.har,.jar,.rar,.sar,.war,.zip"
       template="dropdown-box"
       hideProgressOnSuccess={true}
+      allowRemove={true}
     />
   );
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2913

If an application fails to be uploaded then the user is now able to delete that row.

![Screenshot from 2020-12-04 10-54-53](https://user-images.githubusercontent.com/2582866/101149472-471e8280-361f-11eb-91d4-6aa5c009706b.png)
