### PR TITLE
WINDUP-2906: [UI] Same tooltip for invalid labels and rules files

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/rule-label-title/rule-label-title.tsx
+++ b/ui-pf4/src/main/webapp/src/components/rule-label-title/rule-label-title.tsx
@@ -9,13 +9,17 @@ import {
   global_danger_color_100 as dangerColor,
 } from "@patternfly/react-tokens";
 
+import { RuleLabel } from "models/api";
+
 export interface RulelabelTitleProps {
+  type: RuleLabel;
   name: string;
   errors: string[];
   numberOfRulesLabels: number;
 }
 
 export const RulelabelTitle: React.FC<RulelabelTitleProps> = ({
+  type,
   name,
   errors,
   numberOfRulesLabels,
@@ -33,7 +37,9 @@ export const RulelabelTitle: React.FC<RulelabelTitleProps> = ({
   }
   if (numberOfRulesLabels === 0) {
     info = (
-      <Tooltip content="Could not identify any rule inside this file/folder">
+      <Tooltip
+        content={`Could not identify any ${type.toLocaleLowerCase()} inside this file/folder`}
+      >
         <i>
           {" "}
           <WarningTriangleIcon color={warningColor.value} />

--- a/ui-pf4/src/main/webapp/src/components/rule-label-title/tests/rule-label-title.test.tsx
+++ b/ui-pf4/src/main/webapp/src/components/rule-label-title/tests/rule-label-title.test.tsx
@@ -5,7 +5,12 @@ import { RulelabelTitle } from "../rule-label-title";
 describe("RulelabelTitle", () => {
   it("Renders without crashing", () => {
     const wrapper = shallow(
-      <RulelabelTitle name="My rule" errors={[]} numberOfRulesLabels={0} />
+      <RulelabelTitle
+        type="Rule"
+        name="My rule"
+        errors={[]}
+        numberOfRulesLabels={0}
+      />
     );
     expect(wrapper).toMatchSnapshot();
   });

--- a/ui-pf4/src/main/webapp/src/containers/custom-labels/custom-labels.tsx
+++ b/ui-pf4/src/main/webapp/src/containers/custom-labels/custom-labels.tsx
@@ -207,6 +207,7 @@ export const CustomLabels: React.FC<CustomLabelsProps> = ({
             {
               title: (
                 <RulelabelTitle
+                  type="Label"
                   name={item.shortPath || item.path}
                   errors={errors}
                   numberOfRulesLabels={numberOfLabels}

--- a/ui-pf4/src/main/webapp/src/containers/custom-rules/custom-rules.tsx
+++ b/ui-pf4/src/main/webapp/src/containers/custom-rules/custom-rules.tsx
@@ -208,6 +208,7 @@ export const CustomRules: React.FC<CustomRulesProps> = ({
             {
               title: (
                 <RulelabelTitle
+                  type="Rule"
                   name={item.shortPath || item.path}
                   errors={errors}
                   numberOfRulesLabels={numberOfRules}

--- a/ui-pf4/src/main/webapp/src/pages/global-labels/user-provided/user-provided.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/global-labels/user-provided/user-provided.tsx
@@ -138,6 +138,7 @@ export const UserProvided: React.FC = () => {
             {
               title: (
                 <RulelabelTitle
+                  type="Label"
                   name={item.shortPath || item.path}
                   errors={errors}
                   numberOfRulesLabels={numberOfLabels}

--- a/ui-pf4/src/main/webapp/src/pages/global-rules/user-provided/user-provided.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/global-rules/user-provided/user-provided.tsx
@@ -144,6 +144,7 @@ export const UserProvided: React.FC = () => {
             {
               title: (
                 <RulelabelTitle
+                  type="Rule"
                   name={item.shortPath || item.path}
                   errors={errors}
                   numberOfRulesLabels={numberOfRules}


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2906

This PR makes a small change in order to show the words "label" or "rule" depending on which of those components we are located in. See the screenshots of the ticket.