### PR TITLE
WINDUP-2940: Static reports available through new "mta-ui" context

### DIFF
--- a/services/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/services/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-web>
-    <context-root>mta-web/api</context-root>
+    <context-root>mta-ui/api</context-root>
 </jboss-web>

--- a/tools/graph-tool/src/main/java/org/jboss/windup/web/ui/FreemarkerServlet.java
+++ b/tools/graph-tool/src/main/java/org/jboss/windup/web/ui/FreemarkerServlet.java
@@ -94,7 +94,7 @@ public class FreemarkerServlet extends freemarker.ext.servlet.FreemarkerServlet
              */
             String apiServerUrl = this.readEnvVariable(
                     "MTA_API_SERVER_URL",
-                    System.getProperty("mta.apiServer.url", serverAddress + "/mta-web/api")
+                    System.getProperty("mta.apiServer.url", serverAddress + "/mta-ui/api")
             );
 
             hashModel.put("apiServerUrl", apiServerUrl);

--- a/ui-pf4/src/main/java/org/jboss/windup/web/ui/PF4FreemarkerServlet.java
+++ b/ui-pf4/src/main/java/org/jboss/windup/web/ui/PF4FreemarkerServlet.java
@@ -94,7 +94,7 @@ public class PF4FreemarkerServlet extends freemarker.ext.servlet.FreemarkerServl
              */
             String apiServerUrl = this.readEnvVariable(
                     "MTA_API_SERVER_URL",
-                    System.getProperty("mta.apiServer.url", serverAddress + "/mta-web/api")
+                    System.getProperty("mta.apiServer.url", serverAddress + "/mta-ui/api")
             );
 
             hashModel.put("apiServerUrl", apiServerUrl);

--- a/ui-pf4/src/main/webapp/src/api/apiInit.ts
+++ b/ui-pf4/src/main/webapp/src/api/apiInit.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-export const API_BASE_URL = "/mta-web/api";
+export const API_BASE_URL = "/mta-ui/api";
 
 export const initApi = () => {
   axios.defaults.baseURL = `${API_BASE_URL}`;

--- a/ui/src/main/java/org/jboss/windup/web/ui/FreemarkerServlet.java
+++ b/ui/src/main/java/org/jboss/windup/web/ui/FreemarkerServlet.java
@@ -94,7 +94,7 @@ public class FreemarkerServlet extends freemarker.ext.servlet.FreemarkerServlet
              */
             String apiServerUrl = this.readEnvVariable(
                     "MTA_API_SERVER_URL",
-                    System.getProperty("mta.apiServer.url", serverAddress + "/mta-web/api")
+                    System.getProperty("mta.apiServer.url", serverAddress + "/mta-ui/api")
             );
 
             hashModel.put("apiServerUrl", apiServerUrl);


### PR DESCRIPTION
https://issues.redhat.com/projects/WINDUP/issues/WINDUP-2940

Static reports url changed from `/mta-web/api/static-report/2/index.html` to `/mta-ui/api/static-report/2/index.html`