### PR TITLE
WINDUP-2890: RFE: We should not be able to "Enable" a rule with invalid file name

### DIFF
--- a/ui-pf4/src/main/webapp/src/containers/custom-rules/custom-rules.tsx
+++ b/ui-pf4/src/main/webapp/src/containers/custom-rules/custom-rules.tsx
@@ -236,7 +236,7 @@ export const CustomRules: React.FC<CustomRulesProps> = ({
                   onChange={(isChecked) =>
                     handleRulePathToggled(isChecked, item)
                   }
-                  isDisabled={errors.length > 0}
+                  isDisabled={errors.length > 0 || numberOfRules === 0}
                 />
               ),
             },


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2890

Disables the "Switch" button in the table (see screenshot)

![Screenshot from 2021-01-11 11-28-19](https://user-images.githubusercontent.com/2582866/104169711-46d48c80-5400-11eb-8a9a-80d1a04bcadb.png)
