### PR TITLE
Restored 'debug' profile

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -499,7 +499,7 @@
             <id>debug</id>
             <activation> <property> <name>debug</name> </property> </activation>
             <properties>
-                <jvm.debug.argsx>-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=y</jvm.debug.argsx>
+                <jvm.debug.args>-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=y</jvm.debug.args>
             </properties>
         </profile>
 
@@ -507,6 +507,9 @@
             <id>arquillian-wildfly-10-managed</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>debug</name>
+                </property>
             </activation>
             <dependencies>
                 <dependency>
@@ -561,7 +564,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <server.jvm.args>${surefire.server.jvm.args}</server.jvm.args>
+                                <server.jvm.args>${jvm.debug.args}</server.jvm.args>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                             </systemPropertyVariables>
                         </configuration>


### PR DESCRIPTION
- `argsx` was a typo
- `activeByDefault` is disabled when a profile is enabled so the property `debug` has been added to ensure it's enabled also when debugging
- no usage/value for `surefire.server.jvm.args` property has been found anywhere so it has been replaced with `jvm.debug.args`