### PR TITLE
[WINDUP-3320] - Improvements to the presentation of the 'Review project details'

### DIFF
--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/review/review.tsx
@@ -253,6 +253,19 @@ export const Review: React.FC<ReviewProps> = ({ match, history }) => {
                   </DescriptionListDescription>
                 </DescriptionListGroup>
                 <DescriptionListGroup>
+                  <DescriptionListTerm>Sources</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    {nullabeContent(
+                      analysisContext.advancedOptions
+                        .filter(
+                          (f) => f.name === AdvancedOptionsFieldKey.SOURCE
+                        )
+                        .map((f) => f.value)
+                        .join(", ")
+                    )}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
                   <DescriptionListTerm>Included packages</DescriptionListTerm>
                   <DescriptionListDescription>
                     {analysisContext.includePackages.length === 0 ? (
@@ -312,6 +325,7 @@ export const Review: React.FC<ReviewProps> = ({ match, history }) => {
                   <DescriptionListTerm>Advanced options</DescriptionListTerm>
                   <DescriptionListDescription>
                     {getAdvancedOptionsWithExclusion(analysisContext, [
+                      AdvancedOptionsFieldKey.SOURCE,
                       AdvancedOptionsFieldKey.TARGET,
                     ]).length > 0 ? (
                       <table


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3320

- Added SOURCES to the review page
- The set of Sources should no longer appear in the Advanced options, at the bottom of the review page.

![Screenshot from 2022-04-01 11-33-15](https://user-images.githubusercontent.com/2582866/161237191-431e7b86-9238-4b35-b93b-bb403376ca33.png)
