### PR TITLE
[WINDUP-3333] - Web Console fails to start if any of the parent folders contains blank spaces

### DIFF
--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
@@ -1,5 +1,6 @@
 package org.jboss.windup.web.furnaceserviceprovider;
 
+import org.jboss.forge.furnace.util.OperatingSystemUtils;
 import org.jboss.vfs.VFS;
 import org.jboss.vfs.VirtualFile;
 
@@ -127,11 +128,12 @@ public class WebProperties
             String pathString;
             if (pathUrl.toString().startsWith("vfs:"))
             {
-                // In Windows OS the pathUrl points to the full path. E.g.
-                // vfs:/C:/Users/myUsername/Downloads/mta-web/temp 1/content/api.war/WEB-INF/lib/furnace-service-provider-5.3.0-SNAPSHOT.jar
-                // This full path might contain blank spaces which will generate an exception.
-                // The following code will avoid the exception in Windows OS
-                if (pathUrl.toString().contains(" ")) {
+                // Below there are examples of different the values for "pathUrl" depending on the OS where MTA Web is running:
+                // In Linux: pathUrl=vfs:/content/api.war/WEB-INF/lib/furnace-service-provider-5.3.0.Final.jar
+                // In Windows pathUrl=vfs:/C:/Users/myUsername/Downloads/mta-web/temp 1/content/api.war/WEB-INF/lib/furnace-service-provider-5.3.0.Final.jar
+                // In Windows: due to the fact that "pathUrl" contains the full path, there is the possibility that
+                // "pathUrl" might contain blank spaces which will generate an exception on "pathUrl.toURI()".
+                if (OperatingSystemUtils.isWindows() && pathUrl.toString().contains(" ")) {
                     pathUrl = new URL(pathUrl.toString().replace(" ", "%20"));
                 }
 

--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
@@ -6,6 +6,7 @@ import org.jboss.vfs.VirtualFile;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -126,6 +127,14 @@ public class WebProperties
             String pathString;
             if (pathUrl.toString().startsWith("vfs:"))
             {
+                // In Windows OS the pathUrl points to the full path. E.g.
+                // vfs:/C:/Users/myUsername/Downloads/mta-web/temp 1/content/api.war/WEB-INF/lib/furnace-service-provider-5.3.0-SNAPSHOT.jar
+                // This full path might contain blank spaces which will generate an exception.
+                // The following code will avoid the exception in Windows OS
+                if (pathUrl.toString().contains(" ")) {
+                    pathUrl = new URL(pathUrl.toString().replace(" ", "%20"));
+                }
+
                 VirtualFile virtualFile = VFS.getChild(pathUrl.toURI());
                 pathString = virtualFile.getParent().getParent().getParent().getPhysicalFile().getCanonicalPath();
                 LOG.info("From VFS - Path String: " + pathString);

--- a/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
+++ b/furnace-service-provider/src/main/java/org/jboss/windup/web/furnaceserviceprovider/WebProperties.java
@@ -128,7 +128,7 @@ public class WebProperties
             String pathString;
             if (pathUrl.toString().startsWith("vfs:"))
             {
-                // Below there are examples of different the values for "pathUrl" depending on the OS where MTA Web is running:
+                // Below there are examples of different values for "pathUrl" depending on the OS where the Web Console is running:
                 // In Linux: pathUrl=vfs:/content/api.war/WEB-INF/lib/furnace-service-provider-5.3.0.Final.jar
                 // In Windows pathUrl=vfs:/C:/Users/myUsername/Downloads/mta-web/temp 1/content/api.war/WEB-INF/lib/furnace-service-provider-5.3.0.Final.jar
                 // In Windows: due to the fact that "pathUrl" contains the full path, there is the possibility that


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3333