### PR TITLE
Add openjdk17 to the transformation path page

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
+++ b/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
@@ -69,7 +69,18 @@ const options: TransformationPathOption[] = [
   {
     label: "OpenJDK 11",
     description: "Rules to support the migration to OpenJDK 11 from OpenJDK 8.",
-    options: "openjdk11",
+    options: [
+      {
+        label: "OpenJDK 11",
+        value: "openjdk11",
+        default: false,
+      },
+      {
+        label: "OpenJDK 17",
+        value: "openjdk17",
+        default: true,
+      },
+    ],
     iconSrc: mug,
     isNew: true,
   },

--- a/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
+++ b/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
@@ -67,7 +67,7 @@ const options: TransformationPathOption[] = [
     iconSrc: mug,
   },
   {
-    label: "OpenJDK 11",
+    label: "OpenJDK",
     description: "Rules to support the migration to OpenJDK 11 from OpenJDK 8.",
     options: [
       {

--- a/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
+++ b/ui-pf4/src/main/webapp/src/components/select-card-gallery/select-card-gallery.tsx
@@ -68,7 +68,8 @@ const options: TransformationPathOption[] = [
   },
   {
     label: "OpenJDK",
-    description: "Rules to support the migration to OpenJDK 11 from OpenJDK 8.",
+    description:
+      "Rules to support upgrading the version of OpenJDK. Migrate to OpenJDK 11 or OpenJDK 17.",
     options: [
       {
         label: "OpenJDK 11",

--- a/ui-pf4/src/main/webapp/src/components/select-card/select-card.tsx
+++ b/ui-pf4/src/main/webapp/src/components/select-card/select-card.tsx
@@ -103,7 +103,11 @@ export const SelectCard: React.FC<SelectCardProps> = ({
             {label}
           </Title>
           {isNew && (
-            <Title headingLevel="h4" size="md">
+            <Title
+              headingLevel="h4"
+              size="md"
+              style={Array.isArray(options) ? { paddingBottom: 5 } : {}}
+            >
               <b>
                 <i
                   style={{


### PR DESCRIPTION
- OpenJDK 17 is the default selected in the Dropdown of its CARD.
- Requires https://github.com/windup/windup-rulesets/pull/734 

![Screenshot from 2022-08-05 10-33-01](https://user-images.githubusercontent.com/2582866/183037152-69e1b2df-bb4f-4997-8c5b-9bc930d159c4.png)

