### PR TITLE
H2 upgrade

### DIFF
--- a/model/src/main/java/org/jboss/windup/web/services/model/AdvancedOption.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/AdvancedOption.java
@@ -33,7 +33,8 @@ public class AdvancedOption implements Serializable
     @NotNull
     private String name;
 
-    @Column(length = 8192)
+    // "value" is a reserved word, hence need to be escaped
+    @Column(name = "\"value\"", length = 8192)
     private String value;
 
     public AdvancedOption() {}

--- a/model/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Type;
 
 /**
  * Contains information about how Windup analysis should be configured.
@@ -65,18 +66,22 @@ public class AnalysisContext implements Serializable
 
     @Column(nullable = false)
     @ColumnDefault("true")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean generateStaticReports = true;
 
     /*
      * @TODO temporary added for obey single target selection in migration path
      */
     @Column(name = "cloudtargets")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean cloudTargetsIncluded;
 
     @Column(name = "linuxtargets")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean linuxTargetsIncluded;
 
     @Column(name = "openjdktargets")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean openJdkTargetsIncluded;
 
     @JsonIgnore

--- a/model/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/AnalysisContext.java
@@ -66,22 +66,22 @@ public class AnalysisContext implements Serializable
 
     @Column(nullable = false)
     @ColumnDefault("true")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean generateStaticReports = true;
 
     /*
      * @TODO temporary added for obey single target selection in migration path
      */
     @Column(name = "cloudtargets")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean cloudTargetsIncluded;
 
     @Column(name = "linuxtargets")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean linuxTargetsIncluded;
 
     @Column(name = "openjdktargets")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean openJdkTargetsIncluded;
 
     @JsonIgnore

--- a/model/src/main/java/org/jboss/windup/web/services/model/Configuration.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/Configuration.java
@@ -49,7 +49,7 @@ public class Configuration implements Serializable
     private Long id;
 
     @Column
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean global;
 
     @Version

--- a/model/src/main/java/org/jboss/windup/web/services/model/Configuration.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/Configuration.java
@@ -1,6 +1,7 @@
 package org.jboss.windup.web.services.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.Type;
 
 import java.io.Serializable;
 import java.util.Set;
@@ -48,6 +49,7 @@ public class Configuration implements Serializable
     private Long id;
 
     @Column
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean global;
 
     @Version

--- a/model/src/main/java/org/jboss/windup/web/services/model/LabelsPath.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/LabelsPath.java
@@ -1,6 +1,7 @@
 package org.jboss.windup.web.services.model;
 
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -36,6 +37,7 @@ public class LabelsPath implements Serializable
     @Column
     @NotNull
     @ColumnDefault("true")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean scanRecursively = true;
 
     @Column(length = 2048)

--- a/model/src/main/java/org/jboss/windup/web/services/model/LabelsPath.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/LabelsPath.java
@@ -37,7 +37,7 @@ public class LabelsPath implements Serializable
     @Column
     @NotNull
     @ColumnDefault("true")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean scanRecursively = true;
 
     @Column(length = 2048)

--- a/model/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Type;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -62,6 +63,7 @@ public class MigrationProject implements Serializable
      */
     @Column(nullable = true)
     @ColumnDefault("FALSE")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean provisional = true;
 
     @Column(length = 120, unique = false, nullable = false)

--- a/model/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/MigrationProject.java
@@ -63,7 +63,7 @@ public class MigrationProject implements Serializable
      */
     @Column(nullable = true)
     @ColumnDefault("FALSE")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean provisional = true;
 
     @Column(length = 120, unique = false, nullable = false)

--- a/model/src/main/java/org/jboss/windup/web/services/model/Package.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/Package.java
@@ -46,7 +46,7 @@ public class Package implements Serializable
     @Column()
     private int countClasses;
 
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean isKnown;
 
     @ManyToOne()

--- a/model/src/main/java/org/jboss/windup/web/services/model/Package.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/Package.java
@@ -2,6 +2,7 @@ package org.jboss.windup.web.services.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.hibernate.annotations.Type;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -45,6 +46,7 @@ public class Package implements Serializable
     @Column()
     private int countClasses;
 
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean isKnown;
 
     @ManyToOne()

--- a/model/src/main/java/org/jboss/windup/web/services/model/RegisteredApplication.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/RegisteredApplication.java
@@ -23,6 +23,7 @@ import javax.persistence.Version;
 import javax.validation.constraints.Size;
 
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Type;
 import org.jboss.windup.web.services.validators.FileExistsConstraint;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
@@ -71,6 +72,7 @@ public class RegisteredApplication implements Serializable
      */
     @Column(nullable = false)
     @ColumnDefault("FALSE")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean exploded;
 
     @Column(length = 2048)
@@ -91,6 +93,7 @@ public class RegisteredApplication implements Serializable
     private Calendar lastModified;
 
     @Column
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean isDeleted = false;
 
     public RegisteredApplication()

--- a/model/src/main/java/org/jboss/windup/web/services/model/RegisteredApplication.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/RegisteredApplication.java
@@ -72,7 +72,7 @@ public class RegisteredApplication implements Serializable
      */
     @Column(nullable = false)
     @ColumnDefault("FALSE")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean exploded;
 
     @Column(length = 2048)
@@ -93,7 +93,7 @@ public class RegisteredApplication implements Serializable
     private Calendar lastModified;
 
     @Column
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean isDeleted = false;
 
     public RegisteredApplication()

--- a/model/src/main/java/org/jboss/windup/web/services/model/ReportFilter.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/ReportFilter.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.Type;
 
 /**
  * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
@@ -61,6 +62,7 @@ public class ReportFilter implements Serializable
     private WindupExecution windupExecution;
 
     @Column(nullable = false)
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean isEnabled = false;
 
     public ReportFilter()

--- a/model/src/main/java/org/jboss/windup/web/services/model/ReportFilter.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/ReportFilter.java
@@ -62,7 +62,7 @@ public class ReportFilter implements Serializable
     private WindupExecution windupExecution;
 
     @Column(nullable = false)
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean isEnabled = false;
 
     public ReportFilter()

--- a/model/src/main/java/org/jboss/windup/web/services/model/RulesPath.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/RulesPath.java
@@ -15,6 +15,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Type;
 
 /**
  * Contains the path to a Rules directory.
@@ -45,6 +46,7 @@ public class RulesPath implements Serializable
     @Column
     @NotNull
     @ColumnDefault("true")
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean scanRecursively = true;
 
     @Column(length = 2048)

--- a/model/src/main/java/org/jboss/windup/web/services/model/RulesPath.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/RulesPath.java
@@ -46,7 +46,7 @@ public class RulesPath implements Serializable
     @Column
     @NotNull
     @ColumnDefault("true")
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean scanRecursively = true;
 
     @Column(length = 2048)

--- a/model/src/main/java/org/jboss/windup/web/services/model/Tag.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/Tag.java
@@ -40,11 +40,11 @@ public class Tag
     private String name;
 
     @Column
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean isRoot;
 
     @Column
-    @Type(type= "org.hibernate.type.NumericBooleanType")
+    @Type(type= "yes_no")
     private boolean isPseudo;
 
     @Column

--- a/model/src/main/java/org/jboss/windup/web/services/model/Tag.java
+++ b/model/src/main/java/org/jboss/windup/web/services/model/Tag.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.Type;
 
 /**
  * @author <a href="mailto:dklingenberg@gmail.com">David Klingenberg</a>
@@ -39,9 +40,11 @@ public class Tag
     private String name;
 
     @Column
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean isRoot;
 
     @Column
+    @Type(type= "org.hibernate.type.NumericBooleanType")
     private boolean isPseudo;
 
     @Column


### PR DESCRIPTION
Changes needed for the upgrade to H2 V2 in https://github.com/windup/windup-web-distribution/pull/94

- boolean columns needed to be explicitly mapped to a type in db, hence using Hibernate `@Type`
- `AdvancedOption` Entity is using a reserved word `value` as a column name. Hence escaping it. Reserved words can be found at http://www.h2database.com/html/advanced.html