### PR TITLE
[WINDUP-3513] - MTA Web UI - Known Libraries are being analyzed erroneously

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/package-dual-list/package-dual-list.tsx
+++ b/ui-pf4/src/main/webapp/src/components/package-dual-list/package-dual-list.tsx
@@ -30,6 +30,7 @@ const packageToTree = (node: Package): TreeNode => {
 };
 
 export interface PackageDualListProps {
+  isDisabled: boolean;
   packages: Package[];
   includedPackages: string[];
   onChange: (includedPackages: string[]) => void;
@@ -57,6 +58,7 @@ const generateTree = (
 const stringCompartor = (a: string, b: string) => a.localeCompare(b);
 
 export const PackageDualList: React.FC<PackageDualListProps> = ({
+  isDisabled,
   packages,
   includedPackages,
   onChange,
@@ -123,6 +125,7 @@ export const PackageDualList: React.FC<PackageDualListProps> = ({
           listStyle={{
             height: TRANSFER_TREE_HEIGHT + 40, // We need to add the size of the header
           }}
+          disabled={isDisabled}
         >
           {({ direction, onItemSelect, selectedKeys }) => {
             if (direction === "left") {
@@ -157,6 +160,7 @@ export const PackageDualList: React.FC<PackageDualListProps> = ({
                       </small>
                     </span>
                   )}
+                  disabled={isDisabled}
                 />
               );
             }

--- a/ui-pf4/src/main/webapp/src/components/package-selection/package-selection.tsx
+++ b/ui-pf4/src/main/webapp/src/components/package-selection/package-selection.tsx
@@ -16,6 +16,7 @@ import {
   EmptyStateIcon,
   EmptyStateVariant,
   EmptyStateBody,
+  Switch,
 } from "@patternfly/react-core";
 import { UndoIcon, SpinnerIcon } from "@patternfly/react-icons";
 
@@ -29,6 +30,10 @@ export interface PackageSelectionProps {
   onSelectedPackagesChange: (values: string[]) => void;
   onUndo: () => void;
 
+  isDirty: boolean;
+  enablePackageSelection: boolean;
+  onEnablePackageSelecionChange: (isChecked: boolean) => void;
+
   isFetching: boolean;
   isFetchingPlaceholder: any;
   fetchError?: any;
@@ -39,6 +44,11 @@ export const PackageSelection: React.FC<PackageSelectionProps> = ({
   selectedPackages,
   onSelectedPackagesChange,
   onUndo,
+
+  isDirty,
+  enablePackageSelection,
+  onEnablePackageSelecionChange,
+
   isFetching,
   isFetchingPlaceholder,
   fetchError,
@@ -66,17 +76,30 @@ export const PackageSelection: React.FC<PackageSelectionProps> = ({
                   </Text>
                 </LevelItem>
                 <LevelItem>
-                  <Tooltip content={<div>Restore initial values.</div>}>
-                    <Button variant="plain" aria-label="Undo" onClick={onUndo}>
-                      <UndoIcon /> Undo
-                    </Button>
-                  </Tooltip>
+                  {enablePackageSelection && isDirty && (
+                    <Tooltip content={<div>Restore initial values.</div>}>
+                      <Button
+                        variant="plain"
+                        aria-label="Undo"
+                        onClick={onUndo}
+                      >
+                        <UndoIcon /> Undo
+                      </Button>
+                    </Tooltip>
+                  )}
+                  <Switch
+                    isChecked={enablePackageSelection}
+                    onChange={onEnablePackageSelecionChange}
+                    label="On"
+                    labelOff="Off"
+                  />
                 </LevelItem>
               </Level>
             </TextContent>
           </StackItem>
           <StackItem>
             <PackageDualList
+              isDisabled={!enablePackageSelection}
               packages={packages}
               includedPackages={selectedPackages}
               onChange={onSelectedPackagesChange}

--- a/ui-pf4/src/main/webapp/src/pages/analysis-configuration/configuration-details/packages/packages.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/analysis-configuration/configuration-details/packages/packages.tsx
@@ -185,6 +185,7 @@ export const Packages: React.FC<PackagesProps> = ({
                 enablePackageSelection={enablePackageSelection}
                 onEnablePackageSelecionChange={(isChecked) => {
                   setEnablePackageSelection(isChecked);
+                  setDirty(true);
                 }}
                 packages={packages || []}
                 selectedPackages={selectedPackages}

--- a/ui-pf4/src/main/webapp/src/pages/analysis-configuration/configuration-details/packages/packages.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/analysis-configuration/configuration-details/packages/packages.tsx
@@ -30,6 +30,7 @@ import {
   arePackagesEquals,
   fullNameToPackage,
   getAxiosErrorMessage,
+  getUnknownPackages,
 } from "utils/modelUtils";
 
 import {
@@ -58,6 +59,7 @@ export const Packages: React.FC<PackagesProps> = ({
     loadPackages,
   } = useFetchProjectPackages();
 
+  const [enablePackageSelection, setEnablePackageSelection] = useState(false);
   const [selectedPackages, setSelectedPackages] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -71,11 +73,19 @@ export const Packages: React.FC<PackagesProps> = ({
 
   useEffect(() => {
     if (analysisContext && applicationPackages) {
-      setSelectedPackages(
-        analysisContext.includePackages.map((f) => f.fullName)
-      );
+      let newSelectedPackages = analysisContext.includePackages;
+      if (newSelectedPackages.length === 0) {
+        newSelectedPackages = getUnknownPackages(applicationPackages);
+      }
+      setSelectedPackages(newSelectedPackages.map((f) => f.fullName));
     }
   }, [analysisContext, applicationPackages]);
+
+  useEffect(() => {
+    if (analysisContext && analysisContext.includePackages.length > 0) {
+      setEnablePackageSelection(true);
+    }
+  }, [analysisContext]);
 
   const handleOnSelectedPackagesChange = (value: string[]) => {
     if (!analysisContext || !packages) {
@@ -96,8 +106,13 @@ export const Packages: React.FC<PackagesProps> = ({
       return;
     }
 
+    const defaultPackages =
+      analysisContext.includePackages.length > 0
+        ? analysisContext.includePackages
+        : getUnknownPackages(applicationPackages || []);
+
     setDirty(false);
-    setSelectedPackages(analysisContext.includePackages.map((f) => f.fullName));
+    setSelectedPackages(defaultPackages.map((f) => f.fullName));
   };
 
   const onSubmit = (runAnalysis: boolean) => {
@@ -110,7 +125,9 @@ export const Packages: React.FC<PackagesProps> = ({
       .then(({ data }) => {
         const newAnalysisContext: AnalysisContext = {
           ...data,
-          includePackages: fullNameToPackage(selectedPackages, packages),
+          includePackages: enablePackageSelection
+            ? fullNameToPackage(selectedPackages, packages)
+            : [],
         };
         return saveAnalysisContext(project.id, newAnalysisContext, false);
       })
@@ -164,6 +181,11 @@ export const Packages: React.FC<PackagesProps> = ({
           <Card>
             <CardBody>
               <PackageSelection
+                isDirty={dirty}
+                enablePackageSelection={enablePackageSelection}
+                onEnablePackageSelecionChange={(isChecked) => {
+                  setEnablePackageSelection(isChecked);
+                }}
                 packages={packages || []}
                 selectedPackages={selectedPackages}
                 onSelectedPackagesChange={handleOnSelectedPackagesChange}

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/select-packages/select-packages.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/select-packages/select-packages.tsx
@@ -53,6 +53,7 @@ export const SelectPackages: React.FC<SelectPackagesProps> = ({
     loadPackages,
   } = useFetchProjectPackages();
 
+  const [enablePackageSelection, setEnablePackageSelection] = useState(false);
   const [selectedPackages, setSelectedPackages] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -134,7 +135,9 @@ export const SelectPackages: React.FC<SelectPackagesProps> = ({
       .then(({ data }) => {
         const newAnalysisContext: AnalysisContext = {
           ...data,
-          includePackages: fullNameToPackage(selectedPackages, packages),
+          includePackages: enablePackageSelection
+            ? fullNameToPackage(selectedPackages, packages)
+            : [],
         };
         return saveAnalysisContext(project.id, newAnalysisContext, true);
       })
@@ -211,6 +214,11 @@ export const SelectPackages: React.FC<SelectPackagesProps> = ({
       onGoToStep={handleOnGoToStep}
     >
       <PackageSelection
+        isDirty={dirty}
+        enablePackageSelection={enablePackageSelection}
+        onEnablePackageSelecionChange={(isChecked) => {
+          setEnablePackageSelection(isChecked);
+        }}
         packages={packages || []}
         selectedPackages={selectedPackages}
         onSelectedPackagesChange={handleOnSelectedPackagesChange}

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/select-packages/select-packages.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/select-packages/select-packages.tsx
@@ -65,7 +65,10 @@ export const SelectPackages: React.FC<SelectPackagesProps> = ({
 
       let result: Package[];
       if (params.get(PACKAGES_QUERYPARAM_NAME) === "true") {
-        result = analysisContext.includePackages;
+        result =
+          analysisContext.includePackages.length > 0
+            ? analysisContext.includePackages
+            : getUnknownPackages(applicationPackages);
       } else {
         if (analysisContext.applications.some((f) => f.exploded)) {
           result = [];

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/select-packages/select-packages.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/select-packages/select-packages.tsx
@@ -93,6 +93,12 @@ export const SelectPackages: React.FC<SelectPackagesProps> = ({
     }
   }, [analysisContext, applicationPackages, getDefaultSelectedPackages]);
 
+  useEffect(() => {
+    if (analysisContext && analysisContext.includePackages.length > 0) {
+      setEnablePackageSelection(true);
+    }
+  }, [analysisContext]);
+
   const handleOnSelectedPackagesChange = (value: string[]) => {
     if (!analysisContext || !packages) {
       return;


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3513

- The packages selection has now a "Switch" component to allow the user to explicitly indicate that he wants to customize the set of packages to be analyzed. If the "Switch" is ON then the UI will analyze all packages the user selects; if the "Switch" is OFF then no packages will be selected, therefore Windup will analyze the app in the same the CLI does by default.

![Screenshot from 2022-10-25 10-56-02](https://user-images.githubusercontent.com/2582866/197730379-79aa803f-2ad8-4f91-a36a-861349a94567.png)
