### PR TITLE
Added 'Discovery' card to Transformation Paths page

### DIFF
--- a/ui-pf4/src/main/webapp/src/images/UI_Icon-Red_Hat-Search-A-Red-RGB.svg
+++ b/ui-pf4/src/main/webapp/src/images/UI_Icon-Red_Hat-Search-A-Red-RGB.svg
@@ -1,0 +1,1 @@
+<svg id="Icons" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><defs><style>.cls-1{fill:#e00;}</style></defs><title>UI_Icon-Red_Hat-Search-A-Red-RGB</title><path class="cls-1" d="M14,11.94,11.22,9.23a4.74,4.74,0,1,0-.87.89l2.82,2.72a.62.62,0,0,0,.44.18A.63.63,0,0,0,14,11.94ZM7.5,9.88a3.38,3.38,0,1,1,3.37-3.37A3.37,3.37,0,0,1,7.5,9.88Z"/></svg>

--- a/ui-pf4/src/main/webapp/src/layout/TransformationPaths.ts
+++ b/ui-pf4/src/main/webapp/src/layout/TransformationPaths.ts
@@ -150,7 +150,7 @@ export const CAMEL: TransformationPathOption = {
 export const DISCOVERY: TransformationPathOption = {
   label: "Discovery",
   description:
-    "It runs an analysis to just discover the technologies and frameworks used with the application(s).",
+    "It runs an analysis to just discover the technologies and frameworks used within the application(s).",
   options: "discovery",
   iconSrc: search,
   isNew: true,

--- a/ui-pf4/src/main/webapp/src/layout/TransformationPaths.ts
+++ b/ui-pf4/src/main/webapp/src/layout/TransformationPaths.ts
@@ -5,6 +5,7 @@ import mug from "images/Icon-Red_Hat-Mug-A-Red-RGB.svg";
 import multiply from "images/Icon-Red_Hat-Multiply-A-Red-RGB.svg";
 import server from "images/Icon-Red_Hat-Server-A-Red-RGB.svg";
 import virtualServer from "images/Icon-Red_Hat-Virtual_server_stack-A-Red-RGB.png";
+import search from "images/UI_Icon-Red_Hat-Search-A-Red-RGB.svg";
 
 export interface MultipleOptions {
   label: string;
@@ -146,6 +147,15 @@ export const CAMEL: TransformationPathOption = {
   iconSrc: multiply,
 };
 
+export const DISCOVERY: TransformationPathOption = {
+  label: "Discovery",
+  description:
+    "It runs an analysis to just discover the technologies and frameworks used with the application(s).",
+  options: "discovery",
+  iconSrc: search,
+  isNew: true,
+};
+
 export const DEFAULT_TRANSFORMATION_PATHS = [
   EAP7,
   CONTAINERIZATION,
@@ -158,6 +168,7 @@ export const DEFAULT_TRANSFORMATION_PATHS = [
   OPEN_LIBERTY,
   AZURE,
   CAMEL,
+  DISCOVERY,
 ];
 
 export const MTA_MTR_TRANSFORMATION_PATHS = [
@@ -177,4 +188,5 @@ export const MTA_MTR_TRANSFORMATION_PATHS = [
     options: "azure-appservice",
   },
   CAMEL,
+  DISCOVERY,
 ];


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3558
depends on https://github.com/windup/windup-rulesets/pull/779

The new card has been added as the last one (ref. screenshot)
![Screenshot from 2022-11-21 17-54-32](https://user-images.githubusercontent.com/7288588/203120109-e95a91b6-18d4-4b80-a478-3815407328d5.png)


