### PR TITLE
Bump sshd-common from 2.8.0 to 2.9.2

### DIFF
--- a/addons/messaging-executor/addon/pom.xml
+++ b/addons/messaging-executor/addon/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-common</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
backports #856 
depends on #859 