### PR TITLE
Enabled jobs execution on 'releases' branches (#859)

### DIFF
--- a/.github/workflows/pr_build_jdk11.yaml
+++ b/.github/workflows/pr_build_jdk11.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 jobs:
 
@@ -14,6 +15,7 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           repository: windup/windup
+          ref: ${{ github.base_ref }}
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
backports #859 