### PR TITLE
[WINDUP-3670] - Server path is checking if directory is empty

### DIFF
--- a/services/src/main/java/org/jboss/windup/web/services/rest/FileEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/FileEndpoint.java
@@ -13,7 +13,7 @@ import javax.ws.rs.QueryParam;
  * @author <a href="mailto:jesse.sightler@gmail.com">Jesse Sightler</a>
  */
 @Path("/file")
-@Consumes("application/json")
+@Consumes("text/plain")
 @Produces("application/json")
 public interface FileEndpoint
 {

--- a/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectRegisteredApplicationsEndpoint.java
+++ b/services/src/main/java/org/jboss/windup/web/services/rest/MigrationProjectRegisteredApplicationsEndpoint.java
@@ -45,6 +45,7 @@ public interface MigrationProjectRegisteredApplicationsEndpoint
 
     @Path("register-path")
     @POST
+    @Consumes("text/plain")
     RegisteredApplication registerApplicationByPath(@PathParam("projectId") long projectId, @QueryParam("exploded") Boolean exploded, String path);
 
     /**
@@ -52,6 +53,7 @@ public interface MigrationProjectRegisteredApplicationsEndpoint
      */
     @Path("register-directory-path")
     @POST
+    @Consumes("text/plain")
     Collection<RegisteredApplication> registerApplicationsInDirectoryByPath(@PathParam("projectId") long projectId, String directoryPath);
 
     /**

--- a/ui-pf4/src/main/webapp/src/api/api.tsx
+++ b/ui-pf4/src/main/webapp/src/api/api.tsx
@@ -132,7 +132,13 @@ export const registerApplicationByPath = (
   return ApiClient.post<Application>(
     `${MIGRATION_PROJECTS_PATH}/${projectId}/registeredApplications/register-path?exploded=${isPathExploded}`,
     path,
-    defaultConfig
+    {
+      ...defaultConfig,
+      headers: {
+        ...defaultConfig.headers,
+        "Content-Type": "text/plain",
+      },
+    }
   );
 };
 
@@ -143,7 +149,13 @@ export const registerApplicationInDirectoryByPath = (
   return ApiClient.post<Application>(
     `${MIGRATION_PROJECTS_PATH}/${projectId}/registeredApplications/register-directory-path`,
     path,
-    defaultConfig
+    {
+      ...defaultConfig,
+      headers: {
+        ...defaultConfig.headers,
+        "Content-Type": "text/plain",
+      },
+    }
   );
 };
 

--- a/ui-pf4/src/main/webapp/src/api/api.tsx
+++ b/ui-pf4/src/main/webapp/src/api/api.tsx
@@ -148,17 +148,25 @@ export const registerApplicationInDirectoryByPath = (
 };
 
 export const pathExists = (path: string): AxiosPromise<boolean> => {
-  return ApiClient.post<boolean>("file/pathExists", path, defaultConfig);
+  return ApiClient.post<boolean>("file/pathExists", path, {
+    ...defaultConfig,
+    headers: {
+      ...defaultConfig.headers,
+      "Content-Type": "text/plain",
+    },
+  });
 };
 
 export const pathTargetType = (
   path: string
 ): AxiosPromise<"FILE" | "DIRECTORY"> => {
-  return ApiClient.post<"FILE" | "DIRECTORY">(
-    "file/pathTargetType",
-    path,
-    defaultConfig
-  );
+  return ApiClient.post<"FILE" | "DIRECTORY">("file/pathTargetType", path, {
+    ...defaultConfig,
+    headers: {
+      ...defaultConfig.headers,
+      "Content-Type": "text/plain",
+    },
+  });
 };
 
 export const getAnalysisContext = (


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3670

A previous PR upgraded the npm Axios dependency fixing an issue described here https://github.com/axios/axios/issues/4034 .

After debugging the app the issue ended up being a wrong use of the header "Content-Type" at the moment of verifying paths. The backend, master branch, currently `@consumes` "application-json" bodies; however, the UI sends plain text.

### Example of the current issue
- The UI sends a path `"/home/myuser/folderA"`
- The backend receives the path in this way : `""/home/myuser/folderA""` (with additional quotes)

This PR changes the Content-Type header and use the correct ones.
