### PR TITLE
[WINDUP-3845] - Project details: Need to click twice the "Next" button to proceed to the next step

### DIFF
--- a/ui-pf4/src/main/webapp/src/containers/add-application-button/add-application-button.tsx
+++ b/ui-pf4/src/main/webapp/src/containers/add-application-button/add-application-button.tsx
@@ -115,6 +115,7 @@ export const AddApplicationButton: React.FC<AddApplicationButtonProps> = ({
     validationSchema: AddApplicationsUploadFilesFormSchema(false),
     onSubmit: handleUploadFilesFormikSubmit,
     // initialErrors: { applications: "" },
+    validateOnBlur: false,
   });
 
   const serverPathFormik = useFormik({
@@ -124,6 +125,7 @@ export const AddApplicationButton: React.FC<AddApplicationButtonProps> = ({
     ),
     onSubmit: handleServerPathFormikSubmit,
     initialErrors: { serverPath: "" },
+    validateOnBlur: false,
   });
 
   const handleOnTabChange = (selected: AddApplicationsTabsType) => {

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/add-applications/add-applications.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/add-applications/add-applications.tsx
@@ -141,6 +141,7 @@ export const AddApplications: React.FC<AddApplicationsProps> = ({
     onSubmit: handleUploadFilesFormikSubmit,
     initialErrors:
       project && project.applications.length > 0 ? {} : { applications: "" },
+    validateOnBlur: false,
   });
 
   const serverPathFormik = useFormik({
@@ -150,6 +151,7 @@ export const AddApplications: React.FC<AddApplicationsProps> = ({
     ),
     onSubmit: handleServerPathFormikSubmit,
     initialErrors: { serverPath: "" },
+    validateOnBlur: false,
   });
 
   const handleOnTabChange = (selected: AddApplicationsTabsType) => {

--- a/ui-pf4/src/main/webapp/src/pages/projects/new-project/create-project/create-project.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/new-project/create-project/create-project.tsx
@@ -115,6 +115,7 @@ export const CreateProject: React.FC<CreateProjectProps> = ({
     validationSchema: projectDetailsFormSchema(project),
     onSubmit: handleOnSubmit,
     initialErrors: !project ? { name: "" } : {},
+    validateOnBlur: false,
   });
 
   const handleOnGoToStep = (newStep: NewProjectWizardStepIds) => {


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3845

Issue introduced at https://github.com/windup/windup-web/pull/865 when upgrading the library `formik`. An old version behaves differently than the last version.

## How to reproduce the issue in current master branch
- Have windup web console running locally
- Try to create a new project
- Use Chrome + use Chrome tools to make the network really slow (see image below)
- After filling the name of the project try to click on "Next"

![Screenshot from 2023-05-04 16-23-42](https://user-images.githubusercontent.com/2582866/236237015-b42343b0-bc10-4a8d-b7fb-5766c25997bb.png)

Explanation to the issue: the form is being validated in both "When the form changes" and "on blur (when the input boxes lose the focus)". When the user fills the input boxes and tries to click on "Next" the "onBlur" validation is fired blocking the "Next" button and not allowing it to go to the next page.
