### PR TITLE
[WINDUP-3877] - Edit Project : Need to click twice the "Save" button to edit a project

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/add-rulelabel-tabs/add-rulelabel-tabs.tsx
+++ b/ui-pf4/src/main/webapp/src/components/add-rulelabel-tabs/add-rulelabel-tabs.tsx
@@ -160,6 +160,7 @@ export const AddRuleLabelTabs: React.FC<AddRuleLabelTabsProps> = ({
               validationSchema={RuleLabelServerPathFormSchema()}
               onSubmit={handleOnSubmit}
               initialErrors={{ name: "" }}
+              validateOnBlur={false}
             >
               {({
                 isValid,

--- a/ui-pf4/src/main/webapp/src/pages/projects/edit-project/edit-project.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/edit-project/edit-project.tsx
@@ -114,6 +114,7 @@ export const EditProject: React.FC<ApplicationListProps> = ({
                   validationSchema={projectDetailsFormSchema(project)}
                   onSubmit={handleOnSubmit}
                   initialErrors={{ name: "" }}
+                  validateOnBlur={false}
                 >
                   {({
                     isValid,

--- a/ui-pf4/src/main/webapp/src/pages/projects/project-list/components/edit-project-modal.tsx
+++ b/ui-pf4/src/main/webapp/src/pages/projects/project-list/components/edit-project-modal.tsx
@@ -79,6 +79,7 @@ export const EditProjectModal: React.FC<EditProjectModalProps> = ({
         validationSchema={projectDetailsFormSchema(project)}
         onSubmit={handleOnSubmit}
         initialErrors={{ name: "" }}
+        validateOnBlur={false}
       >
         {({
           isValid,


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3877

Fix applied to 2 places:
- Edit project (project list => edit button)
- Add custom labels/rules using server path (create a project then once it is created go to "Analysis configuration", then "custom rules/labels", then click on "Add rule/label", then use "Server path")

To reproduce the error Use Chrome + use Chrome tools to make the network really slow (see image below). This way the issue clearly appears.

![Screenshot from 2023-05-04 16-23-42](https://user-images.githubusercontent.com/2582866/236237015-b42343b0-bc10-4a8d-b7fb-5766c25997bb.png)