### PR TITLE
[WINDUP-3892] - Upgrade htmlUnit dependency

### DIFF
--- a/ui-pf4/pom.xml
+++ b/ui-pf4/pom.xml
@@ -131,6 +131,7 @@
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <version>2.70.0</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/ui-pf4/pom.xml
+++ b/ui-pf4/pom.xml
@@ -120,7 +120,19 @@
             <artifactId>graphene-webdriver</artifactId>
             <type>pom</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sourceforge.htmlunit</groupId>
+                    <artifactId>htmlunit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.htmlunit</groupId>
+            <artifactId>htmlunit</artifactId>
+            <version>2.70.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3892

The direct dependency injecting the htmlunit dependency is `org.jboss.arquillian.graphene:graphene-webdriver:2.5.4` and we are already using the latest stable version of it https://mvnrepository.com/artifact/org.jboss.arquillian.graphene/graphene-webdriver . Therefore, as we can no upgrade the direct dependency, we need to exclude the htmlunit dependency from `org.jboss.arquillian.graphene:graphene-webdriver:2.5.4` and inject it as a direct dependency