### PR TITLE
fix: Add Padding to the cards to avoid MTR cards to change width while selecting camel

### DIFF
--- a/ui-pf4/src/main/webapp/src/components/transformation-path/transformation-path.tsx
+++ b/ui-pf4/src/main/webapp/src/components/transformation-path/transformation-path.tsx
@@ -46,10 +46,10 @@ export const TransformationPath: React.FC<TransformationPathProps> = ({
             </TextContent>
           </StackItem>
           <StackItem
-          style={{
-            // margin: "0px -25px",
-            padding: "5px 5px",
-          }}
+            style={{
+              // margin: "0px -25px",
+              padding: "5px 5px",
+            }}
           >
             <SelectCardGallery
               value={selectedTargets}

--- a/ui-pf4/src/main/webapp/src/components/transformation-path/transformation-path.tsx
+++ b/ui-pf4/src/main/webapp/src/components/transformation-path/transformation-path.tsx
@@ -46,10 +46,10 @@ export const TransformationPath: React.FC<TransformationPathProps> = ({
             </TextContent>
           </StackItem>
           <StackItem
-          // style={{
-          //   margin: "0px -25px",
-          //   padding: "15px 15px",
-          // }}
+          style={{
+            // margin: "0px -25px",
+            padding: "5px 5px",
+          }}
           >
             <SelectCardGallery
               value={selectedTargets}


### PR DESCRIPTION
Steps to reproduce the issue:
- Change this line https://github.com/windup/windup-web/blob/master/ui-pf4/src/main/webapp/src/layout/ThemeUtils.tsx#L81 and replace `"windup"` by `"mtr"` because the issue only happens with the MTR cards
- run the ui and in the in the "transformation path" page select and unselect "camel" dropdown values

Use Chrome to do the tests since the issue does not appear in Firefox