### PR TITLE
WINDUP-4123: upgrade keycloak to v24.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.furnace>2.29.1.Final</version.furnace>
         <version.windup>6.4.0-SNAPSHOT</version.windup>
         <version.windup.cli>6.4.0-SNAPSHOT</version.windup.cli>
-        <version.keycloak>22.0.5</version.keycloak>
+        <version.keycloak>22.0.10</version.keycloak>
         <wildfly.groupId>org.wildfly</wildfly.groupId>
         <wildfly.artifactId>wildfly-dist</wildfly.artifactId>
         <version.wildfly>23.0.2.Final</version.wildfly>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.furnace>2.29.1.Final</version.furnace>
         <version.windup>6.4.0-SNAPSHOT</version.windup>
         <version.windup.cli>6.4.0-SNAPSHOT</version.windup.cli>
-        <version.keycloak>22.0.10</version.keycloak>
+        <version.keycloak>24.0.3</version.keycloak>
         <wildfly.groupId>org.wildfly</wildfly.groupId>
         <wildfly.artifactId>wildfly-dist</wildfly.artifactId>
         <version.wildfly>23.0.2.Final</version.wildfly>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-4123

This PR handles the CVE linked in the JIRA for the upstream windup build ( downstream is taken are of by the pipeline config)