### PR TITLE
[releases/6.3.z] WINDUP-4123: upgrade keycloak to v24.0.3 (#978)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version.furnace>2.29.1.Final</version.furnace>
         <version.windup>6.3.8-SNAPSHOT</version.windup>
         <version.windup.cli>6.3.8-SNAPSHOT</version.windup.cli>
-        <version.keycloak>22.0.5</version.keycloak>
+        <version.keycloak>24.0.3</version.keycloak>
         <wildfly.groupId>org.wildfly</wildfly.groupId>
         <wildfly.artifactId>wildfly-dist</wildfly.artifactId>
         <version.wildfly>23.0.2.Final</version.wildfly>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `releases/6.3.z`:
 - [WINDUP-4123: upgrade keycloak to v24.0.3 (#978)](https://github.com/windup/windup-web/pull/978)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)