### PR TITLE
[releases/6.3.z] WINDUP-3631 upgrade undertow to 2.2.32.Final (#980)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <windup.distribution.name>windup-cli</windup.distribution.name>
         <version.hibernate>5.3.20.Final</version.hibernate>
-        <version.undertow>2.2.24.Final</version.undertow>
+        <version.undertow>2.2.32.Final</version.undertow>
         <version.httpcomponents>4.5.13</version.httpcomponents>
         <version.maven-war-plugin>3.3.2</version.maven-war-plugin>
         <version.mockito-core>5.1.1</version.mockito-core>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `releases/6.3.z`:
 - [WINDUP-3631 upgrade undertow to 2.2.32.Final (#980)](https://github.com/windup/windup-web/pull/980)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)