### PR TITLE
[releases/6.3.z] WINDUP-4139:axios upgrade to 0.28.0 (#975)

### DIFF
--- a/ui-pf4/src/main/webapp/package.json
+++ b/ui-pf4/src/main/webapp/package.json
@@ -29,7 +29,7 @@
     "@types/websocket": "^1.0.5",
     "@types/yup": "0.29.6",
     "antd": "4.7.0",
-    "axios": "0.21.4",
+    "axios": "^0.28.0",
     "axios-mock-adapter": "^1.21.2",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.7",
@@ -66,7 +66,8 @@
     "@types/react": "^16.9.49",
     "follow-redirects": "^1.15.6",
     "semver": "^7.5.4",
-    "tough-cookie": "^4.1.3"
+    "tough-cookie": "^4.1.3",
+    "axios": "^0.28.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/ui-pf4/src/main/webapp/src/api/apiInit.ts
+++ b/ui-pf4/src/main/webapp/src/api/apiInit.ts
@@ -10,6 +10,7 @@ export const initInterceptors = (getToken: () => Promise<string>) => {
   axios.interceptors.request.use(
     async (config) => {
       const token = await getToken();
+      if (!config.headers) config.headers = {};
       if (token) config.headers["Authorization"] = "Bearer " + token;
       return config;
     },

--- a/ui-pf4/src/main/webapp/src/store/alert/actions.tsx
+++ b/ui-pf4/src/main/webapp/src/store/alert/actions.tsx
@@ -13,8 +13,8 @@ export const alertFetchEndpoint = (err: AxiosError) => {
   if (err.response && err.response.data) {
     if (typeof err.response.data === "string") {
       errorDescription = err.response.data;
-    } else if (err.response.data.error) {
-      errorDescription = err.response.data.error;
+    } else if ((err.response.data as any).error) {
+      errorDescription = (err.response.data as any).error;
     }
   }
   return (dispatch: Dispatch) => {

--- a/ui-pf4/src/main/webapp/src/utils/modelUtils.ts
+++ b/ui-pf4/src/main/webapp/src/utils/modelUtils.ts
@@ -149,8 +149,8 @@ export const getErrorsFromLabelProviderEntity = (
 
 // Axios error
 export const getAxiosErrorMessage = (axiosError: AxiosError) => {
-  if (axiosError.response?.data.message) {
-    return axiosError.response?.data.message;
+  if ((axiosError.response?.data as any).message) {
+    return (axiosError.response?.data as any).message;
   }
   return axiosError.message;
 };

--- a/ui-pf4/src/main/webapp/yarn.lock
+++ b/ui-pf4/src/main/webapp/yarn.lock
@@ -3503,19 +3503,14 @@ axios-mock-adapter@^1.21.2:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@^0.19.0, axios@^0.28.0:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.1.tgz#2a7bcd34a3837b71ee1a5ca3762214b86b703e70"
+  integrity sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==
   dependencies:
-    follow-redirects "^1.14.0"
-
-axios@^0.19.0:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -6042,7 +6037,7 @@ focus-trap@6.9.2:
   dependencies:
     tabbable "^5.3.2"
 
-follow-redirects@1.5.10, follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.6:
+follow-redirects@^1.0.0, follow-redirects@^1.15.0, follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -6087,6 +6082,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -10268,6 +10272,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `releases/6.3.z`:
 - [WINDUP-4139:axios upgrade to 0.28.0 (#975)](https://github.com/windup/windup-web/pull/975)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)